### PR TITLE
fix(3-4): accept interval flag for non-numeric cell types

### DIFF
--- a/src/dpmcore/dpm_xl/types/scalar.py
+++ b/src/dpmcore/dpm_xl/types/scalar.py
@@ -318,6 +318,4 @@ class ScalarFactory:
         scalar_type = self.database_types_mapping(code)
         if isinstance(scalar_type(), Number):
             return scalar_type(interval)  # type: ignore[call-arg]
-        if interval:
-            raise SemanticError("3-4", operand_type=scalar_type.__name__)
         return scalar_type()

--- a/tests/unit/semantic/test_interval_type_validation.py
+++ b/tests/unit/semantic/test_interval_type_validation.py
@@ -1,7 +1,7 @@
 """Tests for interval type validation in ScalarFactory.
 
-Tests that the ScalarFactory correctly validates that interval=true can only
-be used with Number and Integer types, not with String, Boolean, Item, etc.
+Tests that the ScalarFactory correctly handles interval=true: stored for
+Number and Integer types, no effect for String, Boolean, Item, etc.
 """
 
 import pytest
@@ -15,7 +15,6 @@ from dpmcore.dpm_xl.types.scalar import (
     String,
     TimeInterval,
 )
-from dpmcore.errors import SemanticError
 
 
 class TestIntervalTypeValidation:
@@ -26,63 +25,54 @@ class TestIntervalTypeValidation:
         """Create a ScalarFactory instance for testing."""
         return ScalarFactory()
 
-    def test_interval_with_string_type_raises_error(self, scalar_factory):
-        """interval=True with String type (STR) should raise SemanticError 3-4."""
-        with pytest.raises(SemanticError) as exc_info:
-            scalar_factory.from_database_to_scalar_types("STR", interval=True)
+    def test_interval_with_string_type_is_valid(self, scalar_factory):
+        """interval=True with String type (STR) must be accepted."""
+        result = scalar_factory.from_database_to_scalar_types(
+            "STR", interval=True
+        )
+        assert isinstance(result, String)
 
-        assert "Interval can't be used" in str(exc_info.value)
-        assert "String" in str(exc_info.value)
+    def test_interval_with_uri_string_type_is_valid(self, scalar_factory):
+        """interval=True with String type (URI) must be accepted."""
+        result = scalar_factory.from_database_to_scalar_types(
+            "URI", interval=True
+        )
+        assert isinstance(result, String)
 
-    def test_interval_with_uri_string_type_raises_error(self, scalar_factory):
-        """interval=True with String type (URI) should raise SemanticError 3-4."""
-        with pytest.raises(SemanticError) as exc_info:
-            scalar_factory.from_database_to_scalar_types("URI", interval=True)
+    def test_interval_with_es_string_type_is_valid(self, scalar_factory):
+        """interval=True with String type (es) must be accepted."""
+        result = scalar_factory.from_database_to_scalar_types(
+            "es", interval=True
+        )
+        assert isinstance(result, String)
 
-        assert "Interval can't be used" in str(exc_info.value)
-        assert "String" in str(exc_info.value)
+    def test_interval_with_boolean_type_is_valid(self, scalar_factory):
+        """interval=True with Boolean type (BOO) must be accepted."""
+        result = scalar_factory.from_database_to_scalar_types(
+            "BOO", interval=True
+        )
+        assert isinstance(result, Boolean)
 
-    def test_interval_with_es_string_type_raises_error(self, scalar_factory):
-        """interval=True with String type (es) should raise SemanticError 3-4."""
-        with pytest.raises(SemanticError) as exc_info:
-            scalar_factory.from_database_to_scalar_types("es", interval=True)
+    def test_interval_with_tru_boolean_type_is_valid(self, scalar_factory):
+        """interval=True with Boolean type (TRU) must be accepted."""
+        result = scalar_factory.from_database_to_scalar_types(
+            "TRU", interval=True
+        )
+        assert isinstance(result, Boolean)
 
-        assert "Interval can't be used" in str(exc_info.value)
-        assert "String" in str(exc_info.value)
+    def test_interval_with_item_type_is_valid(self, scalar_factory):
+        """interval=True with Item type (ENU) must be accepted."""
+        result = scalar_factory.from_database_to_scalar_types(
+            "ENU", interval=True
+        )
+        assert isinstance(result, Item)
 
-    def test_interval_with_boolean_type_raises_error(self, scalar_factory):
-        """interval=True with Boolean type (BOO) should raise SemanticError 3-4."""
-        with pytest.raises(SemanticError) as exc_info:
-            scalar_factory.from_database_to_scalar_types("BOO", interval=True)
-
-        assert "Interval can't be used" in str(exc_info.value)
-        assert "Boolean" in str(exc_info.value)
-
-    def test_interval_with_tru_boolean_type_raises_error(self, scalar_factory):
-        """interval=True with Boolean type (TRU) should raise SemanticError 3-4."""
-        with pytest.raises(SemanticError) as exc_info:
-            scalar_factory.from_database_to_scalar_types("TRU", interval=True)
-
-        assert "Interval can't be used" in str(exc_info.value)
-        assert "Boolean" in str(exc_info.value)
-
-    def test_interval_with_item_type_raises_error(self, scalar_factory):
-        """interval=True with Item type (ENU) should raise SemanticError 3-4."""
-        with pytest.raises(SemanticError) as exc_info:
-            scalar_factory.from_database_to_scalar_types("ENU", interval=True)
-
-        assert "Interval can't be used" in str(exc_info.value)
-        assert "Item" in str(exc_info.value)
-
-    def test_interval_with_time_interval_type_raises_error(
-        self, scalar_factory
-    ):
-        """interval=True with TimeInterval type (DAT) should raise SemanticError 3-4."""
-        with pytest.raises(SemanticError) as exc_info:
-            scalar_factory.from_database_to_scalar_types("DAT", interval=True)
-
-        assert "Interval can't be used" in str(exc_info.value)
-        assert "TimeInterval" in str(exc_info.value)
+    def test_interval_with_timeinterval_type_is_valid(self, scalar_factory):
+        """interval=True with TimeInterval type (DAT) must be accepted."""
+        result = scalar_factory.from_database_to_scalar_types(
+            "DAT", interval=True
+        )
+        assert isinstance(result, TimeInterval)
 
     def test_interval_with_number_type_is_valid(self, scalar_factory):
         """interval=True with Number type (DEC) should be valid."""


### PR DESCRIPTION
fix(3-4): accept interval flag for non-numeric cells

`with {col, interval: true}` propagates `interval: true` to all inner VarIDs, including non-numeric ones (Item, Boolean, TimeInterval). `from_database_to_scalar_types` in `ScalarFactory` was raising 3-4 for any non-Number/non-Integer type receiving `interval: true`, even though the flag has no effect on those types.

The fix removes the raise and returns the scalar instance as-is for non-numeric types.

## Impact

246 operations no longer raise 3-4.

| operand_type | count |
|---|---|
| Item | 219 |
| Boolean | 24 |
| TimeInterval | 3 |

**Item** (219 operations)
```
with {c0010, interval: true}: if ( {tF_00.01, r0010, default: ""} = [eba_AS:x2] ) then ...   (v0787_m, 3.4)
with {c0010, interval: true}: if ( {tF_00.01, r0010, default: ""} = [eba_qAS:qx2004] ) then ...   (v0787_m, 4.2)
```

**Boolean** (24 operations)
```
with {interval: true}: {tI_10.01, r0070, c0010, default: 0} = sum ( filter ({tI_10.02, c0060, default: 0}, ...))   (v11335_m, 3.4)
with {interval: true}: {tI_10.01, r0070, c0010, default: 0} = sum ( filter ({tI_10.02, c0060, default: 0}, ...))   (v11335_m, 4.0)
```

**TimeInterval** (3 operations)
```
with {tC_14.00, default: null, interval: true}: {c0120} <= {c0121}   (v7339_m, 3.4)
with {tC_14.00, default: null, interval: true}: {c0121} < {c0290}   (v7353_m, 3.4)

This are the failures left after the fix: [test_data_failures.csv](https://github.com/user-attachments/files/28305901/test_data_failures.csv)


## Checklist

- [X] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [X] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [X] Documentation updated (if applicable)

## Impact / Risk

- Breaking changes? (public API / CLI / REST endpoints / Django models)
- Database schema or migration concerns?
- Notes for release/changelog?

## Notes

<!-- Follow-ups, TODOs, or anything reviewers should know. -->
