### PR TITLE
fix(1-20): accept uniform dimension omission as "apply to all"

### DIFF
--- a/src/dpmcore/dpm_xl/ast/operands.py
+++ b/src/dpmcore/dpm_xl/ast/operands.py
@@ -215,6 +215,11 @@ class OperandsChecking(ASTTemplate, ABC):
             and getattr(self.partial_selection, header) is not None
         ):
             return
+        # If ALL operands omit the header, the expression applies to every
+        # instance of that dimension ("apply to all" semantics) — valid.
+        # Only raise 1-20 when SOME operands specify the header and SOME don't.
+        if all(getattr(node, header) is None for node in self.operands[table]):
+            return
         for node in self.operands[table]:
             if getattr(node, header) is None:
                 if header == "cols":

--- a/tests/unit/dpm_xl/test_check_header_present.py
+++ b/tests/unit/dpm_xl/test_check_header_present.py
@@ -1,0 +1,91 @@
+import pytest
+
+from dpmcore.dpm_xl.ast.nodes import VarID
+from dpmcore.dpm_xl.ast.operands import OperandsChecking
+from dpmcore.errors import SemanticError
+
+
+def _varid(table: str, rows=None, cols=None, sheets=None) -> VarID:
+    return VarID(
+        table=table,
+        rows=rows,
+        cols=cols,
+        sheets=sheets,
+        default=None,
+        interval=False,
+    )
+
+
+def _make_oc(
+    operands: list[VarID],
+    partial_selection: VarID | None = None,
+) -> OperandsChecking:
+    oc = object.__new__(OperandsChecking)
+    table = operands[0].table
+    assert table is not None
+    oc.operands = {table: operands}
+    oc.partial_selection = partial_selection
+    return oc
+
+
+class TestCheckHeaderPresentUniformOmission:
+    """Uniform omission of a header means 'apply to all', must NOT raise 1-20."""
+
+    def test_all_operands_omit_cols_no_raise(self):
+        """All operands omit cols (row-only expression) are valid."""
+        nodes = [
+            _varid("C_02.00.a", rows=["r0010"]),
+            _varid("C_02.00.a", rows=["r0040"]),
+            _varid("C_02.00.a", rows=["r0490"]),
+        ]
+        oc = _make_oc(nodes)
+        oc._check_header_present("C_02.00.a", "cols")  # must not raise
+
+    def test_all_operands_omit_rows_no_raise(self):
+        """All operands omit rows (column-only expression) are valid."""
+        nodes = [
+            _varid("C_07.00.a", cols=["c0215"]),
+            _varid("C_07.00.a", cols=["c0216"]),
+            _varid("C_07.00.a", cols=["c0220"]),
+        ]
+        oc = _make_oc(nodes)
+        oc._check_header_present("C_07.00.a", "rows")  # must not raise
+
+    def test_single_operand_omits_cols_no_raise(self):
+        """Single operand without cols (e.g. {tTable, c0020} <= 1) are valid."""
+        nodes = [_varid("C_34.07", cols=["c0020"])]
+        oc = _make_oc(nodes)
+        oc._check_header_present("C_34.07", "rows")  # must not raise
+
+    def test_partial_selection_without_cols_all_operands_omit_no_raise(self):
+        """partial_selection without cols and all operands omit cols must be valid."""
+        ps = _varid("C_02.00.a")  # partial_selection: no cols
+        nodes = [
+            _varid("C_02.00.a", rows=["r0010"]),
+            _varid("C_02.00.a", rows=["r0040"]),
+        ]
+        oc = _make_oc(nodes, partial_selection=ps)
+        oc._check_header_present("C_02.00.a", "cols")  # must not raise
+
+
+class TestCheckHeaderPresentMixedSpecification:
+    """Mixed specification raises 1-20."""
+
+    def test_mixed_cols_raises(self):
+        """Some operands have cols and one does not must raise 1-20."""
+        nodes = [
+            _varid("SomeTable", rows=["r0010"], cols=["c0010"]),
+            _varid("SomeTable", rows=["r0040"]),  # no cols
+        ]
+        oc = _make_oc(nodes)
+        with pytest.raises(SemanticError, match="Missing explicit"):
+            oc._check_header_present("SomeTable", "cols")
+
+    def test_partial_selection_with_cols_skips_check(self):
+        """partial_selection that specifies cols must skip the check entirely."""
+        ps = _varid("SomeTable", cols=["c0010"])
+        nodes = [
+            _varid("SomeTable", rows=["r0010"]),  # no cols in operand
+        ]
+        oc = _make_oc(nodes, partial_selection=ps)
+        oc._check_header_present("SomeTable", "cols")  # must not raise


### PR DESCRIPTION
Fixes #91 

When a table is closed in a dimension (e.g. rows or columns), `_check_header_present` required every operand to explicitly specify that dimension. This was too strict: if none of the operands specify it, the expression is intended to apply to all instances of that dimension, which is a valid pattern. As a result, 52 operations in release 4.0 were incorrectly rejected.

The fix adds an early return when all operands omit the header. 1-20 is still raised when SOME operands specify the header and SOME don't (inconsistent expression).

## Impact

52 operations no longer raise 1-20

Examples:

| operation_vid | code | expression |
|---|---|---|
| 8607 | v0204_m | `with {tC_02.00.a, default: 0, interval: true}: {r0010} = {r0040} + {r0490} + ...` |
| 9154 | v0329_m | `with {tC_07.00.a, default: 0, interval: true}: {c0215} + {c0216} + {c0217} = {c0220}` |
| 9904 | v09841_m | `{tC_34.07, c0020, default: null, interval: false} <= 1` |

This are the failures left after the fix: [test_data_failures.csv](https://github.com/user-attachments/files/28316390/test_data_failures.csv)


## Checklist

- [X] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [X] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [X] Documentation updated (if applicable)

## Impact / Risk

- Breaking changes? (public API / CLI / REST endpoints / Django models)
- Database schema or migration concerns?
- Notes for release/changelog?

## Notes

<!-- Follow-ups, TODOs, or anything reviewers should know. -->
