### PR TITLE
fix(2-9): skip record count check for comparison operators

### DIFF
--- a/src/dpmcore/dpm_xl/operators/base.py
+++ b/src/dpmcore/dpm_xl/operators/base.py
@@ -350,7 +350,8 @@ class Binary(Operator):
             )
             if left.records is not None and right.records is not None:
                 if (
-                    len(left.records) != len(right.records)
+                    not cls.do_not_check_with_return_type
+                    and len(left.records) != len(right.records)
                     and len(left.records) != 0
                     and len(right.records) != 0
                 ):

--- a/tests/unit/dpm_xl/test_validate_structures.py
+++ b/tests/unit/dpm_xl/test_validate_structures.py
@@ -1,0 +1,49 @@
+"""Tests for validate_structures record count check in binary operators."""
+
+import pandas as pd
+import pytest
+
+import dpmcore.dpm_xl.semantic_analyzer  # noqa: F401 (resolves circular imports)
+from dpmcore.dpm_xl.operators.arithmetic import BinPlus
+from dpmcore.dpm_xl.operators.comparison import LessEqual
+from dpmcore.dpm_xl.symbols import (
+    FactComponent,
+    KeyComponent,
+    RecordSet,
+    Structure,
+)
+from dpmcore.dpm_xl.types.scalar import Number
+from dpmcore.dpm_xl.utils.tokens import STANDARD
+from dpmcore.errors import SemanticError
+
+
+def _make_recordset(n_rows: int) -> RecordSet:
+    structure = Structure(
+        [
+            KeyComponent("r", Number(), STANDARD, "test"),
+            FactComponent(Number(), "test"),
+        ]
+    )
+    rs = RecordSet(structure, "test", "test")
+    rs.records = pd.DataFrame(
+        {
+            "r": [str(i) for i in range(n_rows)],
+            "data_type": [Number() for _ in range(n_rows)],
+        }
+    )
+    return rs
+
+
+class TestValidateStructuresDifferentRecordCounts:
+    def test_comparison_allows_different_record_counts(self):
+        """LessEqual must not raise 2-9 when record counts differ."""
+        left = _make_recordset(5)
+        right = _make_recordset(3)
+        LessEqual.validate_structures(left, right)  # must not raise
+
+    def test_arithmetic_raises_2_9_for_different_record_counts(self):
+        """BinPlus must raise 2-9 when record counts differ."""
+        left = _make_recordset(5)
+        right = _make_recordset(3)
+        with pytest.raises(SemanticError, match="different number of headers"):
+            BinPlus.validate_structures(left, right)


### PR DESCRIPTION
Closes #89 

`validate_structures` raised 2-9 for comparison operators (`<=`, `=`, etc.) when left and right RecordSets had different row counts, even though different counts are valid for comparisons.

Comparison operators are identified by `do_not_check_with_return_type = True`, so the fix gates the check on `not cls.do_not_check_with_return_type`.

## Impact

3 operations no longer raise 2-9.

| operation_vid | code | release | expression |
|---|---|---|---|
| 8628 | v0330_m | 4.0 | `with {default: 0, interval: true}: {tC_08.01.b, r0010-0170, c0120} <= {tC_08.01.a, (r0010, r0015, ...), c0110}` |
| 8629 | v0333_m | 4.0 | `with {default: 0, interval: true}: {tC_08.01.b, r0010-0170, c0100} <= {tC_08.01.a, (r0010, r0015, ...), c0090}` |
| 8630 | v0334_m | 4.0 | `with {default: 0, interval: true}: {tC_08.01.c, r*, c0130} <= {tC_08.01.a, (r0010, r0015, ...), c0110}` |

## Checklist

- [ ] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [ ] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [ ] Documentation updated (if applicable)

## Impact / Risk

- Breaking changes? (public API / CLI / REST endpoints / Django models)
- Database schema or migration concerns?
- Notes for release/changelog?

## Notes

<!-- Follow-ups, TODOs, or anything reviewers should know. -->
