### PR TITLE
fix(3-1): accept incompatible types when operator has a fixed return type

### DIFF
--- a/src/dpmcore/dpm_xl/types/promotion.py
+++ b/src/dpmcore/dpm_xl/types/promotion.py
@@ -161,10 +161,7 @@ def binary_implicit_type_promotion(
                 add_semantic_warning(
                     f"Implicit promotion between {left} and {right}."
                 )
-        if return_type and (
-            left.is_included(right_implicities)
-            or right.is_included(left_implicities)
-        ):
+        if return_type:
             return return_type
         elif left.is_included(right_implicities):
             return left

--- a/tests/unit/dpm_xl/test_type_promotion.py
+++ b/tests/unit/dpm_xl/test_type_promotion.py
@@ -1,0 +1,32 @@
+"""Tests for binary_implicit_type_promotion in promotion.py."""
+
+from dpmcore.dpm_xl.types.promotion import binary_implicit_type_promotion
+from dpmcore.dpm_xl.types.scalar import Boolean, Item, Number, String
+
+
+class TestBinaryImplicitTypePromotion:
+    def test_number_eq_item_with_boolean_return_type_is_valid(self):
+        """Number = Item must be accepted when return_type=Boolean"""
+        result = binary_implicit_type_promotion(
+            Number(), Item(), return_type=Boolean()
+        )
+        assert isinstance(result, Boolean)
+
+    def test_item_eq_number_with_boolean_return_type_is_valid(self):
+        """Item = Number must be accepted when return_type=Boolean (symmetric)."""
+        result = binary_implicit_type_promotion(
+            Item(), Number(), return_type=Boolean()
+        )
+        assert isinstance(result, Boolean)
+
+    def test_compatible_types_with_return_type_still_returns_return_type(self):
+        """When types are compatible and return_type given, return_type is returned."""
+        result = binary_implicit_type_promotion(
+            Number(), String(), return_type=Boolean()
+        )
+        assert isinstance(result, Boolean)
+
+    def test_compatible_types_without_return_type_resolves_normally(self):
+        """Without return_type, compatible types resolve via normal promotion."""
+        result = binary_implicit_type_promotion(Number(), String())
+        assert isinstance(result, (Number, String))


### PR DESCRIPTION
Closes #86 

`binary_implicit_type_promotion` raised 3-1 for expressions like `{c0070} = [eba_CT:x212]` where `c0070` is `Number` and `[eba_CT:x212]` is `Item`.

## Impact

2 operations no longer raise 3-1.

| operation_vid | code | release | expression |
|---|---|---|---|
| 10668 | v8818_m | 4.0 | `with{tB_05.01, default:0, interval: false}: if ({c0070} = [eba_CT:x212]) then (...)` |
| 20371 | v8818_m | 4.2 | `with{tB_05.01, default:null, interval: false}: if ({c0070} = [eba_CT:x212]) then (...)` |

This are the failures left after the fix: [test_data_failures.csv](https://github.com/user-attachments/files/28307275/test_data_failures.csv)

## Checklist

- [X] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [X] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [X] Documentation updated (if applicable)

## Impact / Risk

- Breaking changes? (public API / CLI / REST endpoints / Django models)
- Database schema or migration concerns?
- Notes for release/changelog?

## Notes

<!-- Follow-ups, TODOs, or anything reviewers should know. -->
