### PR TITLE
Fix/3 6 null default mixed type

### DIFF
--- a/src/dpmcore/dpm_xl/types/promotion.py
+++ b/src/dpmcore/dpm_xl/types/promotion.py
@@ -43,6 +43,7 @@ implicit_type_promotion_dict: dict[type[ScalarType], set[type[ScalarType]]] = {
         Item,
         Subcategory,
         Null,
+        Mixed,
     },
 }
 

--- a/tests/unit/semantic/test_default_value_type_check.py
+++ b/tests/unit/semantic/test_default_value_type_check.py
@@ -12,6 +12,7 @@ from dpmcore.dpm_xl.types.scalar import (
     Boolean,
     Integer,
     Item,
+    Mixed,
     Number,
     String,
 )
@@ -229,6 +230,15 @@ class TestCheckDefaultValue:
         """Null default for Number operand should be valid."""
         default_value = self._create_constant("Null", None)
         expected_type = Number()
+
+        InputAnalyzer._InputAnalyzer__check_default_value(
+            default_value, expected_type
+        )
+
+    def test_null_default_for_mixed_is_valid(self):
+        """Null default for Mixed operand should be valid."""
+        default_value = self._create_constant("Null", None)
+        expected_type = Mixed()
 
         InputAnalyzer._InputAnalyzer__check_default_value(
             default_value, expected_type


### PR DESCRIPTION
Closes #68

`default: null` on Mixed-type cells was incorrectly raising error 3-6. `null` is a valid default for any type.

`Mixed` was missing from `implicit_type_promotion_dict[Null]` in `promotion.py`.

## Result

16 operations fixed.

| operation_vid | code | release | expression |
|---|---|---|---|
| 5390 | e10773_e | 3.4 | `with {tM_03.00, default: null, interval: false}: not ( isnull ({(r0010, r0100, r0110, r0200, r0400, r0420), c0010}) )` |
| 6596 | v12543_e | 3.4 | `not ( isnull ({tR_07.00, (r0010, r0020, r0030, r0040, r0050, r0070), c0010, default: null, interval: false}) )` |
| 10413 | e23675_e | 4.0 | `with {tB_01.03, default:null, interval:false}: not ( isnull ({c*}) )` |
| 10414 | e23676_e | 4.0 | `with {tB_01.02, default:null, interval:false}: not ( isnull ({c0020-0090}) )` |
| 10415 | e23677_e | 4.0 | `with {tB_01.01, default:null, interval:false}: not ( isnull ({c*}) )` |
| 10418 | e23680_e | 4.0 | `with {tB_02.02, default:null, interval:false}: not ( isnull ({c0040-0080}) )` |
| 10419 | e23681_e | 4.0 | `with {tB_07.01, default:null, interval:false}: not ( isnull ({(c0050, c0070, c0080, c0090, c0100)}) )` |
| 10420 | e23682_e | 4.0 | `with {tB_06.01, default:null, interval:false}: not ( isnull ({(c0020, c0030, c0040, c0050, c0060)}) )` |
| 10734 | e23792_e | 4.0 | `with {tB_02.01, default:null, interval:false}: not ( isnull ({(c0020, c0040, c0050, c0060, c0070)}) )` |
| 18444 | e10773_e | 4.2 | `with {tM_03.00, default: null, interval: false}: not ( isnull ({(r0010, r0100, r0110, r0200, r0400, r0420), c0010}) )` |
| 19285 | v12543_e | 4.2 | `not ( isnull ({tR_07.00, (r0010, r0020, r0030, r0040, r0050, r0070), c0010, default: null, interval: false}) )` |
| 21036 | v903581_m | 4.2 | `with {tB_02.02, default:null, interval:false}: not ( isnull ({c*}) )` |
| 21039 | v903584_m | 4.2 | `with {tB_02.01, default:null, interval:false}: not ( isnull ({(c0020, c0040, c0050, c0060, c0070)}) )` |
| 21040 | v903585_m | 4.2 | `with {tB_06.01, default:null, interval:false}: not ( isnull ({c*}) )` |
| 21081 | e23682_e | 4.2 | `with {tB_06.01, default:null, interval:false}: not ( isnull ({(c0020, c0030, c0040, c0050, c0060)}) )` |
| 21083 | e23792_e | 4.2 | `with {tB_02.01, default:null, interval:false}: not ( isnull ({(c0020, c0040, c0050, c0060, c0070)}) )` |

This are the failures resting: [test_data_failures.csv](https://github.com/user-attachments/files/28276459/test_data_failures.csv)

## Checklist

- [X] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [X] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [X] Documentation updated (if applicable)

## Impact / Risk

- Breaking changes? (public API / CLI / REST endpoints / Django models)
- Database schema or migration concerns?
- Notes for release/changelog?

## Notes

<!-- Follow-ups, TODOs, or anything reviewers should know. -->
