### PR TITLE
fix(3-6): accept String default for cells whose type promotes to String

### DIFF
--- a/src/dpmcore/dpm_xl/semantic_analyzer.py
+++ b/src/dpmcore/dpm_xl/semantic_analyzer.py
@@ -202,18 +202,20 @@ class InputAnalyzer(ASTTemplate, ABC):
         if default_value is None:
             return
         default_type = ScalarFactory().scalar_factory(code=default_value.type)
-        # Import the implicit type promotion dictionary for unidirectional check
         from dpmcore.dpm_xl.types.promotion import implicit_type_promotion_dict
 
-        # Check if default_type can be promoted TO type_ (unidirectional check)
-        # Get the set of types that default_type can be promoted to
-        default_implicities = implicit_type_promotion_dict[
-            default_type.__class__
-        ]
-
-        # If expected type is not in the set of types default can be promoted to,
-        # raise a semantic error
-        if not type_.is_included(default_implicities):
+        default_implicities = implicit_type_promotion_dict.get(
+            default_type.__class__, set()
+        )
+        cell_implicities = implicit_type_promotion_dict.get(
+            type_.__class__, set()
+        )
+        # Accept bidirectionally: D->C or C->D. Mixed has no dict entry; empty
+        # cell_implicities short-circuits the check (any default is valid).
+        if cell_implicities and not (
+            type_.is_included(default_implicities)
+            or default_type.is_included(cell_implicities)
+        ):
             raise errors.SemanticError(
                 "3-6", expected_type=type_, default_type=default_type
             )

--- a/tests/unit/semantic/test_default_value_type_check.py
+++ b/tests/unit/semantic/test_default_value_type_check.py
@@ -10,11 +10,11 @@ from dpmcore.dpm_xl.ast.nodes import Constant
 from dpmcore.dpm_xl.semantic_analyzer import InputAnalyzer
 from dpmcore.dpm_xl.types.scalar import (
     Boolean,
-    Integer,
     Item,
     Mixed,
     Number,
     String,
+    TimeInterval,
 )
 from dpmcore.errors import SemanticError
 
@@ -26,48 +26,6 @@ class TestCheckDefaultValue:
     def _create_constant(type_code: str, value) -> Constant:
         """Helper to create a Constant node for testing."""
         return Constant(type_=type_code, value=value)
-
-    def test_string_default_for_boolean_raises_error(self):
-        """String default for Boolean operand should raise SemanticError 3-6."""
-        default_value = self._create_constant("String", "")
-        expected_type = Boolean()
-
-        with pytest.raises(SemanticError) as exc_info:
-            InputAnalyzer._InputAnalyzer__check_default_value(
-                default_value, expected_type
-            )
-
-        assert "Invalid default type" in str(exc_info.value)
-        assert "String" in str(exc_info.value)
-        assert "Boolean" in str(exc_info.value)
-
-    def test_string_default_for_number_raises_error(self):
-        """String default for Number operand should raise SemanticError 3-6."""
-        default_value = self._create_constant("String", "")
-        expected_type = Number()
-
-        with pytest.raises(SemanticError) as exc_info:
-            InputAnalyzer._InputAnalyzer__check_default_value(
-                default_value, expected_type
-            )
-
-        assert "Invalid default type" in str(exc_info.value)
-        assert "String" in str(exc_info.value)
-        assert "Number" in str(exc_info.value)
-
-    def test_string_default_for_integer_raises_error(self):
-        """String default for Integer operand should raise SemanticError 3-6."""
-        default_value = self._create_constant("String", "")
-        expected_type = Integer()
-
-        with pytest.raises(SemanticError) as exc_info:
-            InputAnalyzer._InputAnalyzer__check_default_value(
-                default_value, expected_type
-            )
-
-        assert "Invalid default type" in str(exc_info.value)
-        assert "String" in str(exc_info.value)
-        assert "Integer" in str(exc_info.value)
 
     def test_integer_default_for_number_is_valid(self):
         """Integer default for Number operand should be valid (Integer can be promoted to Number)."""
@@ -129,19 +87,46 @@ class TestCheckDefaultValue:
             default_value, expected_type
         )
 
-    def test_string_default_for_item_raises_error(self):
-        """String default for Item operand should raise SemanticError 3-6."""
+    def test_string_default_for_boolean_is_valid(self):
+        """String default for Boolean cell must be accepted.
+
+        Boolean is string-representable (Boolean promotes to String).
+        """
         default_value = self._create_constant("String", "")
-        expected_type = Item()
+        InputAnalyzer._InputAnalyzer__check_default_value(
+            default_value, Boolean()
+        )
 
-        with pytest.raises(SemanticError) as exc_info:
-            InputAnalyzer._InputAnalyzer__check_default_value(
-                default_value, expected_type
-            )
+    def test_string_default_for_number_is_valid(self):
+        """String default for Number cell must be accepted.
 
-        assert "Invalid default type" in str(exc_info.value)
-        assert "String" in str(exc_info.value)
-        assert "Item" in str(exc_info.value)
+        Number is string-representable (Number promotes to String).
+        """
+        default_value = self._create_constant("String", "")
+        InputAnalyzer._InputAnalyzer__check_default_value(
+            default_value, Number()
+        )
+
+    def test_string_default_for_item_is_valid(self):
+        """String default for Item cell must be accepted.
+
+        Item columns are string-representable (Item promotes to String),
+        so ``default: ""`` is a valid sentinel for a missing enumeration value.
+        """
+        default_value = self._create_constant("String", "")
+        InputAnalyzer._InputAnalyzer__check_default_value(
+            default_value, Item()
+        )
+
+    def test_string_default_for_timeinterval_is_valid(self):
+        """String default for TimeInterval cell must be accepted.
+
+        TimeInterval is string-representable (TimeInterval promotes to String).
+        """
+        default_value = self._create_constant("String", "")
+        InputAnalyzer._InputAnalyzer__check_default_value(
+            default_value, TimeInterval()
+        )
 
     def test_item_default_for_string_is_valid(self):
         """Item default for String operand should be valid (Item can be promoted to String)."""


### PR DESCRIPTION
Closes #79 

`__check_default_value` in `InputAnalyzer` validated default value types with a
unidirectional promotion check: a default of type `D` was accepted for a cell of
type `C` only when `D` could be promoted to `C`.

The fix adds the reverse direction: also accept when `C` promotes to `D`.
In practice this means a `String` default (`""`) is now valid for any cell whose
type promotes to `String` — namely `Item`, `Boolean`, `TimeInterval`, and `Number`.

## Impact

320 operations no longer raise 3-6.

| default type | cell type | count |
|---|---|---|
| String | Item | 270 |
| String | Boolean | 34 |
| String | TimeInterval | 14 |
| String | Number | 2 |

This is the failures .csv after the fix: [test_data_failures.csv](https://github.com/user-attachments/files/28301882/test_data_failures.csv)


## Checklist

- [X] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [X] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [X] Documentation updated (if applicable)

## Impact / Risk

- Breaking changes? (public API / CLI / REST endpoints / Django models)
- Database schema or migration concerns?
- Notes for release/changelog?

## Notes

<!-- Follow-ups, TODOs, or anything reviewers should know. -->
