### PR TITLE
fix(2-6): join TableVersionHeader before HeaderVersion to prevent stale header code leaks

### DIFF
--- a/src/dpmcore/dpm_xl/model_queries.py
+++ b/src/dpmcore/dpm_xl/model_queries.py
@@ -1151,37 +1151,71 @@ class ViewDatapointsQuery:
                 Cell,
                 TableVersionCell.cell_id == Cell.cell_id,
             )
-            .outerjoin(
-                hvr,
-                hvr.header_id == Cell.row_id,
-            )
+            # Join TVH first to get the release-pinned HeaderVersion (fallback: direct header_id).
             .outerjoin(
                 tvh_row,
                 and_(
                     tvh_row.table_vid == TableVersion.table_vid,
-                    tvh_row.header_vid == hvr.header_vid,
+                    tvh_row.header_id == Cell.row_id,
                 ),
             )
             .outerjoin(
-                hvc,
-                hvc.header_id == Cell.column_id,
+                hvr,
+                or_(
+                    # TVH present: use the exact HeaderVersion it references
+                    and_(
+                        tvh_row.header_vid.isnot(None),
+                        hvr.header_vid == tvh_row.header_vid,
+                    ),
+                    # TVH absent: fall back to direct join on header_id
+                    and_(
+                        tvh_row.table_vid.is_(None),
+                        hvr.header_id == Cell.row_id,
+                    ),
+                ),
             )
             .outerjoin(
                 tvh_col,
                 and_(
                     tvh_col.table_vid == TableVersion.table_vid,
-                    tvh_col.header_vid == hvc.header_vid,
+                    tvh_col.header_id == Cell.column_id,
                 ),
             )
             .outerjoin(
-                hvs,
-                hvs.header_id == Cell.sheet_id,
+                hvc,
+                or_(
+                    # TVH present: use the exact HeaderVersion it references
+                    and_(
+                        tvh_col.header_vid.isnot(None),
+                        hvc.header_vid == tvh_col.header_vid,
+                    ),
+                    # TVH absent: fall back to direct join on header_id
+                    and_(
+                        tvh_col.table_vid.is_(None),
+                        hvc.header_id == Cell.column_id,
+                    ),
+                ),
             )
             .outerjoin(
                 tvh_sheet,
                 and_(
                     tvh_sheet.table_vid == TableVersion.table_vid,
-                    tvh_sheet.header_vid == hvs.header_vid,
+                    tvh_sheet.header_id == Cell.sheet_id,
+                ),
+            )
+            .outerjoin(
+                hvs,
+                or_(
+                    # TVH present: use the exact HeaderVersion it references
+                    and_(
+                        tvh_sheet.header_vid.isnot(None),
+                        hvs.header_vid == tvh_sheet.header_vid,
+                    ),
+                    # TVH absent: fall back to direct join on header_id
+                    and_(
+                        tvh_sheet.table_vid.is_(None),
+                        hvs.header_id == Cell.sheet_id,
+                    ),
                 ),
             )
         )

--- a/tests/integration/validation/test_semantic_release.py
+++ b/tests/integration/validation/test_semantic_release.py
@@ -4,6 +4,8 @@ Each test validates a DPM-XL expression at a specific release ID using
 the SemanticService backed by the fixture SQLite database.
 """
 
+import pytest
+
 from dpmcore.services.semantic import SemanticService
 
 
@@ -326,3 +328,38 @@ def test_sub_duplicate_property_code_rejected(fixture_session):
         f"{result.error_message}"
     )
     assert "qEBB" in (result.error_message or "")
+
+
+@pytest.mark.parametrize(
+    ("expression", "release_code"),
+    [
+        # tR_06.00.b 3.4: wildcard hits a header whose code changed in 4.2+
+        (
+            "with {tR_06.00.b, default: null, interval: false}: {r*, c0020-0050} >= 0",
+            "3.4",
+        ),
+        # tR_06.00.b 4.2: TVH must resolve to the updated header code
+        (
+            "{tR_06.00.b, r*, c*, default: 0, interval: false} <= 1",
+            "4.2",
+        ),
+        # tK_60.00.a 3.4: same multi-release header issue on a different table
+        (
+            "with {tK_60.00.a, default: null, interval: false}: {r0100-0290, c*} >= 0",
+            "3.4",
+        ),
+    ],
+)
+def test_no_spurious_2_6_on_multi_release_headers(
+    fixture_session, expression, release_code
+):
+    """Wildcard/range selectors on tables whose headers changed code across
+    releases must be valid (no errors at all).
+    """
+    svc = SemanticService(fixture_session)
+    result = svc.validate(expression, release_code=release_code)
+
+    assert result.is_valid, (
+        f"Expected valid at release {release_code!r}, got {result.error_code}: "
+        f"{result.error_message}"
+    )

--- a/tests/integration/validation/test_semantic_release.py
+++ b/tests/integration/validation/test_semantic_release.py
@@ -350,7 +350,7 @@ def test_sub_duplicate_property_code_rejected(fixture_session):
         ),
     ],
 )
-def test_no_spurious_2_6_on_multi_release_headers(
+def test_no_false_2_6_on_multi_release_headers(
     fixture_session, expression, release_code
 ):
     """Wildcard/range selectors on tables whose headers changed code across


### PR DESCRIPTION
Closes #97 

A header (row/column ordinate) can change its code across releases. For example, a row that was `0010` in release 3.4 becomes `0030` in release 4.2. `ViewDatapointsQuery._create_base_query_with_aliases` joined `HeaderVersion` directly on `Cell.row_id`, returning all versions of that header regardless of release. After `drop_duplicates`, the wrong code could survive, producing a phantom duplicate `(row_code, col_code)` and triggering a false 2-6.

`TableVersionHeader` (composite PK `(table_vid, header_id)`) is the exact link between a table version and the `HeaderVersion` it uses for each header. The fix joins `TableVersionHeader` first to get the right `header_vid` for the current release, and then joins only that `HeaderVersion`. For headers with no TVH entry, it falls back to the old direct join, which is safe because those headers have only one version. The fix is applied to all three dimensions (row, column, sheet):

```
Before:  Cell -> HeaderVersion  (all versions of that header, any release)
After:   Cell -> TableVersionHeader -> HeaderVersion  (only the one for this release)
```

## Impact

11 operations no longer raise 2-6:

| operation_vid | code | release | expression |
|---|---|---|---|
| 6229 | v12124_s | 3.4 | `with {tR_06.00.b, default: null, interval: false}: {r*, c0020-0050} >= 0` |
| 11314 | v12124_s | 4.0 | `with {tR_06.00.b, r*, default: null, interval: false}: {c0020-0050} >= 0` |
| 14865 | v12124_s | 4.2 | `with {tR_06.00.b, r*, default: null, interval: false}: {c0020-0050} >= 0` |
| 6586 | v12532_m | 3.4 | `{tR_06.00.b, r*, c*, default: 0, interval: false} <= 1` |
| 19296 | v12532_m | 4.2 | `{tR_06.00.b, r*, c*, default: 0, interval: false} <= 1` |
| 6588 | v12534_m | 3.4 | `with {tR_06.00.b, r*, default: 0, interval: false}: {c0030} + {c0040} = 1` |
| 19298 | v12534_m | 4.2 | `with {tR_06.00.b, r*, default: 0, interval: false}: {c0030} + {c0040} = 1` |
| 6942 | v16055_s | 3.4 | `with {tK_60.00.a, c*, default: 0, interval: true}: {r0200} = + {r0220} + {r0210}` |
| 6952 | v16065_s | 3.4 | `with {tK_60.00.a, default: null, interval: false}: {r0100-0290, c*} >= 0` |
| 10439 | v16065_s | 4.0 | `with {tK_60.00.a, c*, default: null, interval: false}: {r0100-0290} >= 0` |
| 9990 | v23367_h | 4.0 | `with{tK_60.00.a, c0020-0030, default: 0, interval: true}: {r0200} = {r0210} + {r0220}` |

This are the failures left after the fix: [test_data_failures.csv](https://github.com/user-attachments/files/28343967/test_data_failures.csv)


## Checklist

- [X] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [X] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [X] Documentation updated (if applicable)

## Impact / Risk

- Breaking changes? (public API / CLI / REST endpoints / Django models)
- Database schema or migration concerns?
- Notes for release/changelog?

## Notes

<!-- Follow-ups, TODOs, or anything reviewers should know. -->
