### PR TITLE
fix(1-2): remove post-query range boundary check

### DIFF
--- a/src/dpmcore/dpm_xl/model_queries.py
+++ b/src/dpmcore/dpm_xl/model_queries.py
@@ -173,35 +173,6 @@ def _filter_elements(
     return query.filter(or_(*dynamic_filter))
 
 
-def _check_ranges_values_are_present(
-    data: pd.DataFrame,
-    data_column: str,
-    values: Sequence[str] | None,
-) -> pd.DataFrame:
-    """Validate range boundaries exist in returned data.
-
-    Args:
-        data: DataFrame from the query.
-        data_column: Column name to validate.
-        values: Filter values (may contain ranges).
-
-    Returns:
-        Original data if valid, empty DataFrame otherwise.
-    """
-    if values is None or len(values) == 0:
-        return data
-    actual_values = list(data[data_column].values)
-    for value in values:
-        if "-" in value:
-            limits = value.split("-")
-            if (
-                limits[0] not in actual_values
-                or limits[1] not in actual_values
-            ):
-                return pd.DataFrame(columns=data.columns)
-    return data
-
-
 # ------------------------------------------------------------------ #
 # ItemCategory queries
 # ------------------------------------------------------------------ #
@@ -1317,10 +1288,6 @@ class ViewDatapointsQuery:
         if len(data) > 0:
             data = data.sort_values("variable_id", na_position="last")
             data = data.drop_duplicates(subset=["cell_code"], keep="first")
-
-        data = _check_ranges_values_are_present(data, "row_code", rows)
-        data = _check_ranges_values_are_present(data, "column_code", cols)
-        data = _check_ranges_values_are_present(data, "sheet_code", sheets)
 
         cls._TABLE_DATA_CACHE[cache_key] = data
         return data

--- a/tests/unit/dpm_xl/test_check_header_present.py
+++ b/tests/unit/dpm_xl/test_check_header_present.py
@@ -1,7 +1,10 @@
+from unittest.mock import MagicMock
+
 import pytest
 
 from dpmcore.dpm_xl.ast.nodes import VarID
 from dpmcore.dpm_xl.ast.operands import OperandsChecking
+from dpmcore.dpm_xl.model_queries import _filter_elements
 from dpmcore.errors import SemanticError
 
 
@@ -89,3 +92,17 @@ class TestCheckHeaderPresentMixedSpecification:
         ]
         oc = _make_oc(nodes, partial_selection=ps)
         oc._check_header_present("SomeTable", "cols")  # must not raise
+
+
+def test_range_filter_uses_between():
+    """A range like r0090-0110 must translate to BETWEEN, not an exact match."""
+    col = MagicMock()
+    _filter_elements(MagicMock(), col, ["0090-0110"])
+    col.between.assert_called_once_with("0090", "0110")
+
+
+def test_exact_value_filter_does_not_use_between():
+    """A single exact value must use equality, not BETWEEN."""
+    col = MagicMock()
+    _filter_elements(MagicMock(), col, ["0090"])
+    col.between.assert_not_called()


### PR DESCRIPTION
Closes #93 

When a range like `r0090-0110` was used, `_check_ranges_values_are_present` returned an empty DataFrame if either boundary value was absent from the table, causing 1-2 even when other rows within the range existed.

According to the DPM-XL spec (`dpm-xl-docs/docs/operators/03-selection-operators.md`, §3.1.6), ranges select all Headers whose codes fall between the start and end codes. The boundary values are not required to exist. The function and its three
call sites have been removed entirely

## Impact

6 operations no longer raise 1-2 for ranges where boundary values are absent:

| code | expression | error |
|------|-----------|-------|
| v22366_s | `{r0090-0110} <= 0` | Cell expression C_91.01, r0090-0110, c0170 was not found. |
| v22367_s | `{r0010-0080} <= 0` | Cell expression C_91.01, r0010-0080, c0020 was not found. |
| v22414_m | `sum({c0100-0220, ...})` | Cell expression C_92.01, c0100-0220 was not found. |
 
This are the failures left after the fix: [test_data_failures.csv](https://github.com/user-attachments/files/28340236/test_data_failures.csv)



## Checklist

- [X] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [X] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [X] Documentation updated (if applicable)

## Impact / Risk

- Breaking changes? (public API / CLI / REST endpoints / Django models)
- Database schema or migration concerns?
- Notes for release/changelog?

## Notes

<!-- Follow-ups, TODOs, or anything reviewers should know. -->
