### PR TITLE
Substitute artificial sort_order column with computed semver com…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dpmcore"
-version = "0.1.0rc2"
+version = "0.1.0rc3"
 description = "Python library for DPM 2.0 Refit regulatory reporting (ORM, services, REST API)"
 license = { text = "Apache-2.0" }
 readme = "README.md"

--- a/src/dpmcore/__init__.py
+++ b/src/dpmcore/__init__.py
@@ -1,6 +1,6 @@
 """Your opinionated Python DPM library."""
 
-__version__ = "0.1.0rc2"
+__version__ = "0.1.0rc3"
 
 from dpmcore.connection import DpmConnection, connect
 

--- a/src/dpmcore/dpm_xl/utils/filters.py
+++ b/src/dpmcore/dpm_xl/utils/filters.py
@@ -3,19 +3,25 @@
 Provides composable SQLAlchemy filter conditions for
 release-based versioning and date-range queries.
 
-Release-range comparisons use ``Release.sort_order`` rather than
-``Release.release_id`` because EBA's post-4.2.1 ID scheme is no longer
-monotonic (4.2.1 has ``ReleaseID = 1010000003``). ``sort_order`` is
-populated from the parsed semver ``code``, so a hypothetical backport
-``4.0.1`` is correctly placed inside the ``4.0`` lineage even when
-published chronologically after ``4.2.1``.
+Release-range comparisons compare against the semver-parsed sort order
+of ``Release.code`` (computed in Python via
+:func:`dpmcore.orm.release_sort_order.compute_sort_order`) rather than
+against the raw ``Release.release_id`` FK, because EBA's post-4.2.1 ID
+scheme is no longer monotonic (4.2.1 has ``ReleaseID = 1010000003``).
+A hypothetical backport ``4.0.1`` is correctly placed inside the
+``4.0`` lineage even when published chronologically after ``4.2.1``.
 """
 
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
-from sqlalchemy import Date, and_, cast, or_, select
-from sqlalchemy.orm import aliased
+from sqlalchemy import Date, and_, cast, or_
+
+from dpmcore.orm.release_sort_order import (
+    load_release_sort_orders,
+    release_ids_for_sort_order,
+    resolve_sort_order,
+)
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -115,25 +121,6 @@ def resolve_release_id(
     return row[0]
 
 
-def sort_order_subquery(release_id_col: Any) -> Any:
-    """Return a scalar subquery for ``Release.sort_order`` of *col*.
-
-    Useful when a JOIN cannot be added to the query (typically inside a
-    JOIN ``ON`` clause that already correlates against an aliased
-    ``Release`` row). Prefer joining an aliased ``Release`` and
-    referencing its ``sort_order`` directly when the surrounding query
-    can be mutated — see :func:`filter_by_release` for an example.
-    """
-    # Local import keeps this util's dependency direction clean.
-    from dpmcore.orm.infrastructure import Release
-
-    return (
-        select(Release.sort_order)
-        .where(Release.release_id == release_id_col)
-        .scalar_subquery()
-    )
-
-
 def filter_by_release(
     query: Any,
     start_col: Any,
@@ -145,27 +132,19 @@ def filter_by_release(
 
     Logic (semver-aware):
         If release_id provided:
-            start.sort_order <= target.sort_order AND
-            (end IS NULL OR end.sort_order > target.sort_order)
+            sort_order(start) <= sort_order(target) AND
+            (end IS NULL OR sort_order(end) > sort_order(target))
         If release_id is None:
             * ``active_only_fallback=True`` → ``end_col IS NULL`` only
               (currently-active rows). Useful for callers that want a
               deterministic default when no release is supplied.
             * Otherwise → return query unmodified.
 
-    Implementation note: the comparison joins two aliased ``Release``
-    rows (one for ``start_col``, one for ``end_col``) so the database
-    looks up ``sort_order`` once per row rather than re-running a
-    correlated subquery for every comparison. The end-side join is a
-    LEFT OUTER JOIN to preserve rows where ``end_col IS NULL``
-    (currently-active records).
-
     Args:
         query: SQLAlchemy ``Query`` — must be a session-bound ``Query``
             (i.e. produced by ``Session.query(...)``). Core ``Select``
             statements are not supported because the helper needs the
-            session to resolve the target release's sort order before
-            adding the filter joins.
+            session to load the release mapping.
         start_col: Column for start release ID (FK to ``Release``).
         end_col: Column for end release ID (FK to ``Release``).
         release_id: Release ID to filter for.
@@ -180,15 +159,13 @@ def filter_by_release(
         TypeError: If ``query`` is not a session-bound SQLAlchemy
             ``Query`` (e.g. a Core ``Select`` was passed).
         ValueError: If ``release_id`` does not correspond to a known
-            ``Release`` row, or that release has no parseable
-            ``sort_order``.
+            ``Release`` row, or that release's code is not parseable
+            as ``MAJOR.MINOR[.PATCH]``.
     """
     if release_id is None:
         if active_only_fallback:
             return filter_active_only(query, end_col)
         return query
-
-    from dpmcore.orm.infrastructure import Release
 
     session = getattr(query, "session", None)
     if session is None:
@@ -198,30 +175,15 @@ def filter_by_release(
             f"{type(query).__name__!r} which has no .session — Core "
             "Select statements are not supported.",
         )
-    target_sort_order = (
-        session.query(Release.sort_order)
-        .filter(Release.release_id == release_id)
-        .scalar()
-    )
-    if target_sort_order is None:
-        raise ValueError(
-            f"Release {release_id} has no sort_order — its code "
-            "could not be parsed as MAJOR.MINOR[.PATCH].",
-        )
 
-    start_release = aliased(Release)
-    end_release = aliased(Release)
-    return (
-        query.join(start_release, start_release.release_id == start_col)
-        .outerjoin(end_release, end_release.release_id == end_col)
-        .filter(
-            and_(
-                start_release.sort_order <= target_sort_order,
-                or_(
-                    end_col.is_(None),
-                    end_release.sort_order > target_sort_order,
-                ),
-            )
+    target_sort_order = resolve_sort_order(session, release_id)
+    sort_orders = load_release_sort_orders(session)
+    start_ids = release_ids_for_sort_order(sort_orders, le=target_sort_order)
+    end_ids = release_ids_for_sort_order(sort_orders, gt=target_sort_order)
+    return query.filter(
+        and_(
+            start_col.in_(start_ids),
+            or_(end_col.is_(None), end_col.in_(end_ids)),
         )
     )
 
@@ -240,6 +202,7 @@ def filter_active_only(query: Any, end_col: Any) -> Any:
 
 
 def filter_item_version(
+    sort_orders: Dict[int, Optional[int]],
     ref_sort_order: Optional[int],
     item_start_col: Any,
     item_end_col: Any,
@@ -248,31 +211,27 @@ def filter_item_version(
 
     Pattern (semver-aware):
 
-        item_start.sort_order <= ref_sort_order
-        AND (item_end IS NULL OR ref_sort_order < item_end.sort_order)
-
-    The reference side is passed as a Python ``int`` (the caller has
-    already resolved its ``Release.sort_order``) so only one correlated
-    subquery is emitted per item-side column instead of three.
-    Comparison still runs against ``Release.sort_order`` so backports
-    like a future ``4.0.1`` published after ``4.2.1`` slot into the
-    correct lineage.
+        sort_order(item_start) <= ref_sort_order
+        AND (item_end IS NULL OR ref_sort_order < sort_order(item_end))
 
     Args:
-        ref_sort_order: Reference release's pre-resolved
-            ``Release.sort_order`` value. ``None`` (unparseable code)
-            makes every comparison evaluate to NULL — i.e. the join
-            condition never matches.
+        sort_orders: Pre-loaded mapping from
+            :func:`load_release_sort_orders`.
+        ref_sort_order: Reference release's pre-resolved sort order.
+            ``None`` (unparseable code) collapses to a condition that
+            never matches.
         item_start_col: Item's start-release ID column.
         item_end_col: Item's end-release ID column.
 
     Returns:
         SQLAlchemy boolean expression.
     """
+    if ref_sort_order is None:
+        return and_(item_start_col.is_(None), item_start_col.isnot(None))
+
+    start_ids = release_ids_for_sort_order(sort_orders, le=ref_sort_order)
+    end_ids = release_ids_for_sort_order(sort_orders, gt=ref_sort_order)
     return and_(
-        sort_order_subquery(item_start_col) <= ref_sort_order,
-        or_(
-            sort_order_subquery(item_end_col) > ref_sort_order,
-            item_end_col.is_(None),
-        ),
+        item_start_col.in_(start_ids),
+        or_(item_end_col.is_(None), item_end_col.in_(end_ids)),
     )

--- a/src/dpmcore/loaders/migration.py
+++ b/src/dpmcore/loaders/migration.py
@@ -86,7 +86,6 @@ class MigrationService:
         data, backend = self._extract_tables(access_path)
         self._create_schema()
         warnings = self._load_data(data)
-        self._populate_release_sort_order()
 
         table_details = {name: len(df) for name, df in data.items()}
         total_rows = sum(table_details.values())
@@ -415,25 +414,6 @@ class MigrationService:
         """Drop and recreate all ORM tables for a clean migration."""
         Base.metadata.drop_all(self._engine)
         Base.metadata.create_all(self._engine)
-
-    def _populate_release_sort_order(self) -> None:
-        """Backfill ``Release.sort_order`` from each row's ``code``.
-
-        Bulk loads bypass the ORM ``before_insert`` listener that would
-        normally populate ``sort_order``, so we run a single UPDATE
-        after migration that derives the value from the parsed
-        semver code.
-        """
-        from sqlalchemy.orm import Session
-
-        from dpmcore.orm.infrastructure import Release
-        from dpmcore.orm.release_sort_order import compute_sort_order
-
-        with Session(self._engine) as session:
-            rows = session.query(Release).all()
-            for r in rows:
-                r.sort_order = compute_sort_order(r.code)
-            session.commit()
 
     def _load_data(self, data: Dict[str, Any]) -> List[str]:
         """Write DataFrames into the database.

--- a/src/dpmcore/orm/__init__.py
+++ b/src/dpmcore/orm/__init__.py
@@ -8,9 +8,6 @@ import dpmcore.orm.glossary  # noqa: F401
 import dpmcore.orm.infrastructure  # noqa: F401
 import dpmcore.orm.operations  # noqa: F401
 import dpmcore.orm.packaging  # noqa: F401
-
-# Register the Release.sort_order auto-populate listeners.
-import dpmcore.orm.release_sort_order  # noqa: F401
 import dpmcore.orm.rendering  # noqa: F401
 import dpmcore.orm.variables  # noqa: F401
 from dpmcore.orm.base import (

--- a/src/dpmcore/orm/infrastructure.py
+++ b/src/dpmcore/orm/infrastructure.py
@@ -831,13 +831,6 @@ class Release(Base):
     type: Mapped[Optional[str]] = mapped_column("Type", String(20))
     error: Mapped[Optional[str]] = mapped_column("Error", String(4000))
     owner_id: Mapped[Optional[int]] = mapped_column("OwnerID", Integer)
-    # Synthetic — derived from ``code`` (semver-parsed) so range filters
-    # do not depend on the integer ordering of ``ReleaseID``. Populated
-    # via the SQLAlchemy ``before_insert`` / ``before_update`` listeners
-    # in ``dpmcore.orm.release_sort_order``.
-    sort_order: Mapped[Optional[int]] = mapped_column(
-        "SortOrder", Integer, index=True
-    )
 
     concept: Mapped[Optional["Concept"]] = relationship(
         foreign_keys=[row_guid]

--- a/src/dpmcore/orm/release_sort_order.py
+++ b/src/dpmcore/orm/release_sort_order.py
@@ -1,25 +1,21 @@
-"""Auto-populate ``Release.sort_order`` from ``Release.code``.
+"""Compute release sort order from ``Release.code`` at query time.
 
 DPM ``ReleaseID`` values are no longer monotonic (4.2.1 has
 ``ReleaseID = 1010000003`` while older releases are still 1..5), so
 release-range comparisons cannot rely on numeric ID ordering. Instead
 we parse ``Release.code`` as a semver-style version tuple and pack it
-into a single ``SortOrder`` integer, which is the column compared at
-every range-filter site.
-
-Backports — e.g. a hypothetical ``4.0.1`` published *after* ``4.2.1``
-— still slot correctly into the ``4.0`` lineage when ordered by
-``SortOrder``, which is the semantic that EBA's range expressions
-("module is valid from release X to Y") actually intend.
+into a single sortable integer. Backports — e.g. a hypothetical
+``4.0.1`` published after ``4.2.1`` — still slot correctly into the
+``4.0`` lineage because comparison runs against the parsed semver, not
+the FK ID.
 """
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional
 
-from sqlalchemy import event, inspect
-
-from dpmcore.orm.infrastructure import Release
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
 
 # Three 6-digit slots per version segment → can hold 999999.999999.999999.
 # Plenty of headroom for any realistic DPM versioning while staying within
@@ -62,9 +58,8 @@ def compute_sort_order(code: Optional[str]) -> Optional[int]:
     if ``parse_version(a) < parse_version(b)`` then
     ``compute_sort_order(a) < compute_sort_order(b)``.
 
-    Returns ``None`` when the code is missing or unparseable so the
-    DB row can still be inserted; range queries simply exclude such
-    rows from comparison.
+    Returns ``None`` when the code is missing or unparseable so callers
+    can decide whether to skip or fail for that release.
     """
     parsed = parse_version(code)
     if parsed is None:
@@ -75,25 +70,96 @@ def compute_sort_order(code: Optional[str]) -> Optional[int]:
     )
 
 
-@event.listens_for(Release, "before_insert")
-def _release_before_insert(
-    mapper: Any, connection: Any, target: Release
-) -> None:
-    """Auto-populate ``sort_order`` on insert when not explicitly set."""
-    if target.sort_order is None:
-        target.sort_order = compute_sort_order(target.code)
+def load_release_sort_orders(
+    session: "Session",
+) -> Dict[int, Optional[int]]:
+    """Return ``{release_id: sort_order}`` parsed from ``Release.code``.
 
-
-@event.listens_for(Release, "before_update")
-def _release_before_update(
-    mapper: Any, connection: Any, target: Release
-) -> None:
-    """Recompute ``sort_order`` only when ``code`` is dirty.
-
-    Skipping the recompute on unrelated updates lets the migration
-    backfill (which sets ``sort_order`` directly before commit) and
-    any future manual override survive.
+    Rows whose code is unparseable map to ``None`` so callers can fail
+    loudly when one of them is named as a bound.
     """
-    code_history = inspect(target).attrs.code.history
-    if code_history.has_changes():
-        target.sort_order = compute_sort_order(target.code)
+    from dpmcore.orm.infrastructure import Release
+
+    rows = session.query(Release.release_id, Release.code).all()
+    return {rid: compute_sort_order(code) for rid, code in rows}
+
+
+def resolve_sort_order(
+    session: "Session", release_id: int, *, role: str = "release"
+) -> int:
+    """Return the parsed sort order for ``release_id`` or raise.
+
+    Args:
+        session: Open SQLAlchemy session.
+        release_id: Numeric FK of the release whose sort order to
+            resolve.
+        role: Short label used in the error message to identify the
+            release's role (``"window start release"`` etc.) so callers
+            don't have to wrap the call in their own try/except just to
+            customise wording.
+
+    Raises:
+        ValueError: If no Release row matches ``release_id`` or its
+            code cannot be parsed as ``MAJOR.MINOR[.PATCH]``.
+    """
+    from dpmcore.orm.infrastructure import Release
+
+    row = (
+        session.query(Release.code)
+        .filter(Release.release_id == release_id)
+        .first()
+    )
+    if row is None:
+        raise ValueError(
+            f"{role} {release_id} has no sort_order — "
+            "no Release row matches that ID."
+        )
+    sort_order = compute_sort_order(row[0])
+    if sort_order is None:
+        raise ValueError(
+            f"{role} {release_id} has no sort_order — its "
+            "code could not be parsed as MAJOR.MINOR[.PATCH]."
+        )
+    return sort_order
+
+
+def release_ids_for_sort_order(
+    sort_orders: Dict[int, Optional[int]],
+    *,
+    le: Optional[int] = None,
+    lt: Optional[int] = None,
+    ge: Optional[int] = None,
+    gt: Optional[int] = None,
+) -> List[int]:
+    """Filter ``{release_id: sort_order}`` by inequality predicates.
+
+    Releases whose ``sort_order`` is ``None`` (unparseable code) are
+    always excluded — they cannot satisfy a comparison either way.
+
+    Args:
+        sort_orders: Mapping from :func:`load_release_sort_orders`.
+        le: Optional ``sort_order <= le`` bound.
+        lt: Optional ``sort_order < lt`` bound.
+        ge: Optional ``sort_order >= ge`` bound.
+        gt: Optional ``sort_order > gt`` bound. All bounds are
+            combined with logical AND.
+
+    Returns:
+        Sorted list of matching release IDs (ascending by
+        ``sort_order``).
+    """
+    matches: List[tuple[int, int]] = []
+    for rid, so in sort_orders.items():
+        if so is None:
+            continue
+        if le is not None and not so <= le:
+            continue
+        if lt is not None and not so < lt:
+            continue
+        if ge is not None and not so >= ge:
+            continue
+        if gt is not None and not so > gt:
+            continue
+        matches.append((rid, so))
+    matches.sort(key=lambda pair: pair[1])
+    return [rid for rid, _ in matches]

--- a/src/dpmcore/services/ast_generator.py
+++ b/src/dpmcore/services/ast_generator.py
@@ -386,62 +386,52 @@ class ASTGeneratorService:
     def _latest_release_in_window(self, mv: Any) -> Any:
         """Pick the latest ``released`` Release covering *mv*'s window.
 
-        Comparison runs against ``Release.sort_order`` (parsed from the
-        semver ``code``) so a hypothetical backport like ``4.0.1``
+        Comparison runs against the semver-parsed sort order of each
+        candidate's ``code`` so a hypothetical backport like ``4.0.1``
         published after ``4.2.1`` is correctly placed inside the
         ``4.0`` lineage. Falls back to the latest of any status if no
         released row matches.
         """
         from dpmcore.orm.infrastructure import Release
+        from dpmcore.orm.release_sort_order import (
+            compute_sort_order,
+            resolve_sort_order,
+        )
 
         if self.session is None:
             raise RuntimeError("session required")
 
-        # Resolve start/end sort_order once at Python time. The bounds
-        # are integer release IDs known up-front, so a single Release
-        # lookup beats a correlated subquery executed per row. An
-        # unresolved bound (missing Release row or unparseable code)
-        # would silently widen the window, so fail loudly instead.
         start_sort: Optional[int] = None
         end_sort: Optional[int] = None
         if mv.start_release_id is not None:
-            start_sort = (
-                self.session.query(Release.sort_order)
-                .filter(Release.release_id == mv.start_release_id)
-                .scalar()
+            start_sort = resolve_sort_order(
+                self.session,
+                mv.start_release_id,
+                role="Module version window start release",
             )
-            if start_sort is None:
-                raise ValueError(
-                    f"Module version window start release "
-                    f"{mv.start_release_id} has no sort_order — its "
-                    "code could not be parsed as MAJOR.MINOR[.PATCH]."
-                )
         if mv.end_release_id is not None:
-            end_sort = (
-                self.session.query(Release.sort_order)
-                .filter(Release.release_id == mv.end_release_id)
-                .scalar()
+            end_sort = resolve_sort_order(
+                self.session,
+                mv.end_release_id,
+                role="Module version window end release",
             )
-            if end_sort is None:
-                raise ValueError(
-                    f"Module version window end release "
-                    f"{mv.end_release_id} has no sort_order — its "
-                    "code could not be parsed as MAJOR.MINOR[.PATCH]."
-                )
 
-        base_query = self.session.query(Release)
-        if start_sort is not None:
-            base_query = base_query.filter(Release.sort_order >= start_sort)
-        if end_sort is not None:
-            base_query = base_query.filter(Release.sort_order < end_sort)
-        latest = (
-            base_query.filter(Release.status == "released")
-            .order_by(Release.sort_order.desc())
-            .first()
-        )
-        if latest is None:
-            latest = base_query.order_by(Release.sort_order.desc()).first()
-        return latest
+        rows = self.session.query(Release).all()
+        candidates: List[tuple[int, Any]] = []
+        for r in rows:
+            so = compute_sort_order(r.code)
+            if so is None:
+                continue
+            if start_sort is not None and so < start_sort:
+                continue
+            if end_sort is not None and so >= end_sort:
+                continue
+            candidates.append((so, r))
+        if not candidates:
+            return None
+        released = [(so, r) for so, r in candidates if r.status == "released"]
+        pool = released or candidates
+        return max(pool, key=lambda pair: pair[0])[1]
 
     def _resolve_severities(
         self,

--- a/src/dpmcore/services/ecb_validations_import.py
+++ b/src/dpmcore/services/ecb_validations_import.py
@@ -191,43 +191,36 @@ class EcbValidationsImportService:
         start_release_id: int,
         end_release_id: Optional[int],
     ) -> List[int]:
-        """Release IDs in [start, end) ordered by semver sort_order.
+        """Release IDs in [start, end) ordered by semver sort order.
 
-        Comparison runs against ``Release.sort_order`` so backports
-        (e.g. a hypothetical ``4.0.1`` post-``4.2.1``) place correctly
-        within their version lineage. The start/end bounds are
-        resolved to integer ``sort_order`` values once before the main
-        query rather than via correlated subqueries.
+        Comparison runs against the semver-parsed sort order of each
+        release's ``code`` so backports (e.g. a hypothetical ``4.0.1``
+        post-``4.2.1``) place correctly within their version lineage.
         """
-        start_sort = (
-            session.query(Release.sort_order)
-            .filter(Release.release_id == start_release_id)
-            .scalar()
+        from dpmcore.orm.release_sort_order import (
+            load_release_sort_orders,
+            release_ids_for_sort_order,
         )
+
+        sort_orders = load_release_sort_orders(session)
+        start_sort = sort_orders.get(start_release_id)
         if start_sort is None:
             raise EcbValidationsImportError(
                 f"Release {start_release_id} has no sort_order — its "
                 "code could not be parsed as MAJOR.MINOR[.PATCH]."
             )
-        query = (
-            session.query(Release.release_id)
-            .filter(Release.sort_order >= start_sort)
-            .order_by(Release.sort_order)
-        )
-        if end_release_id is not None:
-            end_sort = (
-                session.query(Release.sort_order)
-                .filter(Release.release_id == end_release_id)
-                .scalar()
+        if end_release_id is None:
+            return release_ids_for_sort_order(sort_orders, ge=start_sort)
+        end_sort = sort_orders.get(end_release_id)
+        if end_sort is None:
+            raise EcbValidationsImportError(
+                f"Release {end_release_id} has no sort_order — "
+                "its code could not be parsed as "
+                "MAJOR.MINOR[.PATCH]."
             )
-            if end_sort is None:
-                raise EcbValidationsImportError(
-                    f"Release {end_release_id} has no sort_order — "
-                    "its code could not be parsed as "
-                    "MAJOR.MINOR[.PATCH]."
-                )
-            query = query.filter(Release.sort_order < end_sort)
-        return [row[0] for row in query.all()]
+        return release_ids_for_sort_order(
+            sort_orders, ge=start_sort, lt=end_sort
+        )
 
     def _collect_table_codes_from_ast(self, node: Any) -> Set[str]:
         table_codes: Set[str] = set()

--- a/src/dpmcore/services/hierarchy.py
+++ b/src/dpmcore/services/hierarchy.py
@@ -19,13 +19,13 @@ from dpmcore.orm.glossary import (
     Item,
     ItemCategory,
 )
-from dpmcore.orm.infrastructure import Release
 from dpmcore.orm.packaging import (
     Framework,
     Module,
     ModuleVersion,
     ModuleVersionComposition,
 )
+from dpmcore.orm.release_sort_order import load_release_sort_orders
 from dpmcore.orm.rendering import (
     Cell,
     HeaderVersion,
@@ -37,6 +37,30 @@ from dpmcore.orm.rendering import (
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
+
+
+def _most_recent_by_release(
+    session: "Session",
+    rows: List[Any],
+    release_key: Any,
+) -> Optional[Any]:
+    """Pick the row whose start-release sorts last by semver order.
+
+    Rows whose release has no parseable sort order lose to any
+    parseable row, mirroring ``NULLS LAST`` ordering.
+    """
+    if not rows:
+        return None
+    sort_orders = load_release_sort_orders(session)
+
+    def key(row: Any) -> tuple[int, int]:
+        rid = release_key(row)
+        so = sort_orders.get(rid) if rid is not None else None
+        if so is None:
+            return (0, 0)
+        return (1, so)
+
+    return max(rows, key=key)
 
 
 def _ensure_single_filter(
@@ -331,20 +355,8 @@ class HierarchyService:
             self.session, release_id=release_id, release_code=release_code
         )
 
-        # Order by Release.sort_order — start_release_id is no longer
-        # monotonic post-4.2.1 (4.2.1 has ReleaseID 1010000003), so
-        # picking the "most recent" via the raw FK would be wrong on
-        # any DB that contains opaque IDs. LEFT JOIN so a missing or
-        # unparseable Release does not drop the row entirely; a NULL
-        # sort_order simply sorts last via ``nulls_last``.
-        mv_start_release = aliased(Release)
-        q = (
-            self.session.query(ModuleVersion)
-            .outerjoin(
-                mv_start_release,
-                mv_start_release.release_id == ModuleVersion.start_release_id,
-            )
-            .filter(ModuleVersion.code == module_code)
+        q = self.session.query(ModuleVersion).filter(
+            ModuleVersion.code == module_code
         )
         if release_id is not None:
             q = filter_by_release(
@@ -355,9 +367,9 @@ class HierarchyService:
             )
         else:
             q = filter_active_only(q, ModuleVersion.end_release_id)
-        row = q.order_by(
-            mv_start_release.sort_order.desc().nulls_last()
-        ).first()
+        row = _most_recent_by_release(
+            self.session, q.all(), lambda mv: mv.start_release_id
+        )
         return row.to_dict() if row else None
 
     def get_table_details(
@@ -472,25 +484,18 @@ class HierarchyService:
         if tv is None:
             raise ValueError(f"Table {table_code} was not found.")
 
-        # Resolve the reference release's sort_order once at Python
-        # time so the per-row ItemCategory range comparisons emit just
-        # one correlated subquery per item-side column instead of
-        # three. ``filter_item_version`` accepts ``None`` (unparseable
-        # code) and produces a NULL-comparing clause that never matches.
-        #
         # Items/categories are versioned independently of TableVersion,
         # so when the caller asks for a specific release we evaluate
-        # item membership at *that* release rather than at the table
-        # version's start. Without a release filter (date-only or no
-        # filter), fall back to the table version's start release as
-        # the anchor.
+        # item membership at *that* release; otherwise fall back to the
+        # table version's start release.
         ref_release_id = (
             release_id if release_id is not None else tv.start_release_id
         )
+        sort_orders = load_release_sort_orders(self.session)
         ref_sort_order = (
-            self.session.query(Release.sort_order)
-            .filter(Release.release_id == ref_release_id)
-            .scalar()
+            sort_orders.get(ref_release_id)
+            if ref_release_id is not None
+            else None
         )
 
         iccp = aliased(ItemCategory)
@@ -532,6 +537,7 @@ class HierarchyService:
                 and_(
                     ContextComposition.property_id == iccp.item_id,
                     filter_item_version(
+                        sort_orders,
                         ref_sort_order,
                         iccp.start_release_id,
                         iccp.end_release_id,
@@ -543,6 +549,7 @@ class HierarchyService:
                 and_(
                     ContextComposition.item_id == icci.item_id,
                     filter_item_version(
+                        sort_orders,
                         ref_sort_order,
                         icci.start_release_id,
                         icci.end_release_id,
@@ -554,6 +561,7 @@ class HierarchyService:
                 and_(
                     HeaderVersion.property_id == icmp.item_id,
                     filter_item_version(
+                        sort_orders,
                         ref_sort_order,
                         icmp.start_release_id,
                         icmp.end_release_id,
@@ -637,17 +645,11 @@ class HierarchyService:
         Joins through ModuleVersionComposition + ModuleVersion so that
         the date filter (which is tracked on ModuleVersion) applies
         consistently. Falls back to the most recent module-version
-        match when several rows survive the filter.
-
-        "Most recent" is decided by ``Release.sort_order`` because the
-        raw ``start_release_id`` FK is no longer monotonic post-4.2.1
-        (4.2.1 has ``ReleaseID = 1010000003``). LEFT JOIN so a missing
-        or unparseable Release does not drop the row; a NULL
-        sort_order simply sorts last via ``nulls_last``.
+        match (by semver-parsed sort order of ``start_release_id``)
+        when several rows survive the filter.
         """
-        mv_start_release = aliased(Release)
         q = (
-            self.session.query(TableVersion)
+            self.session.query(TableVersion, ModuleVersion.start_release_id)
             .join(
                 ModuleVersionComposition,
                 ModuleVersionComposition.table_vid == TableVersion.table_vid,
@@ -657,13 +659,15 @@ class HierarchyService:
                 ModuleVersion.module_vid
                 == ModuleVersionComposition.module_vid,
             )
-            .outerjoin(
-                mv_start_release,
-                mv_start_release.release_id == ModuleVersion.start_release_id,
-            )
             .filter(TableVersion.code == table_code)
         )
         q = _apply_module_filter(q, release_id, date)
-        return q.order_by(
-            mv_start_release.sort_order.desc().nulls_last()
-        ).first()
+        rows = q.all()
+        if not rows:
+            return None
+        picked = _most_recent_by_release(
+            self.session, rows, lambda row: row[1]
+        )
+        if picked is None:
+            return None
+        return picked[0]

--- a/tests/integration/releases/test_semver_sort_order.py
+++ b/tests/integration/releases/test_semver_sort_order.py
@@ -2,8 +2,8 @@
 
 DPM ``ReleaseID`` values are no longer monotonic (4.2.1 has
 ``ReleaseID = 1010000003`` while older releases are still 1..5), so
-range filters must compare against ``Release.sort_order`` (parsed
-from semver ``code``) rather than against the raw integer ID.
+range filters must compare against a semver-parsed sort order rather
+than against the raw integer ID.
 
 The headline scenario is a *backport*: a hypothetical ``4.0.1``
 published chronologically after ``4.2.1`` but semantically belonging
@@ -79,12 +79,13 @@ def test_compute_sort_order_is_monotone() -> None:
     assert compute_sort_order("4.0.1") < compute_sort_order("4.1")
 
 
-def test_release_sort_order_auto_populated() -> None:
-    """The ``before_insert`` listener fills ``sort_order`` from ``code``."""
+def test_load_release_sort_orders_from_code() -> None:
+    """``load_release_sort_orders`` parses ``Release.code`` per row."""
     from sqlalchemy import create_engine
     from sqlalchemy.orm import Session
 
     from dpmcore.orm import Base
+    from dpmcore.orm.release_sort_order import load_release_sort_orders
 
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
@@ -98,7 +99,7 @@ def test_release_sort_order_auto_populated() -> None:
             ),
         )
         session.commit()
-        rows = {r.release_id: r.sort_order for r in session.query(Release)}
+        rows = load_release_sort_orders(session)
     # 4.2 → (4, 2, 0); 4.2.1 → (4, 2, 1) — the latter must compare greater.
     assert rows[1] is not None
     assert rows[1010000003] is not None
@@ -253,7 +254,7 @@ def test_unparseable_release_code_excluded(memory_session):
 
 
 # --------------------------------------------------------------------- #
-# filter_item_version (per-row sort_order subqueries)
+# filter_item_version (IN-list expanded from semver-parsed sort order)
 # --------------------------------------------------------------------- #
 
 
@@ -261,9 +262,10 @@ def test_filter_item_version_handles_backport(backport_session):
     """ItemCategory range filter pulls in the right metadata for a backport.
 
     The query joins TableVersion to ItemCategory using
-    ``filter_item_version`` — the JOIN condition compares
-    ``Release.sort_order``. An ItemCategory valid 4.0..4.2 (FK
-    start=3 end=5) must match a TableVersion at the 4.0.1 backport.
+    ``filter_item_version`` — the JOIN condition expands into
+    ``release_id IN (...)`` lists built from the semver-parsed sort
+    order of each release's ``code``. An ItemCategory valid 4.0..4.2
+    (FK start=3 end=5) must match a TableVersion at the 4.0.1 backport.
     """
     session = backport_session
     session.add(Category(category_id=1, code="C1"))
@@ -326,5 +328,5 @@ def test_filter_item_version_handles_backport(backport_session):
         e.get("main_property_code") == "prop:42" for e in main_entries
     ), (
         "ItemCategory valid 4.0..4.2 must match a TableVersion at the "
-        "4.0.1 backport via filter_item_version's sort_order JOIN."
+        "4.0.1 backport via filter_item_version's IN-list filter."
     )

--- a/tests/unit/orm/test_schema_alignment.py
+++ b/tests/unit/orm/test_schema_alignment.py
@@ -40,10 +40,6 @@ EXCLUDED_TABLES: Set[str] = {
 # the Access table has no natural primary key).  {table: {col, …}}
 SYNTHETIC_ORM_COLUMNS: Dict[str, Set[str]] = {
     "ModelViolations": {"id"},
-    # Release.SortOrder is computed from Release.Code at insert time
-    # (see dpmcore.orm.release_sort_order). It does not exist in the
-    # Access source schema.
-    "Release": {"SortOrder"},
 }
 
 # Access types → canonical type names used for comparison.

--- a/tests/unit/services/test_ast_generator.py
+++ b/tests/unit/services/test_ast_generator.py
@@ -609,8 +609,12 @@ class TestLatestReleaseInWindow:
         svc, _, _ = _bare_svc()
         svc.session = MagicMock()
         mv = SimpleNamespace(start_release_id=42, end_release_id=None)
-        # First (and only) sort_order lookup returns None.
-        svc.session.query.return_value.filter.return_value.scalar.return_value = None  # noqa: E501
+        # resolve_sort_order issues session.query(Release.code).filter(
+        # Release.release_id == ...).first(); return an unparseable code
+        # so compute_sort_order produces None and the helper raises.
+        svc.session.query.return_value.filter.return_value.first.return_value = (  # noqa: E501
+            "garbage",
+        )
         with pytest.raises(
             ValueError, match="window start release 42 has no sort_order"
         ):
@@ -620,10 +624,12 @@ class TestLatestReleaseInWindow:
         svc, _, _ = _bare_svc()
         svc.session = MagicMock()
         mv = SimpleNamespace(start_release_id=1, end_release_id=99)
-        # Two sort_order lookups: first OK, second None.
-        svc.session.query.return_value.filter.return_value.scalar.side_effect = [  # noqa: E501
-            10,
-            None,
+        # Two resolve_sort_order calls: first returns a parseable code,
+        # second returns an unparseable one so the end-bound resolver
+        # raises.
+        svc.session.query.return_value.filter.return_value.first.side_effect = [  # noqa: E501
+            ("4.0",),
+            ("garbage",),
         ]
         with pytest.raises(
             ValueError, match="window end release 99 has no sort_order"


### PR DESCRIPTION
…parison

## Summary

<!-- Short description of the change and why it's needed. -->

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [ ] Documentation updated (if applicable)

## Impact / Risk

- Breaking changes? (public API / CLI / REST endpoints / Django models)
- Database schema or migration concerns?
- Notes for release/changelog?

## Notes

<!-- Follow-ups, TODOs, or anything reviewers should know. -->
