### PR TITLE
fix(3-6): accept Integer default for non-Boolean cells

### DIFF
--- a/src/dpmcore/dpm_xl/semantic_analyzer.py
+++ b/src/dpmcore/dpm_xl/semantic_analyzer.py
@@ -47,6 +47,7 @@ from dpmcore.dpm_xl.symbols import (
     Structure,
 )
 from dpmcore.dpm_xl.types.scalar import (
+    Boolean,
     Integer,
     Item,
     Mixed,
@@ -210,11 +211,16 @@ class InputAnalyzer(ASTTemplate, ABC):
         cell_implicities = implicit_type_promotion_dict.get(
             type_.__class__, set()
         )
-        # Accept bidirectionally: D->C or C->D. Mixed has no dict entry; empty
-        # cell_implicities short-circuits the check (any default is valid).
+        # Accept: D→C, C→D, or shared promotion target (excl. Boolean crossings).
+        # Mixed has no dict entry; empty cell_implicities skips the check.
         if cell_implicities and not (
             type_.is_included(default_implicities)
             or default_type.is_included(cell_implicities)
+            or (
+                not isinstance(default_type, Boolean)
+                and not isinstance(type_, Boolean)
+                and default_implicities & cell_implicities
+            )
         ):
             raise errors.SemanticError(
                 "3-6", expected_type=type_, default_type=default_type

--- a/tests/unit/semantic/test_default_value_type_check.py
+++ b/tests/unit/semantic/test_default_value_type_check.py
@@ -128,6 +128,30 @@ class TestCheckDefaultValue:
             default_value, TimeInterval()
         )
 
+    def test_integer_default_for_item_is_valid(self):
+        """Integer default for Item cell must be accepted.
+
+        Both Integer and Item are string-representable, so integer 0 is a valid
+        numeric sentinel for a missing enumeration value.
+        Regression: 5 operations raised 3-6 with this pattern.
+        """
+        default_value = self._create_constant("Integer", 0)
+        InputAnalyzer._InputAnalyzer__check_default_value(
+            default_value, Item()
+        )
+
+    def test_integer_default_for_timeinterval_is_valid(self):
+        """Integer default for TimeInterval cell must be accepted.
+
+        Both Integer and TimeInterval are string-representable, so integer 0 is
+        a valid numeric sentinel for a missing time-interval value.
+        Regression: 1 operation raised 3-6 with this pattern.
+        """
+        default_value = self._create_constant("Integer", 0)
+        InputAnalyzer._InputAnalyzer__check_default_value(
+            default_value, TimeInterval()
+        )
+
     def test_item_default_for_string_is_valid(self):
         """Item default for String operand should be valid (Item can be promoted to String)."""
         default_value = self._create_constant("Item", "[x1]")


### PR DESCRIPTION
# fix(3-6): accept Integer default for non-Boolean cells

`__check_default_value` raised 3-6 for `Integer 0` defaults on `Item` and
`TimeInterval` cells because no direct promotion path exists between those types.

The fix adds a third acceptance condition: if both types share a common promotion
target (their promotion sets intersect) and neither is `Boolean`, the default is
valid. In practice this means `0` is accepted as a numeric null sentinel for any
non-Boolean cell type.

## Impact

7 operations no longer raise 3-6.

| operation_vid | code | release | expression |
|---|---|---|---|
| 10353 | v8803_m | 4.0 | `with {tB_01.02, default: 0, interval: false}: if (not (isnull ({c0110}))) ...` |
| 10684 | v8804_m | 4.0 | `with {tB_01.02, default: 0, interval: false}: if ({c0040} != [eba_CT:x318] ...` |
| 10355 | v8805_m | 4.0 | `with {tB_02.01, default: 0, interval: false}: if ({c0020} = [eba_CO:x3]) ...` |
| 10593 | v8816_m | 4.0 | `with {tB_02.02, default: 0, interval: false}: {c0080} > {c0070}` |
| 10667 | v8817_m | 4.0 | `with {tB_05.01, default: 0, interval: false}: if ({c0070} = [eba_CT:x212]) ...` |
| 10595 | v8821_m | 4.0 | `with {tB_05.01, default: 0, interval: false}: if ({c0020} = [eba_qCO:qx2000]) ...` |
| 10654 | v8825_m | 4.0 | `with {tB_07.01, default: 0, interval: false}: if {c0050} = [eba_ZZ:x959] ...` |

This are the failures after the fix: [test_data_failures.csv](https://github.com/user-attachments/files/28304387/test_data_failures.csv)


## Checklist

- [X] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [X] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [X] Documentation updated (if applicable)

## Impact / Risk

- Breaking changes? (public API / CLI / REST endpoints / Django models)
- Database schema or migration concerns?
- Notes for release/changelog?

## Notes

<!-- Follow-ups, TODOs, or anything reviewers should know. -->
