### PR TITLE
fix: pass output_path to MigrationService in build-meili-json to prev…

### DIFF
--- a/src/dpmcore/services/meili_build.py
+++ b/src/dpmcore/services/meili_build.py
@@ -65,7 +65,9 @@ class MeiliBuildService:
             migration_service = MigrationService(engine)
 
             try:
-                migration_service.migrate_from_csv_dir(str(csv_dir))
+                migration_service.migrate_from_csv_dir(
+                    str(csv_dir), output_path=db_path
+                )
                 if ecb_validations_file:
                     EcbValidationsImportService(engine).import_csv(
                         ecb_validations_file

--- a/tests/unit/meili/test_meili_build_service.py
+++ b/tests/unit/meili/test_meili_build_service.py
@@ -24,7 +24,8 @@ class TestMeiliBuildService:
         ):
             result = MeiliBuildService().build(output_file=str(output_file))
 
-        migrate_csv.assert_called_once_with(str(Path("data/DPM")))
+        call = migrate_csv.call_args
+        assert call.args[0] == str(Path("data/DPM"))
         assert result.operations_written == 12
         assert result.used_access_file is False
         assert result.ecb_validations_imported is False
@@ -159,7 +160,8 @@ class TestMeiliBuildService:
                 source_dir=str(custom_dir),
             )
 
-        migrate_csv.assert_called_once_with(str(custom_dir))
+        call = migrate_csv.call_args
+        assert call.args[0] == str(custom_dir)
         assert result.used_access_file is False
         assert result.source_dir == Path(str(custom_dir))
 
@@ -181,3 +183,34 @@ class TestMeiliBuildService:
             result = MeiliBuildService().build(output_file=str(output_file))
 
         assert result.source_dir == Path("data/DPM")
+
+    def test_migrate_called_with_output_path_to_prevent_relocation(
+        self, tmp_path
+    ):
+        # Regression: without output_path, MigrationService._finalize renames
+        # the temp SQLite file via _relocate_database, disposing the engine and
+        # moving the file to a date-stamped name.  Any code that runs after
+        # (ECB import, MeiliJsonService) connects through the old engine URL,
+        # SQLite silently creates a fresh empty DB there, and every ORM query
+        # fails with "no such table".
+        output_file = tmp_path / "operations.json"
+        fake_result = MagicMock()
+        fake_result.operations_written = 0
+        fake_result.output_file = output_file
+
+        with (
+            patch(
+                "dpmcore.services.meili_build.MigrationService"
+            ) as MockMigration,
+            patch(
+                "dpmcore.services.meili_build.MeiliJsonService.generate",
+                return_value=fake_result,
+            ),
+        ):
+            MeiliBuildService().build(output_file=str(output_file))
+
+        call_kwargs = (
+            MockMigration.return_value.migrate_from_csv_dir.call_args.kwargs
+        )
+        assert "output_path" in call_kwargs
+        assert call_kwargs["output_path"].name == "dpmcore_meili.db"


### PR DESCRIPTION
…ent temp DB relocation

MigrationService._finalize calls _relocate_database which disposes the engine and moves the SQLite file to a date-stamped name.  Any code running after migrate_from_csv_dir (ECB validations import, MeiliJsonService) reconnects through the now-stale engine URL; SQLite silently creates a fresh empty database at that path, so every ORM query fails with "no such table".

The same fix was applied to database_update.py in PR #47 but meili_build.py was missed.  Passing output_path=db_path makes _relocate_database short-circuit (source == destination) so the engine stays valid.

## Summary

<!-- Short description of the change and why it's needed. -->

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [x] Documentation updated (if applicable)

## Impact / Risk

- Breaking changes? (public API / CLI / REST endpoints / Django models)
- Database schema or migration concerns?
- Notes for release/changelog?

## Notes

<!-- Follow-ups, TODOs, or anything reviewers should know. -->
