### PR TITLE
feat: support APT-packaged SQLAlchemy 1.4.50 (dual 1.4/2.0)

### DIFF
--- a/.github/workflows/ubuntu_test_24_04.yml
+++ b/.github/workflows/ubuntu_test_24_04.yml
@@ -28,6 +28,10 @@ jobs:
         # httpx 0.26 removed that kwarg, so the combo is broken out of
         # the box. Installing fastapi via pip pulls a modern starlette
         # (>=0.37) that uses httpx.ASGITransport instead.
+        #
+        # python3-sqlalchemy is Noble's 1.4.50; dpmcore is compatible with
+        # both 1.4 and 2.0, so SQLAlchemy comes from apt with no pip
+        # override (see issue #104).
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -42,19 +46,21 @@ jobs:
             python3-pyodbc \
             python3-pytest \
             python3-rich \
+            python3-sqlalchemy \
             python3-uvicorn \
             unixodbc-dev
 
       - name: Install pip-only dependencies
-        # SQLAlchemy: Noble ships 1.4; dpmcore ORM requires 2.0 APIs.
         # fastapi: see the apt step above — pip pulls a starlette that
         # is compatible with apt httpx 0.26.
         # pytest-django: Noble 4.5.2 is below the dpmcore floor (>=4.9).
         run: |
           pip install --break-system-packages \
-            "sqlalchemy>=2.0,<3.0" \
             "fastapi>=0.101" \
             "pytest-django>=4.9"
+
+      - name: Show SQLAlchemy version (apt python3-sqlalchemy)
+        run: python3 -c "import sqlalchemy; print(sqlalchemy.__version__)"
 
       - name: Install poetry
         run: |

--- a/poetry.lock
+++ b/poetry.lock
@@ -3251,4 +3251,4 @@ sqlserver = ["pyodbc"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "ccb62475de9b05c2275058fdb70ee87311ce8e913badbf3619092fc868f6d10b"
+content-hash = "7a201e7c65c6c0d86cbaf2c7511db50f643710efb42a7e7c0ba85a110e6df8a5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,10 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "sqlalchemy>=2.0.49,<3.0",
+    # Floor is 1.4.50 to match the python3-sqlalchemy apt package on
+    # Ubuntu 24.04 (Noble); the ORM is compatible with both 1.4 and 2.0
+    # (see issue #104). 2.0 remains the canonical target for dev/wheel.
+    "sqlalchemy>=1.4.50,<3.0",
     # Runtime must match the ANTLR version used to generate the grammar
     # in src/dpmcore/dpm_xl/grammar/generated/. Regenerating with a newer
     # ANTLR is tracked separately.

--- a/src/dpmcore/connection.py
+++ b/src/dpmcore/connection.py
@@ -19,7 +19,8 @@ from __future__ import annotations
 from types import TracebackType
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
-from sqlalchemy import Engine, create_engine
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session, sessionmaker
 
 # Ensure all ORM modules are imported so relationships resolve.
@@ -210,12 +211,17 @@ class DpmConnection:
         pool_config: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Build a connection for ``url`` with optional ``pool_config``."""
-        engine_kwargs: Dict[str, Any] = {"pool_pre_ping": True}
+        # future=True is the 2.0 default and opts SQLAlchemy 1.4 into the
+        # same 2.0-style Engine/Session semantics (see issue #104).
+        engine_kwargs: Dict[str, Any] = {
+            "pool_pre_ping": True,
+            "future": True,
+        }
         if pool_config:
             engine_kwargs.update(pool_config)
 
         self.engine = create_engine(url, **engine_kwargs)
-        self._session_factory = sessionmaker(bind=self.engine)
+        self._session_factory = sessionmaker(bind=self.engine, future=True)
         self.session: Session = self._session_factory()
         self.services = _ServiceAccessor(self.session, self.engine)
 

--- a/src/dpmcore/loaders/migration.py
+++ b/src/dpmcore/loaders/migration.py
@@ -27,7 +27,8 @@ from io import StringIO
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from sqlalchemy import Engine, inspect, select, text
+from sqlalchemy import inspect, select, text
+from sqlalchemy.engine import Engine
 
 from dpmcore.orm.base import Base
 from dpmcore.orm.infrastructure import Release

--- a/src/dpmcore/orm/_compat.py
+++ b/src/dpmcore/orm/_compat.py
@@ -1,0 +1,33 @@
+"""SQLAlchemy 1.4 / 2.0 compatibility shim.
+
+dpmcore targets both SQLAlchemy 2.0.x (the canonical, typed-declarative
+target) and the 1.4.50 package shipped by Ubuntu 24.04 (Noble) via apt.
+The ORM source is written in 2.0 style; on 1.4 this module aliases the
+2.0-only symbols so the same source runs unchanged:
+
+- ``mapped_column`` -> classic ``Column``. dpmcore only uses the
+  ``(name, Type, **kw)`` forms (no 2.0 dataclass kwargs such as
+  ``init=``/``repr=``/``kw_only=``), so the signatures are compatible.
+- ``Mapped`` is re-exported. It exists in 1.4 and is inert on classic
+  columns (verified in issue #104, GATE 0), so the type annotations stay.
+
+``base.py`` builds the declarative base per version. ``SA2`` is exported
+for the rare spots that must branch (e.g. version-gated test skips).
+"""
+
+from typing import TYPE_CHECKING
+
+from sqlalchemy import __version__ as _SA_VERSION
+
+SA2 = _SA_VERSION.startswith("2.")
+
+# TYPE_CHECKING is True under mypy, so the type checker always sees the
+# real 2.0 ``Mapped``/``mapped_column`` (the canonical, typed target);
+# at runtime the branch is chosen by the installed version.
+if SA2 or TYPE_CHECKING:  # pragma: no cover
+    from sqlalchemy.orm import Mapped, mapped_column
+else:  # pragma: no cover
+    from sqlalchemy import Column as mapped_column
+    from sqlalchemy.orm import Mapped
+
+__all__ = ["Mapped", "mapped_column", "SA2"]

--- a/src/dpmcore/orm/auxiliary.py
+++ b/src/dpmcore/orm/auxiliary.py
@@ -13,8 +13,8 @@ from sqlalchemy import (
     String,
     UniqueConstraint,
 )
-from sqlalchemy.orm import Mapped, mapped_column
 
+from dpmcore.orm._compat import Mapped, mapped_column
 from dpmcore.orm.base import Base
 
 # ------------------------------------------------------------------

--- a/src/dpmcore/orm/base.py
+++ b/src/dpmcore/orm/base.py
@@ -1,22 +1,21 @@
-"""Base ORM infrastructure: DeclarativeBase, engine, and session helpers."""
+"""Base ORM infrastructure: declarative base, engine, and session helpers."""
 
-from typing import Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
-from sqlalchemy import Engine
 from sqlalchemy import create_engine as sa_create_engine
-from sqlalchemy.orm import (
-    DeclarativeBase,
-    Session,
-    sessionmaker,
-)
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
+from dpmcore.orm._compat import SA2
 
-class Base(DeclarativeBase):
-    """Base for all dpmcore ORM models.
 
-    Provides a ``to_dict`` helper that serialises column attributes
-    to a plain dictionary.
+class _ToDictMixin:
+    """Mixin adding ``to_dict`` to the declarative base.
+
+    Kept separate from the base class so it can be applied both by
+    subclassing (SQLAlchemy 2.0 ``DeclarativeBase``) and via the
+    ``cls=`` argument of 1.4's ``declarative_base()``.
     """
 
     def to_dict(self) -> Dict[str, Any]:
@@ -28,13 +27,28 @@ class Base(DeclarativeBase):
         Returns:
             Column-name → value mapping for every non-deferred column.
         """
-        from sqlalchemy.inspection import inspect
+        from sqlalchemy.orm import object_mapper
 
         return {
             c.key: getattr(self, c.key)
-            for c in inspect(self).mapper.column_attrs
+            for c in object_mapper(self).column_attrs
             if ("deferred", True) not in c.strategy_key
         }
+
+
+# TYPE_CHECKING is True under mypy, so the type checker always sees the
+# 2.0 ``DeclarativeBase`` subclass; at runtime the branch is chosen by
+# the installed SQLAlchemy version.
+if SA2 or TYPE_CHECKING:  # pragma: no cover
+    from sqlalchemy.orm import DeclarativeBase
+
+    class Base(_ToDictMixin, DeclarativeBase):
+        """Base for all dpmcore ORM models."""
+
+else:  # pragma: no cover
+    from sqlalchemy.orm import declarative_base
+
+    Base = declarative_base(cls=_ToDictMixin)
 
 
 def create_engine(
@@ -67,7 +81,11 @@ def create_engine(
     is_sqlite = url.startswith("sqlite")
     is_memory = ":memory:" in url or "mode=memory" in url
 
-    kwargs: Dict[str, Any] = {"echo": echo}
+    # future=True is the default on SQLAlchemy 2.0 and opts 1.4 into the
+    # same 2.0-style Engine/Connection semantics (Connection.commit(),
+    # Result.scalar_one(), no legacy autocommit), so runtime behaviour is
+    # identical across versions (see issue #104).
+    kwargs: Dict[str, Any] = {"echo": echo, "future": True}
 
     if is_sqlite and is_memory:
         kwargs["poolclass"] = StaticPool
@@ -93,7 +111,7 @@ def create_session(engine: Engine) -> Session:
     Returns:
         A new ``Session`` instance.
     """
-    return Session(bind=engine)
+    return Session(bind=engine, future=True)
 
 
 class SessionFactory:
@@ -112,7 +130,7 @@ class SessionFactory:
             engine: The SQLAlchemy engine to bind sessions to.
         """
         self.engine = engine
-        self._maker = sessionmaker(bind=engine)
+        self._maker = sessionmaker(bind=engine, future=True)
 
     def __call__(self) -> Session:
         """Create and return a new session.

--- a/src/dpmcore/orm/glossary.py
+++ b/src/dpmcore/orm/glossary.py
@@ -17,8 +17,9 @@ from sqlalchemy import (
     String,
     UniqueConstraint,
 )
-from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.orm import relationship
 
+from dpmcore.orm._compat import Mapped, mapped_column
 from dpmcore.orm.base import Base
 from dpmcore.orm.infrastructure import (
     Concept,
@@ -93,28 +94,32 @@ class Category(Base):
     )
 
     concept: Mapped[Optional["Concept"]] = relationship(
-        foreign_keys=[row_guid]
+        "Concept", foreign_keys=[row_guid]
     )
     created_release: Mapped[Optional["Release"]] = relationship(
-        foreign_keys=[created_release_id]
+        "Release", foreign_keys=[created_release_id]
     )
     owner: Mapped[Optional["Organisation"]] = relationship(
-        foreign_keys=[owner_id]
+        "Organisation", foreign_keys=[owner_id]
     )
     subcategories: Mapped[List["SubCategory"]] = relationship(
+        "SubCategory",
         back_populates="category",
     )
     property_categories: Mapped[List["PropertyCategory"]] = relationship(
+        "PropertyCategory",
         back_populates="category",
     )
     supercategory_compositions: Mapped[List["SupercategoryComposition"]] = (
         relationship(
+            "SupercategoryComposition",
             foreign_keys=("SupercategoryComposition.supercategory_id"),
             back_populates="supercategory",
         )
     )
     category_compositions: Mapped[List["SupercategoryComposition"]] = (
         relationship(
+            "SupercategoryComposition",
             foreign_keys=("SupercategoryComposition.category_id"),
             back_populates="category",
         )
@@ -165,18 +170,20 @@ class SubCategory(Base):
     )
 
     category: Mapped[Optional["Category"]] = relationship(
-        back_populates="subcategories"
+        "Category", back_populates="subcategories"
     )
     concept: Mapped[Optional["Concept"]] = relationship(
-        foreign_keys=[row_guid]
+        "Concept", foreign_keys=[row_guid]
     )
     owner: Mapped[Optional["Organisation"]] = relationship(
-        foreign_keys=[owner_id]
+        "Organisation", foreign_keys=[owner_id]
     )
     subcategory_versions: Mapped[List["SubCategoryVersion"]] = relationship(
+        "SubCategoryVersion",
         back_populates="subcategory",
     )
     operand_references: Mapped[List["OperandReference"]] = relationship(
+        "OperandReference",
         back_populates="subcategory",
     )
 
@@ -225,24 +232,27 @@ class SubCategoryVersion(Base):
     )
 
     subcategory: Mapped[Optional["SubCategory"]] = relationship(
-        back_populates="subcategory_versions"
+        "SubCategory", back_populates="subcategory_versions"
     )
     start_release: Mapped[Optional["Release"]] = relationship(
-        foreign_keys=[start_release_id]
+        "Release", foreign_keys=[start_release_id]
     )
     end_release: Mapped[Optional["Release"]] = relationship(
-        foreign_keys=[end_release_id]
+        "Release", foreign_keys=[end_release_id]
     )
     concept: Mapped[Optional["Concept"]] = relationship(
-        foreign_keys=[row_guid]
+        "Concept", foreign_keys=[row_guid]
     )
     subcategory_items: Mapped[List["SubCategoryItem"]] = relationship(
+        "SubCategoryItem",
         back_populates="subcategory_version",
     )
     header_versions: Mapped[List["HeaderVersion"]] = relationship(
+        "HeaderVersion",
         back_populates="subcategory_version",
     )
     variable_versions: Mapped[List["VariableVersion"]] = relationship(
+        "VariableVersion",
         back_populates="subcategory_version",
     )
 
@@ -304,25 +314,28 @@ class SubCategoryItem(Base):
     )
 
     item: Mapped["Item"] = relationship(
+        "Item",
         foreign_keys=[item_id],
         back_populates="subcategory_items",
     )
     subcategory_version: Mapped[Optional["SubCategoryVersion"]] = relationship(
-        back_populates="subcategory_items"
+        "SubCategoryVersion", back_populates="subcategory_items"
     )
     parent_item: Mapped[Optional["Item"]] = relationship(
-        foreign_keys=[parent_item_id]
+        "Item", foreign_keys=[parent_item_id]
     )
     comparison_operator: Mapped[Optional["Operator"]] = relationship(
+        "Operator",
         foreign_keys=[comparison_operator_id],
         back_populates="comparison_subcategory_items",
     )
     arithmetic_operator: Mapped[Optional["Operator"]] = relationship(
+        "Operator",
         foreign_keys=[arithmetic_operator_id],
         back_populates="arithmetic_subcategory_items",
     )
     concept: Mapped[Optional["Concept"]] = relationship(
-        foreign_keys=[row_guid]
+        "Concept", foreign_keys=[row_guid]
     )
 
 
@@ -364,29 +377,35 @@ class Item(Base):
     )
 
     concept: Mapped[Optional["Concept"]] = relationship(
-        foreign_keys=[row_guid]
+        "Concept", foreign_keys=[row_guid]
     )
     owner: Mapped[Optional["Organisation"]] = relationship(
-        foreign_keys=[owner_id]
+        "Organisation", foreign_keys=[owner_id]
     )
     item_categories: Mapped[List["ItemCategory"]] = relationship(
+        "ItemCategory",
         back_populates="item",
     )
     property: Mapped[Optional["Property"]] = relationship(
+        "Property",
         back_populates="item",
         uselist=False,
     )
     operand_references: Mapped[List["OperandReference"]] = relationship(
+        "OperandReference",
         back_populates="item",
     )
     context_compositions: Mapped[List["ContextComposition"]] = relationship(
+        "ContextComposition",
         back_populates="item",
     )
     subcategory_items: Mapped[List["SubCategoryItem"]] = relationship(
+        "SubCategoryItem",
         foreign_keys="SubCategoryItem.item_id",
         back_populates="item",
     )
     compound_item_contexts: Mapped[List["CompoundItemContext"]] = relationship(
+        "CompoundItemContext",
         back_populates="item",
     )
 
@@ -441,14 +460,16 @@ class ItemCategory(Base):
     )
     row_guid: Mapped[Optional[str]] = mapped_column("RowGUID", String(38))
 
-    item: Mapped["Item"] = relationship(back_populates="item_categories")
+    item: Mapped["Item"] = relationship(
+        "Item", back_populates="item_categories"
+    )
     start_release: Mapped["Release"] = relationship(
-        foreign_keys=[start_release_id]
+        "Release", foreign_keys=[start_release_id]
     )
     end_release: Mapped[Optional["Release"]] = relationship(
-        foreign_keys=[end_release_id]
+        "Release", foreign_keys=[end_release_id]
     )
-    category: Mapped[Optional["Category"]] = relationship()
+    category: Mapped[Optional["Category"]] = relationship("Category")
 
 
 # ------------------------------------------------------------------
@@ -501,29 +522,34 @@ class Property(Base):
         ForeignKey("Organisation.OrgID"),
     )
 
-    item: Mapped["Item"] = relationship(back_populates="property")
+    item: Mapped["Item"] = relationship("Item", back_populates="property")
     datatype: Mapped[Optional["DataType"]] = relationship(
-        back_populates="properties"
+        "DataType", back_populates="properties"
     )
     concept: Mapped[Optional["Concept"]] = relationship(
-        foreign_keys=[row_guid]
+        "Concept", foreign_keys=[row_guid]
     )
     owner: Mapped[Optional["Organisation"]] = relationship(
-        foreign_keys=[owner_id]
+        "Organisation", foreign_keys=[owner_id]
     )
     property_categories: Mapped[List["PropertyCategory"]] = relationship(
+        "PropertyCategory",
         back_populates="property",
     )
     context_compositions: Mapped[List["ContextComposition"]] = relationship(
+        "ContextComposition",
         back_populates="property",
     )
     variable_versions: Mapped[List["VariableVersion"]] = relationship(
+        "VariableVersion",
         back_populates="property",
     )
     header_versions: Mapped[List["HeaderVersion"]] = relationship(
+        "HeaderVersion",
         back_populates="property",
     )
     table_versions: Mapped[List["TableVersion"]] = relationship(
+        "TableVersion",
         back_populates="property",
     )
 
@@ -571,16 +597,16 @@ class PropertyCategory(Base):
     row_guid: Mapped[Optional[str]] = mapped_column("RowGUID", String(38))
 
     property: Mapped["Property"] = relationship(
-        back_populates="property_categories"
+        "Property", back_populates="property_categories"
     )
     start_release: Mapped["Release"] = relationship(
-        foreign_keys=[start_release_id]
+        "Release", foreign_keys=[start_release_id]
     )
     end_release: Mapped[Optional["Release"]] = relationship(
-        foreign_keys=[end_release_id]
+        "Release", foreign_keys=[end_release_id]
     )
     category: Mapped[Optional["Category"]] = relationship(
-        back_populates="property_categories"
+        "Category", back_populates="property_categories"
     )
 
 
@@ -627,24 +653,29 @@ class Context(Base):
     )
 
     concept: Mapped[Optional["Concept"]] = relationship(
-        foreign_keys=[row_guid]
+        "Concept", foreign_keys=[row_guid]
     )
     owner: Mapped[Optional["Organisation"]] = relationship(
-        foreign_keys=[owner_id]
+        "Organisation", foreign_keys=[owner_id]
     )
     context_compositions: Mapped[List["ContextComposition"]] = relationship(
+        "ContextComposition",
         back_populates="context",
     )
     variable_versions: Mapped[List["VariableVersion"]] = relationship(
+        "VariableVersion",
         back_populates="context",
     )
     header_versions: Mapped[List["HeaderVersion"]] = relationship(
+        "HeaderVersion",
         back_populates="context",
     )
     table_versions: Mapped[List["TableVersion"]] = relationship(
+        "TableVersion",
         back_populates="context",
     )
     compound_item_contexts: Mapped[List["CompoundItemContext"]] = relationship(
+        "CompoundItemContext",
         back_populates="context",
     )
 
@@ -690,16 +721,16 @@ class ContextComposition(Base):
     )
 
     context: Mapped["Context"] = relationship(
-        back_populates="context_compositions"
+        "Context", back_populates="context_compositions"
     )
     property: Mapped["Property"] = relationship(
-        back_populates="context_compositions"
+        "Property", back_populates="context_compositions"
     )
     item: Mapped[Optional["Item"]] = relationship(
-        back_populates="context_compositions"
+        "Item", back_populates="context_compositions"
     )
     concept: Mapped[Optional["Concept"]] = relationship(
-        back_populates="context_compositions"
+        "Concept", back_populates="context_compositions"
     )
 
 
@@ -746,16 +777,16 @@ class CompoundItemContext(Base):
     row_guid: Mapped[Optional[str]] = mapped_column("RowGUID", String(38))
 
     item: Mapped["Item"] = relationship(
-        back_populates="compound_item_contexts"
+        "Item", back_populates="compound_item_contexts"
     )
     start_release: Mapped["Release"] = relationship(
-        foreign_keys=[start_release_id]
+        "Release", foreign_keys=[start_release_id]
     )
     end_release: Mapped[Optional["Release"]] = relationship(
-        foreign_keys=[end_release_id]
+        "Release", foreign_keys=[end_release_id]
     )
     context: Mapped[Optional["Context"]] = relationship(
-        back_populates="compound_item_contexts"
+        "Context", back_populates="compound_item_contexts"
     )
 
 
@@ -802,16 +833,18 @@ class SupercategoryComposition(Base):
     row_guid: Mapped[Optional[str]] = mapped_column("RowGUID", String(38))
 
     supercategory: Mapped["Category"] = relationship(
+        "Category",
         foreign_keys=[supercategory_id],
         back_populates="supercategory_compositions",
     )
     category: Mapped["Category"] = relationship(
+        "Category",
         foreign_keys=[category_id],
         back_populates="category_compositions",
     )
     start_release: Mapped[Optional["Release"]] = relationship(
-        foreign_keys=[start_release_id]
+        "Release", foreign_keys=[start_release_id]
     )
     end_release: Mapped[Optional["Release"]] = relationship(
-        foreign_keys=[end_release_id]
+        "Release", foreign_keys=[end_release_id]
     )

--- a/src/dpmcore/orm/infrastructure.py
+++ b/src/dpmcore/orm/infrastructure.py
@@ -21,8 +21,9 @@ from sqlalchemy import (
     Text,
     UniqueConstraint,
 )
-from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.orm import relationship
 
+from dpmcore.orm._compat import Mapped, mapped_column
 from dpmcore.orm.base import Base
 
 if TYPE_CHECKING:
@@ -56,16 +57,19 @@ class Concept(Base):
     )
 
     dpm_class: Mapped[Optional["DpmClass"]] = relationship(
-        foreign_keys=[class_id]
+        "DpmClass", foreign_keys=[class_id]
     )
     owner: Mapped[Optional["Organisation"]] = relationship(
+        "Organisation",
         foreign_keys=[owner_id],
         back_populates="concepts_owned",
     )
     related_concepts: Mapped[List["RelatedConcept"]] = relationship(
+        "RelatedConcept",
         back_populates="concept",
     )
     context_compositions: Mapped[List["ContextComposition"]] = relationship(
+        "ContextComposition",
         back_populates="concept",
     )
 
@@ -88,6 +92,7 @@ class ConceptRelation(Base):
     row_guid: Mapped[Optional[str]] = mapped_column("RowGUID", String(38))
 
     related_concepts: Mapped[List["RelatedConcept"]] = relationship(
+        "RelatedConcept",
         back_populates="concept_relation",
     )
 
@@ -122,10 +127,10 @@ class RelatedConcept(Base):
     row_guid: Mapped[Optional[str]] = mapped_column("RowGUID", String(38))
 
     concept: Mapped["Concept"] = relationship(
-        back_populates="related_concepts"
+        "Concept", back_populates="related_concepts"
     )
     concept_relation: Mapped["ConceptRelation"] = relationship(
-        back_populates="related_concepts"
+        "ConceptRelation", back_populates="related_concepts"
     )
 
 
@@ -166,19 +171,23 @@ class Organisation(Base):
     )
 
     concept: Mapped[Optional["Concept"]] = relationship(
-        foreign_keys=[row_guid]
+        "Concept", foreign_keys=[row_guid]
     )
     concepts_owned: Mapped[List["Concept"]] = relationship(
+        "Concept",
         foreign_keys="Concept.owner_id",
         back_populates="owner",
     )
     documents: Mapped[List["Document"]] = relationship(
+        "Document",
         back_populates="organisation",
     )
     users: Mapped[List["User"]] = relationship(
+        "User",
         back_populates="organisation",
     )
     translations: Mapped[List["Translation"]] = relationship(
+        "Translation",
         back_populates="translator",
     )
 
@@ -204,6 +213,7 @@ class Language(Base):
     name: Mapped[Optional[str]] = mapped_column("Name", String(20))
 
     translations: Mapped[List["Translation"]] = relationship(
+        "Translation",
         back_populates="language",
     )
 
@@ -231,9 +241,10 @@ class User(Base):
     name: Mapped[Optional[str]] = mapped_column("Name", String(50))
 
     organisation: Mapped[Optional["Organisation"]] = relationship(
-        back_populates="users"
+        "Organisation", back_populates="users"
     )
     user_roles: Mapped[List["UserRole"]] = relationship(
+        "UserRole",
         back_populates="user",
     )
 
@@ -252,6 +263,7 @@ class Role(Base):
     name: Mapped[Optional[str]] = mapped_column("Name", String(50))
 
     user_roles: Mapped[List["UserRole"]] = relationship(
+        "UserRole",
         back_populates="role",
     )
 
@@ -279,8 +291,8 @@ class UserRole(Base):
         primary_key=True,
     )
 
-    user: Mapped["User"] = relationship(back_populates="user_roles")
-    role: Mapped["Role"] = relationship(back_populates="user_roles")
+    user: Mapped["User"] = relationship("User", back_populates="user_roles")
+    role: Mapped["Role"] = relationship("Role", back_populates="user_roles")
 
 
 # ------------------------------------------------------------------
@@ -318,13 +330,16 @@ class DataType(Base):
     is_active: Mapped[Optional[bool]] = mapped_column("IsActive", Boolean)
 
     parent_datatype: Mapped[Optional["DataType"]] = relationship(
+        "DataType",
         remote_side=[data_type_id],
         back_populates="child_datatypes",
     )
     child_datatypes: Mapped[List["DataType"]] = relationship(
+        "DataType",
         back_populates="parent_datatype",
     )
     properties: Mapped[List["Property"]] = relationship(  # type: ignore[name-defined]
+        "Property",
         back_populates="datatype",
     )
 
@@ -358,19 +373,24 @@ class DpmClass(Base):
     )
 
     owner_class: Mapped[Optional["DpmClass"]] = relationship(
+        "DpmClass",
         remote_side=[class_id],
         back_populates="owned_classes",
     )
     owned_classes: Mapped[List["DpmClass"]] = relationship(
+        "DpmClass",
         back_populates="owner_class",
     )
     concepts: Mapped[List["Concept"]] = relationship(
+        "Concept",
         back_populates="dpm_class",
     )
     dpm_attributes: Mapped[List["DpmAttribute"]] = relationship(
+        "DpmAttribute",
         back_populates="dpm_class",
     )
     changelogs: Mapped[List["Changelog"]] = relationship(
+        "Changelog",
         back_populates="dpm_class",
     )
 
@@ -399,12 +419,14 @@ class DpmAttribute(Base):
     )
 
     dpm_class: Mapped[Optional["DpmClass"]] = relationship(
-        back_populates="dpm_attributes"
+        "DpmClass", back_populates="dpm_attributes"
     )
     changelog_attributes: Mapped[List["ChangelogAttribute"]] = relationship(
+        "ChangelogAttribute",
         back_populates="dpm_attribute",
     )
     translations: Mapped[List["Translation"]] = relationship(
+        "Translation",
         back_populates="dpm_attribute",
     )
 
@@ -455,15 +477,20 @@ class Translation(Base):
     translation: Mapped[Optional[str]] = mapped_column("Translation", Text)
     row_guid: Mapped[Optional[str]] = mapped_column("RowGUID", String(38))
 
-    concept: Mapped["Concept"] = relationship(foreign_keys=[concept_guid])
+    concept: Mapped["Concept"] = relationship(
+        "Concept", foreign_keys=[concept_guid]
+    )
     dpm_attribute: Mapped["DpmAttribute"] = relationship(
-        back_populates="translations"
+        "DpmAttribute", back_populates="translations"
     )
     translator: Mapped["Organisation"] = relationship(
+        "Organisation",
         foreign_keys=[translator_id],
         back_populates="translations",
     )
-    language: Mapped["Language"] = relationship(back_populates="translations")
+    language: Mapped["Language"] = relationship(
+        "Language", back_populates="translations"
+    )
 
 
 # ------------------------------------------------------------------
@@ -513,15 +540,16 @@ class Changelog(Base):
     entity_code: Mapped[Optional[str]] = mapped_column(
         "EntityCode", String(255)
     )
-    action_id: Mapped[int] = mapped_column("ActionID", Integer)
+    action_id: Mapped[int] = mapped_column("ActionID", Integer, nullable=False)
 
     dpm_class: Mapped[Optional["DpmClass"]] = relationship(
-        foreign_keys=[class_id]
+        "DpmClass", foreign_keys=[class_id]
     )
     release: Mapped[Optional["Release"]] = relationship(
-        foreign_keys=[release_id]
+        "Release", foreign_keys=[release_id]
     )
     changelog_attributes: Mapped[List["ChangelogAttribute"]] = relationship(
+        "ChangelogAttribute",
         primaryjoin=(
             "Changelog.action_id == foreign(ChangelogAttribute.action_id)"
         ),
@@ -550,7 +578,7 @@ class ChangelogAttribute(Base):
     changelog_attribute_id: Mapped[int] = mapped_column(
         "ChangeLogAttributeID", Integer, primary_key=True
     )
-    action_id: Mapped[int] = mapped_column("ActionID", Integer)
+    action_id: Mapped[int] = mapped_column("ActionID", Integer, nullable=False)
     attribute_id: Mapped[Optional[int]] = mapped_column(
         "AttributeID",
         Integer,
@@ -560,9 +588,10 @@ class ChangelogAttribute(Base):
     new_value: Mapped[Optional[str]] = mapped_column("NewValue", String(255))
 
     dpm_attribute: Mapped[Optional["DpmAttribute"]] = relationship(
-        foreign_keys=[attribute_id]
+        "DpmAttribute", foreign_keys=[attribute_id]
     )
     changelog: Mapped[Optional["Changelog"]] = relationship(
+        "Changelog",
         foreign_keys=[action_id],
         primaryjoin="ChangelogAttribute.action_id == Changelog.action_id",
         back_populates="changelog_attributes",
@@ -604,12 +633,13 @@ class Document(Base):
     )
 
     organisation: Mapped[Optional["Organisation"]] = relationship(
-        foreign_keys=[org_id]
+        "Organisation", foreign_keys=[org_id]
     )
     concept: Mapped[Optional["Concept"]] = relationship(
-        foreign_keys=[row_guid]
+        "Concept", foreign_keys=[row_guid]
     )
     document_versions: Mapped[List["DocumentVersion"]] = relationship(
+        "DocumentVersion",
         back_populates="document",
     )
 
@@ -647,12 +677,13 @@ class DocumentVersion(Base):
     )
 
     document: Mapped[Optional["Document"]] = relationship(
-        back_populates="document_versions"
+        "Document", back_populates="document_versions"
     )
     concept: Mapped[Optional["Concept"]] = relationship(
-        foreign_keys=[row_guid]
+        "Concept", foreign_keys=[row_guid]
     )
     subdivisions: Mapped[List["Subdivision"]] = relationship(
+        "Subdivision",
         back_populates="document_version",
     )
 
@@ -713,25 +744,28 @@ class Subdivision(Base):
     )
 
     document_version: Mapped[Optional["DocumentVersion"]] = relationship(
-        back_populates="subdivisions"
+        "DocumentVersion", back_populates="subdivisions"
     )
     subdivision_type: Mapped[Optional["SubdivisionType"]] = relationship(
-        back_populates="subdivisions"
+        "SubdivisionType", back_populates="subdivisions"
     )
     parent_subdivision: Mapped[Optional["Subdivision"]] = relationship(
+        "Subdivision",
         remote_side=[subdivision_id],
         back_populates="child_subdivisions",
     )
     child_subdivisions: Mapped[List["Subdivision"]] = relationship(
+        "Subdivision",
         back_populates="parent_subdivision",
     )
     concept: Mapped[Optional["Concept"]] = relationship(
-        foreign_keys=[row_guid]
+        "Concept", foreign_keys=[row_guid]
     )
     owner: Mapped[Optional["Organisation"]] = relationship(
-        foreign_keys=[owner_id]
+        "Organisation", foreign_keys=[owner_id]
     )
     references: Mapped[List["Reference"]] = relationship(
+        "Reference",
         back_populates="subdivision",
     )
 
@@ -756,6 +790,7 @@ class SubdivisionType(Base):
     )
 
     subdivisions: Mapped[List["Subdivision"]] = relationship(
+        "Subdivision",
         back_populates="subdivision_type",
     )
 
@@ -791,9 +826,11 @@ class Reference(Base):
     row_guid: Mapped[Optional[str]] = mapped_column("RowGUID", String(38))
 
     subdivision: Mapped["Subdivision"] = relationship(
-        back_populates="references"
+        "Subdivision", back_populates="references"
     )
-    concept: Mapped["Concept"] = relationship(foreign_keys=[concept_guid])
+    concept: Mapped["Concept"] = relationship(
+        "Concept", foreign_keys=[concept_guid]
+    )
 
 
 # ------------------------------------------------------------------
@@ -844,15 +881,17 @@ class Release(Base):
     )
 
     concept: Mapped[Optional["Concept"]] = relationship(
-        foreign_keys=[row_guid]
+        "Concept", foreign_keys=[row_guid]
     )
     owner: Mapped[Optional["Organisation"]] = relationship(
-        foreign_keys=[owner_id]
+        "Organisation", foreign_keys=[owner_id]
     )
     changelogs: Mapped[List["Changelog"]] = relationship(
+        "Changelog",
         back_populates="release",
     )
     variable_generations: Mapped[List["VariableGeneration"]] = relationship(
+        "VariableGeneration",
         back_populates="release",
     )
 
@@ -890,5 +929,5 @@ class VariableGeneration(Base):
     error: Mapped[Optional[str]] = mapped_column("Error", String(4000))
 
     release: Mapped[Optional["Release"]] = relationship(
-        back_populates="variable_generations"
+        "Release", back_populates="variable_generations"
     )

--- a/src/dpmcore/orm/operations.py
+++ b/src/dpmcore/orm/operations.py
@@ -21,8 +21,9 @@ from sqlalchemy import (
     Text,
     UniqueConstraint,
 )
-from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.orm import relationship
 
+from dpmcore.orm._compat import Mapped, mapped_column
 from dpmcore.orm.base import Base
 from dpmcore.orm.infrastructure import Concept, Organisation, Release
 
@@ -80,19 +81,22 @@ class Operation(Base):
     )
 
     group_operation: Mapped[Optional["Operation"]] = relationship(
+        "Operation",
         remote_side=[operation_id],
         back_populates="grouped_operations",
     )
     grouped_operations: Mapped[List["Operation"]] = relationship(
+        "Operation",
         back_populates="group_operation",
     )
     concept: Mapped[Optional["Concept"]] = relationship(
-        foreign_keys=[row_guid]
+        "Concept", foreign_keys=[row_guid]
     )
     owner: Mapped[Optional["Organisation"]] = relationship(
-        foreign_keys=[owner_id]
+        "Organisation", foreign_keys=[owner_id]
     )
     operation_versions: Mapped[List["OperationVersion"]] = relationship(
+        "OperationVersion",
         back_populates="operation",
     )
 
@@ -167,54 +171,62 @@ class OperationVersion(Base):
     )
 
     operation: Mapped[Optional["Operation"]] = relationship(
-        back_populates="operation_versions"
+        "Operation", back_populates="operation_versions"
     )
     precondition_operation: Mapped[Optional["OperationVersion"]] = (
         relationship(
+            "OperationVersion",
             foreign_keys=[precondition_operation_vid],
             remote_side=[operation_vid],
             back_populates="precondition_dependent_operations",
         )
     )
     severity_operation: Mapped[Optional["OperationVersion"]] = relationship(
+        "OperationVersion",
         foreign_keys=[severity_operation_vid],
         remote_side=[operation_vid],
         back_populates="severity_dependent_operations",
     )
     precondition_dependent_operations: Mapped[List["OperationVersion"]] = (
         relationship(
+            "OperationVersion",
             foreign_keys=[precondition_operation_vid],
             back_populates="precondition_operation",
         )
     )
     severity_dependent_operations: Mapped[List["OperationVersion"]] = (
         relationship(
+            "OperationVersion",
             foreign_keys=[severity_operation_vid],
             back_populates="severity_operation",
         )
     )
     start_release: Mapped[Optional["Release"]] = relationship(
-        foreign_keys=[start_release_id]
+        "Release", foreign_keys=[start_release_id]
     )
     end_release: Mapped[Optional["Release"]] = relationship(
-        foreign_keys=[end_release_id]
+        "Release", foreign_keys=[end_release_id]
     )
     concept: Mapped[Optional["Concept"]] = relationship(
-        foreign_keys=[row_guid]
+        "Concept", foreign_keys=[row_guid]
     )
     operation_nodes: Mapped[List["OperationNode"]] = relationship(
+        "OperationNode",
         back_populates="operation_version",
     )
     operation_scopes: Mapped[List["OperationScope"]] = relationship(
+        "OperationScope",
         back_populates="operation_version",
     )
     operation_version_data: Mapped[Optional["OperationVersionData"]] = (
         relationship(
+            "OperationVersionData",
             back_populates="operation_version",
             uselist=False,
         )
     )
     variable_calculations: Mapped[List["VariableCalculation"]] = relationship(
+        "VariableCalculation",
         back_populates="operation_version",
     )
 
@@ -251,7 +263,7 @@ class OperationVersionData(Base):
     )
 
     operation_version: Mapped["OperationVersion"] = relationship(
-        back_populates="operation_version_data"
+        "OperationVersion", back_populates="operation_version_data"
     )
 
 
@@ -320,24 +332,29 @@ class OperationNode(Base):
     scalar: Mapped[Optional[str]] = mapped_column("Scalar", Text)
 
     operation_version: Mapped[Optional["OperationVersion"]] = relationship(
-        back_populates="operation_nodes"
+        "OperationVersion", back_populates="operation_nodes"
     )
     parent: Mapped[Optional["OperationNode"]] = relationship(
+        "OperationNode",
         remote_side=[node_id],
         back_populates="children",
     )
     children: Mapped[List["OperationNode"]] = relationship(
+        "OperationNode",
         back_populates="parent",
     )
     operator: Mapped[Optional["Operator"]] = relationship(
+        "Operator",
         foreign_keys=[operator_id],
         back_populates="operation_nodes",
     )
     operator_argument: Mapped[Optional["OperatorArgument"]] = relationship(
+        "OperatorArgument",
         foreign_keys=[argument_id],
         back_populates="operation_nodes",
     )
     operand_references: Mapped[List["OperandReference"]] = relationship(
+        "OperandReference",
         back_populates="operation_node",
     )
 
@@ -377,10 +394,11 @@ class OperationScope(Base):
     row_guid: Mapped[Optional[str]] = mapped_column("RowGUID", String(38))
 
     operation_version: Mapped[Optional["OperationVersion"]] = relationship(
-        back_populates="operation_scopes"
+        "OperationVersion", back_populates="operation_scopes"
     )
     operation_scope_compositions: Mapped[List["OperationScopeComposition"]] = (
         relationship(
+            "OperationScopeComposition",
             back_populates="operation_scope",
         )
     )
@@ -417,10 +435,10 @@ class OperationScopeComposition(Base):
     row_guid: Mapped[Optional[str]] = mapped_column("RowGUID", String(38))
 
     operation_scope: Mapped["OperationScope"] = relationship(
-        back_populates="operation_scope_compositions"
+        "OperationScope", back_populates="operation_scope_compositions"
     )
     module_version: Mapped["ModuleVersion"] = relationship(
-        back_populates="operation_scope_compositions"
+        "ModuleVersion", back_populates="operation_scope_compositions"
     )
 
 
@@ -449,20 +467,24 @@ class Operator(Base):
     type: Mapped[Optional[str]] = mapped_column("Type", String(20))
 
     operator_arguments: Mapped[List["OperatorArgument"]] = relationship(
+        "OperatorArgument",
         back_populates="operator",
     )
     operation_nodes: Mapped[List["OperationNode"]] = relationship(
+        "OperationNode",
         foreign_keys="OperationNode.operator_id",
         back_populates="operator",
     )
     comparison_subcategory_items: Mapped[List["SubCategoryItem"]] = (
         relationship(
+            "SubCategoryItem",
             foreign_keys="SubCategoryItem.comparison_operator_id",
             back_populates="comparison_operator",
         )
     )
     arithmetic_subcategory_items: Mapped[List["SubCategoryItem"]] = (
         relationship(
+            "SubCategoryItem",
             foreign_keys="SubCategoryItem.arithmetic_operator_id",
             back_populates="arithmetic_operator",
         )
@@ -502,9 +524,10 @@ class OperatorArgument(Base):
     name: Mapped[Optional[str]] = mapped_column("Name", String(50))
 
     operator: Mapped[Optional["Operator"]] = relationship(
-        back_populates="operator_arguments"
+        "Operator", back_populates="operator_arguments"
     )
     operation_nodes: Mapped[List["OperationNode"]] = relationship(
+        "OperationNode",
         foreign_keys="OperationNode.argument_id",
         back_populates="operator_argument",
     )
@@ -569,21 +592,25 @@ class OperandReference(Base):
     )
 
     operation_node: Mapped[Optional["OperationNode"]] = relationship(
-        back_populates="operand_references"
+        "OperationNode", back_populates="operand_references"
     )
-    item: Mapped[Optional["Item"]] = relationship(foreign_keys=[item_id])
+    item: Mapped[Optional["Item"]] = relationship(
+        "Item", foreign_keys=[item_id]
+    )
     property: Mapped[Optional["Property"]] = relationship(
-        foreign_keys=[property_id]
+        "Property", foreign_keys=[property_id]
     )
     variable: Mapped[Optional["Variable"]] = relationship(
+        "Variable",
         foreign_keys=[variable_id],
         back_populates="operand_references",
     )
     subcategory: Mapped[Optional["SubCategory"]] = relationship(
-        foreign_keys=[subcategory_id]
+        "SubCategory", foreign_keys=[subcategory_id]
     )
     operand_reference_locations: Mapped[List["OperandReferenceLocation"]] = (
         relationship(
+            "OperandReferenceLocation",
             back_populates="operand_reference",
         )
     )
@@ -625,6 +652,8 @@ class OperandReferenceLocation(Base):
     sheet: Mapped[Optional[str]] = mapped_column("Sheet", String(255))
 
     operand_reference: Mapped["OperandReference"] = relationship(
-        back_populates="operand_reference_locations"
+        "OperandReference", back_populates="operand_reference_locations"
     )
-    cell: Mapped[Optional["Cell"]] = relationship(foreign_keys=[cell_id])
+    cell: Mapped[Optional["Cell"]] = relationship(
+        "Cell", foreign_keys=[cell_id]
+    )

--- a/src/dpmcore/orm/packaging.py
+++ b/src/dpmcore/orm/packaging.py
@@ -19,8 +19,9 @@ from sqlalchemy import (
     String,
     UniqueConstraint,
 )
-from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.orm import relationship
 
+from dpmcore.orm._compat import Mapped, mapped_column
 from dpmcore.orm.base import Base
 from dpmcore.orm.infrastructure import Concept, Organisation, Release
 
@@ -72,16 +73,18 @@ class Framework(Base):
     )
 
     concept: Mapped[Optional["Concept"]] = relationship(
-        foreign_keys=[row_guid]
+        "Concept", foreign_keys=[row_guid]
     )
     owner: Mapped[Optional["Organisation"]] = relationship(
-        foreign_keys=[owner_id]
+        "Organisation", foreign_keys=[owner_id]
     )
     modules: Mapped[List["Module"]] = relationship(
+        "Module",
         back_populates="framework",
     )
     operation_code_prefixes: Mapped[List["OperationCodePrefix"]] = (
         relationship(
+            "OperationCodePrefix",
             back_populates="framework",
         )
     )
@@ -126,18 +129,20 @@ class Module(Base):
     )
 
     framework: Mapped[Optional["Framework"]] = relationship(
-        back_populates="modules"
+        "Framework", back_populates="modules"
     )
     concept: Mapped[Optional["Concept"]] = relationship(
-        foreign_keys=[row_guid]
+        "Concept", foreign_keys=[row_guid]
     )
     owner: Mapped[Optional["Organisation"]] = relationship(
-        foreign_keys=[owner_id]
+        "Organisation", foreign_keys=[owner_id]
     )
     module_versions: Mapped[List["ModuleVersion"]] = relationship(
+        "ModuleVersion",
         back_populates="module",
     )
     variable_calculations: Mapped[List["VariableCalculation"]] = relationship(
+        "VariableCalculation",
         back_populates="module",
     )
 
@@ -216,31 +221,34 @@ class ModuleVersion(Base):
     )
 
     module: Mapped[Optional["Module"]] = relationship(
-        back_populates="module_versions"
+        "Module", back_populates="module_versions"
     )
     global_key: Mapped[Optional["CompoundKey"]] = relationship(
-        foreign_keys=[global_key_id]
+        "CompoundKey", foreign_keys=[global_key_id]
     )
     start_release: Mapped[Optional["Release"]] = relationship(
-        foreign_keys=[start_release_id]
+        "Release", foreign_keys=[start_release_id]
     )
     end_release: Mapped[Optional["Release"]] = relationship(
-        foreign_keys=[end_release_id]
+        "Release", foreign_keys=[end_release_id]
     )
     concept: Mapped[Optional["Concept"]] = relationship(
-        foreign_keys=[row_guid]
+        "Concept", foreign_keys=[row_guid]
     )
     module_version_compositions: Mapped[List["ModuleVersionComposition"]] = (
         relationship(
+            "ModuleVersionComposition",
             back_populates="module_version",
         )
     )
     operation_scope_compositions: Mapped[List["OperationScopeComposition"]] = (
         relationship(
+            "OperationScopeComposition",
             back_populates="module_version",
         )
     )
     module_parameters: Mapped[List["ModuleParameters"]] = relationship(
+        "ModuleParameters",
         back_populates="module_version",
     )
 
@@ -284,11 +292,11 @@ class ModuleVersionComposition(Base):
     row_guid: Mapped[Optional[str]] = mapped_column("RowGUID", String(38))
 
     module_version: Mapped["ModuleVersion"] = relationship(
-        back_populates="module_version_compositions"
+        "ModuleVersion", back_populates="module_version_compositions"
     )
-    table: Mapped["Table"] = relationship(foreign_keys=[table_id])
+    table: Mapped["Table"] = relationship("Table", foreign_keys=[table_id])
     table_version: Mapped[Optional["TableVersion"]] = relationship(
-        foreign_keys=[table_vid]
+        "TableVersion", foreign_keys=[table_vid]
     )
 
 
@@ -323,10 +331,10 @@ class ModuleParameters(Base):
     row_guid: Mapped[Optional[str]] = mapped_column("RowGUID", String(38))
 
     module_version: Mapped["ModuleVersion"] = relationship(
-        back_populates="module_parameters"
+        "ModuleVersion", back_populates="module_parameters"
     )
     variable_version: Mapped["VariableVersion"] = relationship(
-        foreign_keys=[variable_vid]
+        "VariableVersion", foreign_keys=[variable_vid]
     )
 
 
@@ -361,5 +369,5 @@ class OperationCodePrefix(Base):
     )
 
     framework: Mapped[Optional["Framework"]] = relationship(
-        back_populates="operation_code_prefixes"
+        "Framework", back_populates="operation_code_prefixes"
     )

--- a/src/dpmcore/orm/rendering.py
+++ b/src/dpmcore/orm/rendering.py
@@ -17,8 +17,9 @@ from sqlalchemy import (
     String,
     UniqueConstraint,
 )
-from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.orm import relationship
 
+from dpmcore.orm._compat import Mapped, mapped_column
 from dpmcore.orm.base import Base
 from dpmcore.orm.infrastructure import Concept, Organisation, Release
 
@@ -81,32 +82,38 @@ class Table(Base):
     )
 
     concept: Mapped[Optional["Concept"]] = relationship(
-        foreign_keys=[row_guid]
+        "Concept", foreign_keys=[row_guid]
     )
     owner: Mapped[Optional["Organisation"]] = relationship(
-        foreign_keys=[owner_id]
+        "Organisation", foreign_keys=[owner_id]
     )
     headers: Mapped[List["Header"]] = relationship(
+        "Header",
         back_populates="table",
     )
     cells: Mapped[List["Cell"]] = relationship(
+        "Cell",
         back_populates="table",
     )
     table_versions: Mapped[List["TableVersion"]] = relationship(
+        "TableVersion",
         foreign_keys="TableVersion.table_id",
         back_populates="table",
     )
     abstract_table_versions: Mapped[List["TableVersion"]] = relationship(
+        "TableVersion",
         foreign_keys="TableVersion.abstract_table_id",
         back_populates="abstract_table",
     )
     table_group_compositions: Mapped[List["TableGroupComposition"]] = (
         relationship(
+            "TableGroupComposition",
             back_populates="table",
         )
     )
     module_version_compositions: Mapped[List["ModuleVersionComposition"]] = (
         relationship(
+            "ModuleVersionComposition",
             back_populates="table",
         )
     )
@@ -186,49 +193,58 @@ class TableVersion(Base):
     )
 
     table: Mapped[Optional["Table"]] = relationship(
+        "Table",
         foreign_keys=[table_id],
         back_populates="table_versions",
     )
     abstract_table: Mapped[Optional["Table"]] = relationship(
+        "Table",
         foreign_keys=[abstract_table_id],
         back_populates="abstract_table_versions",
     )
-    key: Mapped[Optional["CompoundKey"]] = relationship(foreign_keys=[key_id])
+    key: Mapped[Optional["CompoundKey"]] = relationship(
+        "CompoundKey", foreign_keys=[key_id]
+    )
     property: Mapped[Optional["Property"]] = relationship(
-        foreign_keys=[property_id]
+        "Property", foreign_keys=[property_id]
     )
     context: Mapped[Optional["Context"]] = relationship(
-        foreign_keys=[context_id]
+        "Context", foreign_keys=[context_id]
     )
     start_release: Mapped[Optional["Release"]] = relationship(
-        foreign_keys=[start_release_id]
+        "Release", foreign_keys=[start_release_id]
     )
     end_release: Mapped[Optional["Release"]] = relationship(
-        foreign_keys=[end_release_id]
+        "Release", foreign_keys=[end_release_id]
     )
     concept: Mapped[Optional["Concept"]] = relationship(
-        foreign_keys=[row_guid]
+        "Concept", foreign_keys=[row_guid]
     )
     table_version_cells: Mapped[List["TableVersionCell"]] = relationship(
+        "TableVersionCell",
         back_populates="table_version",
     )
     table_version_headers: Mapped[List["TableVersionHeader"]] = relationship(
+        "TableVersionHeader",
         back_populates="table_version",
     )
     table_associations_as_child: Mapped[List["TableAssociation"]] = (
         relationship(
+            "TableAssociation",
             foreign_keys="TableAssociation.child_table_vid",
             back_populates="child_table_version",
         )
     )
     table_associations_as_parent: Mapped[List["TableAssociation"]] = (
         relationship(
+            "TableAssociation",
             foreign_keys="TableAssociation.parent_table_vid",
             back_populates="parent_table_version",
         )
     )
     module_version_compositions: Mapped[List["ModuleVersionComposition"]] = (
         relationship(
+            "ModuleVersionComposition",
             back_populates="table_version",
         )
     )
@@ -274,25 +290,31 @@ class Header(Base):
         ForeignKey("Organisation.OrgID"),
     )
 
-    table: Mapped[Optional["Table"]] = relationship(back_populates="headers")
+    table: Mapped[Optional["Table"]] = relationship(
+        "Table", back_populates="headers"
+    )
     concept: Mapped[Optional["Concept"]] = relationship(
-        foreign_keys=[row_guid]
+        "Concept", foreign_keys=[row_guid]
     )
     owner: Mapped[Optional["Organisation"]] = relationship(
-        foreign_keys=[owner_id]
+        "Organisation", foreign_keys=[owner_id]
     )
     header_versions: Mapped[List["HeaderVersion"]] = relationship(
+        "HeaderVersion",
         back_populates="header",
     )
     column_cells: Mapped[List["Cell"]] = relationship(
+        "Cell",
         foreign_keys="Cell.column_id",
         back_populates="column_header",
     )
     row_cells: Mapped[List["Cell"]] = relationship(
+        "Cell",
         foreign_keys="Cell.row_id",
         back_populates="row_header",
     )
     sheet_cells: Mapped[List["Cell"]] = relationship(
+        "Cell",
         foreign_keys="Cell.sheet_id",
         back_populates="sheet_header",
     )
@@ -370,28 +392,28 @@ class HeaderVersion(Base):
     )
 
     header: Mapped[Optional["Header"]] = relationship(
-        back_populates="header_versions"
+        "Header", back_populates="header_versions"
     )
     property: Mapped[Optional["Property"]] = relationship(
-        foreign_keys=[property_id]
+        "Property", foreign_keys=[property_id]
     )
     context: Mapped[Optional["Context"]] = relationship(
-        foreign_keys=[context_id]
+        "Context", foreign_keys=[context_id]
     )
     subcategory_version: Mapped[Optional["SubCategoryVersion"]] = relationship(
-        foreign_keys=[subcategory_vid]
+        "SubCategoryVersion", foreign_keys=[subcategory_vid]
     )
     key_variable_version: Mapped[Optional["VariableVersion"]] = relationship(
-        foreign_keys=[key_variable_vid]
+        "VariableVersion", foreign_keys=[key_variable_vid]
     )
     start_release: Mapped[Optional["Release"]] = relationship(
-        foreign_keys=[start_release_id]
+        "Release", foreign_keys=[start_release_id]
     )
     end_release: Mapped[Optional["Release"]] = relationship(
-        foreign_keys=[end_release_id]
+        "Release", foreign_keys=[end_release_id]
     )
     concept: Mapped[Optional["Concept"]] = relationship(
-        foreign_keys=[row_guid]
+        "Concept", foreign_keys=[row_guid]
     )
 
 
@@ -445,30 +467,37 @@ class Cell(Base):
         ForeignKey("Organisation.OrgID"),
     )
 
-    table: Mapped[Optional["Table"]] = relationship(back_populates="cells")
+    table: Mapped[Optional["Table"]] = relationship(
+        "Table", back_populates="cells"
+    )
     column_header: Mapped[Optional["Header"]] = relationship(
+        "Header",
         foreign_keys=[column_id],
         back_populates="column_cells",
     )
     row_header: Mapped[Optional["Header"]] = relationship(
+        "Header",
         foreign_keys=[row_id],
         back_populates="row_cells",
     )
     sheet_header: Mapped[Optional["Header"]] = relationship(
+        "Header",
         foreign_keys=[sheet_id],
         back_populates="sheet_cells",
     )
     concept: Mapped[Optional["Concept"]] = relationship(
-        foreign_keys=[row_guid]
+        "Concept", foreign_keys=[row_guid]
     )
     owner: Mapped[Optional["Organisation"]] = relationship(
-        foreign_keys=[owner_id]
+        "Organisation", foreign_keys=[owner_id]
     )
     table_version_cells: Mapped[List["TableVersionCell"]] = relationship(
+        "TableVersionCell",
         back_populates="cell",
     )
     operand_reference_locations: Mapped[List["OperandReferenceLocation"]] = (
         relationship(
+            "OperandReferenceLocation",
             back_populates="cell",
         )
     )
@@ -521,11 +550,13 @@ class TableVersionCell(Base):
     row_guid: Mapped[Optional[str]] = mapped_column("RowGUID", String(38))
 
     table_version: Mapped["TableVersion"] = relationship(
-        back_populates="table_version_cells"
+        "TableVersion", back_populates="table_version_cells"
     )
-    cell: Mapped["Cell"] = relationship(back_populates="table_version_cells")
+    cell: Mapped["Cell"] = relationship(
+        "Cell", back_populates="table_version_cells"
+    )
     variable_version: Mapped[Optional["VariableVersion"]] = relationship(
-        foreign_keys=[variable_vid]
+        "VariableVersion", foreign_keys=[variable_vid]
     )
 
 
@@ -582,14 +613,14 @@ class TableVersionHeader(Base):
     row_guid: Mapped[Optional[str]] = mapped_column("RowGUID", String(38))
 
     table_version: Mapped["TableVersion"] = relationship(
-        back_populates="table_version_headers"
+        "TableVersion", back_populates="table_version_headers"
     )
-    header: Mapped["Header"] = relationship(foreign_keys=[header_id])
+    header: Mapped["Header"] = relationship("Header", foreign_keys=[header_id])
     header_version: Mapped[Optional["HeaderVersion"]] = relationship(
-        foreign_keys=[header_vid]
+        "HeaderVersion", foreign_keys=[header_vid]
     )
     parent_header: Mapped[Optional["Header"]] = relationship(
-        foreign_keys=[parent_header_id]
+        "Header", foreign_keys=[parent_header_id]
     )
 
 
@@ -651,26 +682,29 @@ class TableGroup(Base):
     )
 
     concept: Mapped[Optional["Concept"]] = relationship(
-        foreign_keys=[row_guid]
+        "Concept", foreign_keys=[row_guid]
     )
     start_release: Mapped[Optional["Release"]] = relationship(
-        foreign_keys=[start_release_id]
+        "Release", foreign_keys=[start_release_id]
     )
     end_release: Mapped[Optional["Release"]] = relationship(
-        foreign_keys=[end_release_id]
+        "Release", foreign_keys=[end_release_id]
     )
     parent_table_group: Mapped[Optional["TableGroup"]] = relationship(
+        "TableGroup",
         remote_side=[table_group_id],
         back_populates="child_table_groups",
     )
     child_table_groups: Mapped[List["TableGroup"]] = relationship(
+        "TableGroup",
         back_populates="parent_table_group",
     )
     owner: Mapped[Optional["Organisation"]] = relationship(
-        foreign_keys=[owner_id]
+        "Organisation", foreign_keys=[owner_id]
     )
     table_group_compositions: Mapped[List["TableGroupComposition"]] = (
         relationship(
+            "TableGroupComposition",
             back_populates="table_group",
         )
     )
@@ -721,16 +755,16 @@ class TableGroupComposition(Base):
     row_guid: Mapped[Optional[str]] = mapped_column("RowGUID", String(38))
 
     table_group: Mapped["TableGroup"] = relationship(
-        back_populates="table_group_compositions"
+        "TableGroup", back_populates="table_group_compositions"
     )
     table: Mapped["Table"] = relationship(
-        back_populates="table_group_compositions"
+        "Table", back_populates="table_group_compositions"
     )
     start_release: Mapped[Optional["Release"]] = relationship(
-        foreign_keys=[start_release_id]
+        "Release", foreign_keys=[start_release_id]
     )
     end_release: Mapped[Optional["Release"]] = relationship(
-        foreign_keys=[end_release_id]
+        "Release", foreign_keys=[end_release_id]
     )
 
 
@@ -802,23 +836,26 @@ class TableAssociation(Base):
     )
 
     child_table_version: Mapped[Optional["TableVersion"]] = relationship(
+        "TableVersion",
         foreign_keys=[child_table_vid],
         back_populates="table_associations_as_child",
     )
     parent_table_version: Mapped[Optional["TableVersion"]] = relationship(
+        "TableVersion",
         foreign_keys=[parent_table_vid],
         back_populates="table_associations_as_parent",
     )
     subtype_discriminator_header: Mapped[Optional["Header"]] = relationship(
-        foreign_keys=[subtype_discriminator]
+        "Header", foreign_keys=[subtype_discriminator]
     )
     concept: Mapped[Optional["Concept"]] = relationship(
-        foreign_keys=[row_guid]
+        "Concept", foreign_keys=[row_guid]
     )
     owner: Mapped[Optional["Organisation"]] = relationship(
-        foreign_keys=[owner_id]
+        "Organisation", foreign_keys=[owner_id]
     )
     key_header_mappings: Mapped[List["KeyHeaderMapping"]] = relationship(
+        "KeyHeaderMapping",
         back_populates="table_association",
     )
 
@@ -860,11 +897,11 @@ class KeyHeaderMapping(Base):
     row_guid: Mapped[Optional[str]] = mapped_column("RowGUID", String(38))
 
     table_association: Mapped["TableAssociation"] = relationship(
-        back_populates="key_header_mappings"
+        "TableAssociation", back_populates="key_header_mappings"
     )
     foreign_key_header: Mapped["Header"] = relationship(
-        foreign_keys=[foreign_key_header_id]
+        "Header", foreign_keys=[foreign_key_header_id]
     )
     primary_key_header: Mapped[Optional["Header"]] = relationship(
-        foreign_keys=[primary_key_header_id]
+        "Header", foreign_keys=[primary_key_header_id]
     )

--- a/src/dpmcore/orm/variables.py
+++ b/src/dpmcore/orm/variables.py
@@ -17,8 +17,9 @@ from sqlalchemy import (
     String,
     UniqueConstraint,
 )
-from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.orm import relationship
 
+from dpmcore.orm._compat import Mapped, mapped_column
 from dpmcore.orm.base import Base
 from dpmcore.orm.infrastructure import Concept, Organisation, Release
 
@@ -69,18 +70,21 @@ class Variable(Base):
     )
 
     concept: Mapped[Optional["Concept"]] = relationship(
-        foreign_keys=[row_guid]
+        "Concept", foreign_keys=[row_guid]
     )
     owner: Mapped[Optional["Organisation"]] = relationship(
-        foreign_keys=[owner_id]
+        "Organisation", foreign_keys=[owner_id]
     )
     variable_versions: Mapped[List["VariableVersion"]] = relationship(
+        "VariableVersion",
         back_populates="variable",
     )
     variable_calculations: Mapped[List["VariableCalculation"]] = relationship(
+        "VariableCalculation",
         back_populates="variable",
     )
     operand_references: Mapped[List["OperandReference"]] = relationship(
+        "OperandReference",
         back_populates="variable",
     )
 
@@ -161,37 +165,43 @@ class VariableVersion(Base):
     )
 
     variable: Mapped[Optional["Variable"]] = relationship(
-        back_populates="variable_versions"
+        "Variable", back_populates="variable_versions"
     )
     property: Mapped[Optional["Property"]] = relationship(
-        foreign_keys=[property_id]
+        "Property", foreign_keys=[property_id]
     )
     subcategory_version: Mapped[Optional["SubCategoryVersion"]] = relationship(
-        foreign_keys=[subcategory_vid]
+        "SubCategoryVersion", foreign_keys=[subcategory_vid]
     )
     context: Mapped[Optional["Context"]] = relationship(
-        foreign_keys=[context_id]
+        "Context", foreign_keys=[context_id]
     )
-    key: Mapped[Optional["CompoundKey"]] = relationship(foreign_keys=[key_id])
+    key: Mapped[Optional["CompoundKey"]] = relationship(
+        "CompoundKey", foreign_keys=[key_id]
+    )
     start_release: Mapped[Optional["Release"]] = relationship(
-        foreign_keys=[start_release_id]
+        "Release", foreign_keys=[start_release_id]
     )
     end_release: Mapped[Optional["Release"]] = relationship(
-        foreign_keys=[end_release_id]
+        "Release", foreign_keys=[end_release_id]
     )
     concept: Mapped[Optional["Concept"]] = relationship(
-        foreign_keys=[row_guid]
+        "Concept", foreign_keys=[row_guid]
     )
     key_compositions: Mapped[List["KeyComposition"]] = relationship(
+        "KeyComposition",
         back_populates="variable_version",
     )
     module_parameters: Mapped[List["ModuleParameters"]] = relationship(
+        "ModuleParameters",
         back_populates="variable_version",
     )
     table_version_cells: Mapped[List["TableVersionCell"]] = relationship(
+        "TableVersionCell",
         back_populates="variable_version",
     )
     header_versions: Mapped[List["HeaderVersion"]] = relationship(
+        "HeaderVersion",
         back_populates="key_variable_version",
     )
 
@@ -242,13 +252,13 @@ class VariableCalculation(Base):
     row_guid: Mapped[Optional[str]] = mapped_column("RowGUID", String(38))
 
     module: Mapped["Module"] = relationship(
-        back_populates="variable_calculations"
+        "Module", back_populates="variable_calculations"
     )
     variable: Mapped["Variable"] = relationship(
-        back_populates="variable_calculations"
+        "Variable", back_populates="variable_calculations"
     )
     operation_version: Mapped["OperationVersion"] = relationship(
-        back_populates="variable_calculations"
+        "OperationVersion", back_populates="variable_calculations"
     )
 
 
@@ -284,18 +294,21 @@ class CompoundKey(Base):
     )
 
     concept: Mapped[Optional["Concept"]] = relationship(
-        foreign_keys=[row_guid]
+        "Concept", foreign_keys=[row_guid]
     )
     owner: Mapped[Optional["Organisation"]] = relationship(
-        foreign_keys=[owner_id]
+        "Organisation", foreign_keys=[owner_id]
     )
     key_compositions: Mapped[List["KeyComposition"]] = relationship(
+        "KeyComposition",
         back_populates="compound_key",
     )
     module_versions: Mapped[List["ModuleVersion"]] = relationship(
+        "ModuleVersion",
         back_populates="global_key",
     )
     table_versions: Mapped[List["TableVersion"]] = relationship(
+        "TableVersion",
         back_populates="key",
     )
 
@@ -331,8 +344,8 @@ class KeyComposition(Base):
     row_guid: Mapped[Optional[str]] = mapped_column("RowGUID", String(38))
 
     compound_key: Mapped["CompoundKey"] = relationship(
-        back_populates="key_compositions"
+        "CompoundKey", back_populates="key_compositions"
     )
     variable_version: Mapped["VariableVersion"] = relationship(
-        back_populates="key_compositions"
+        "VariableVersion", back_populates="key_compositions"
     )

--- a/src/dpmcore/server/app.py
+++ b/src/dpmcore/server/app.py
@@ -8,7 +8,8 @@ from typing import AsyncIterator, Dict, Generator, Optional
 from fastapi import Depends, FastAPI
 from fastapi.routing import APIRouter
 from pydantic import BaseModel
-from sqlalchemy import Engine, create_engine
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session, sessionmaker
 
 import dpmcore.orm  # noqa: F401  — ensure all models are loaded

--- a/src/dpmcore/services/database_update.py
+++ b/src/dpmcore/services/database_update.py
@@ -8,7 +8,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from urllib.parse import unquote
 
-from sqlalchemy import Connection, Engine, create_engine, inspect, text
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.engine import Connection, Engine
 
 from dpmcore.loaders.migration import (
     MigrationError,

--- a/src/dpmcore/services/ecb_validations_import.py
+++ b/src/dpmcore/services/ecb_validations_import.py
@@ -10,7 +10,8 @@ from hashlib import md5
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set
 
-from sqlalchemy import Engine, func
+from sqlalchemy import func
+from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session, sessionmaker
 
 from dpmcore.dpm_xl.ast.operands import OperandsChecking

--- a/src/dpmcore/services/schema_validation.py
+++ b/src/dpmcore/services/schema_validation.py
@@ -13,7 +13,8 @@ import time
 from dataclasses import dataclass, field
 from typing import Dict, List, Tuple
 
-from sqlalchemy import Engine, inspect, text
+from sqlalchemy import inspect, text
+from sqlalchemy.engine import Engine
 
 from dpmcore.orm.base import Base
 

--- a/src/dpmcore/services/structure.py
+++ b/src/dpmcore/services/structure.py
@@ -2849,7 +2849,7 @@ class StructureService:
             .filter(CompoundKey.key_id.in_(key_ids))
             .all()
         )
-        return dict(row._tuple() for row in rows)
+        return {row[0]: row[1] for row in rows}
 
     # ------------------------------------------------------------------ #
     # Frameworks

--- a/tests/unit/migration/test_database_update.py
+++ b/tests/unit/migration/test_database_update.py
@@ -30,7 +30,7 @@ def fake_migration_result():
 
 def _engine_with_tables(tmp_path, tables: dict):
     db_path = tmp_path / "test.sqlite"
-    engine = create_engine(f"sqlite:///{db_path}")
+    engine = create_engine(f"sqlite:///{db_path}", future=True)
     with engine.connect() as conn:
         for name, count in tables.items():
             conn.execute(

--- a/tests/unit/migration/test_migration_service.py
+++ b/tests/unit/migration/test_migration_service.py
@@ -17,7 +17,7 @@ FIXED_TOKEN = "20260512"  # noqa: S105
 
 @pytest.fixture
 def sqlite_engine():
-    return create_engine("sqlite:///:memory:")
+    return create_engine("sqlite:///:memory:", future=True)
 
 
 @pytest.fixture
@@ -297,7 +297,7 @@ class TestRenameWithMetadata:
 
     def test_renames_sqlite_file_with_release_and_date(self, tmp_path):
         db_path = tmp_path / "dpm.db"
-        engine = create_engine(f"sqlite:///{db_path}")
+        engine = create_engine(f"sqlite:///{db_path}", future=True)
         service = MigrationService(engine)
 
         csv_dir = tmp_path / "csv"
@@ -313,7 +313,7 @@ class TestRenameWithMetadata:
 
     def test_renames_without_release_token_when_no_release(self, tmp_path):
         db_path = tmp_path / "dpm.db"
-        engine = create_engine(f"sqlite:///{db_path}")
+        engine = create_engine(f"sqlite:///{db_path}", future=True)
         service = MigrationService(engine)
 
         csv_dir = tmp_path / "csv"
@@ -331,7 +331,7 @@ class TestRenameWithMetadata:
 
     def test_falls_back_to_any_release_when_none_is_current(self, tmp_path):
         db_path = tmp_path / "dpm.db"
-        engine = create_engine(f"sqlite:///{db_path}")
+        engine = create_engine(f"sqlite:///{db_path}", future=True)
         service = MigrationService(engine)
 
         csv_dir = tmp_path / "csv"
@@ -345,7 +345,7 @@ class TestRenameWithMetadata:
 
     def test_sanitises_unsafe_characters_in_release_code(self, tmp_path):
         db_path = tmp_path / "dpm.db"
-        engine = create_engine(f"sqlite:///{db_path}")
+        engine = create_engine(f"sqlite:///{db_path}", future=True)
         service = MigrationService(engine)
 
         csv_dir = tmp_path / "csv"
@@ -377,7 +377,7 @@ class TestRenameWithMetadata:
 
     def test_sqlite_file_path_returns_none_when_file_missing(self, tmp_path):
         missing = tmp_path / "nope.db"
-        engine = create_engine(f"sqlite:///{missing}")
+        engine = create_engine(f"sqlite:///{missing}", future=True)
         service = MigrationService(engine)
         assert service._sqlite_file_path() is None
 
@@ -390,7 +390,7 @@ class TestRenameWithMetadata:
 
     def test_release_code_sanitises_to_none_when_only_unsafe(self, tmp_path):
         db_path = tmp_path / "dpm.db"
-        engine = create_engine(f"sqlite:///{db_path}")
+        engine = create_engine(f"sqlite:///{db_path}", future=True)
         service = MigrationService(engine)
 
         csv_dir = tmp_path / "csv"
@@ -413,7 +413,7 @@ class TestOutputPathOverride:
 
     def test_output_path_overrides_convention(self, tmp_path):
         db_path = tmp_path / "dpm.db"
-        engine = create_engine(f"sqlite:///{db_path}")
+        engine = create_engine(f"sqlite:///{db_path}", future=True)
         service = MigrationService(engine)
 
         csv_dir = tmp_path / "csv"
@@ -432,7 +432,7 @@ class TestOutputPathOverride:
 
     def test_output_path_creates_parent_dirs(self, tmp_path):
         db_path = tmp_path / "dpm.db"
-        engine = create_engine(f"sqlite:///{db_path}")
+        engine = create_engine(f"sqlite:///{db_path}", future=True)
         service = MigrationService(engine)
 
         csv_dir = tmp_path / "csv"
@@ -465,7 +465,7 @@ class TestOutputPathOverride:
 
     def test_output_path_noop_when_same_as_current(self, tmp_path):
         db_path = tmp_path / "dpm.db"
-        engine = create_engine(f"sqlite:///{db_path}")
+        engine = create_engine(f"sqlite:///{db_path}", future=True)
         service = MigrationService(engine)
 
         csv_dir = tmp_path / "csv"
@@ -484,7 +484,7 @@ class TestOutputPathOverride:
 
     def test_migrate_from_access_accepts_output_path(self, tmp_path):
         db_path = tmp_path / "dpm.db"
-        engine = create_engine(f"sqlite:///{db_path}")
+        engine = create_engine(f"sqlite:///{db_path}", future=True)
         service = MigrationService(engine)
 
         with patch("subprocess.check_output") as mock_sub:

--- a/tests/unit/orm/_schema_snapshot.txt
+++ b/tests/unit/orm/_schema_snapshot.txt
@@ -1,0 +1,599 @@
+TABLE Aux_CellMapping
+  COL NewCellID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=
+  COL NewTableVID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=
+  COL OldCellID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=
+  COL OldTableVID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=
+  PK NewCellID,NewTableVID
+  UNIQUE NewCellID,NewTableVID
+TABLE Aux_CellStatus
+  COL CellID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=
+  COL IsNewCell pg=BOOLEAN mssql=BIT null=True pk=False ai=auto fks=
+  COL Status pg=VARCHAR(100) mssql=VARCHAR(100) null=True pk=False ai=auto fks=
+  COL TableVID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=
+  PK TableVID,CellID
+  UNIQUE TableVID,CellID
+TABLE Category
+  COL CategoryID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=
+  COL Code pg=VARCHAR(20) mssql=VARCHAR(20) null=True pk=False ai=auto fks=
+  COL CreatedRelease pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Release.ReleaseID
+  COL Description pg=VARCHAR(1000) mssql=VARCHAR(1000) null=True pk=False ai=auto fks=
+  COL IsActive pg=BOOLEAN mssql=BIT null=True pk=False ai=auto fks=
+  COL IsEnumerated pg=BOOLEAN mssql=BIT null=True pk=False ai=auto fks=
+  COL IsExternalRefData pg=BOOLEAN mssql=BIT null=True pk=False ai=auto fks=
+  COL Name pg=VARCHAR(50) mssql=VARCHAR(50) null=True pk=False ai=auto fks=
+  COL OwnerID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Organisation.OrgID
+  COL RefDataSource pg=VARCHAR(255) mssql=VARCHAR(255) null=True pk=False ai=auto fks=
+  COL RowGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=True pk=False ai=auto fks=Concept.ConceptGUID
+  PK CategoryID
+TABLE Cell
+  COL CellID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=
+  COL ColumnID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Header.HeaderID
+  COL OwnerID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Organisation.OrgID
+  COL RowGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=True pk=False ai=auto fks=Concept.ConceptGUID
+  COL RowID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Header.HeaderID
+  COL SheetID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Header.HeaderID
+  COL TableID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Table.TableID
+  PK CellID
+  UNIQUE ColumnID,RowID,SheetID
+TABLE ChangeLog
+  COL ActionID pg=INTEGER mssql=INTEGER null=False pk=False ai=auto fks=
+  COL ChangeType pg=VARCHAR(255) mssql=VARCHAR(255) null=True pk=False ai=auto fks=
+  COL ClassID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=DPMClass.ClassID
+  COL EntityCode pg=VARCHAR(255) mssql=VARCHAR(255) null=True pk=False ai=auto fks=
+  COL EntityID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=
+  COL ReleaseID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Release.ReleaseID
+  COL RowGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=False pk=True ai=auto fks=
+  COL Status pg=VARCHAR(1) mssql=VARCHAR(1) null=True pk=False ai=auto fks=
+  COL Timestamp pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=
+  COL UserEmail pg=VARCHAR(255) mssql=VARCHAR(255) null=True pk=False ai=auto fks=
+  PK RowGUID,ClassID,Timestamp
+TABLE ChangeLogAttribute
+  COL ActionID pg=INTEGER mssql=INTEGER null=False pk=False ai=auto fks=
+  COL AttributeID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=DPMAttribute.AttributeID
+  COL ChangeLogAttributeID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=
+  COL NewValue pg=VARCHAR(255) mssql=VARCHAR(255) null=True pk=False ai=auto fks=
+  COL OldValue pg=VARCHAR(255) mssql=VARCHAR(255) null=True pk=False ai=auto fks=
+  PK ChangeLogAttributeID
+TABLE CompoundItemContext
+  COL ContextID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Context.ContextID
+  COL EndReleaseID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Release.ReleaseID
+  COL ItemID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=Item.ItemID
+  COL RowGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=True pk=False ai=auto fks=
+  COL StartReleaseID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=Release.ReleaseID
+  PK ItemID,StartReleaseID
+TABLE CompoundKey
+  COL KeyID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=
+  COL OwnerID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Organisation.OrgID
+  COL RowGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=True pk=False ai=auto fks=Concept.ConceptGUID
+  COL Signature pg=VARCHAR(255) mssql=VARCHAR(255) null=True pk=False ai=auto fks=
+  PK KeyID
+  UNIQUE Signature
+TABLE Concept
+  COL ClassID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=DPMClass.ClassID
+  COL ConceptGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=False pk=True ai=auto fks=
+  COL OwnerID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Organisation.OrgID
+  PK ConceptGUID
+TABLE ConceptRelation
+  COL ConceptRelationID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=
+  COL RowGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=True pk=False ai=auto fks=
+  COL Type pg=VARCHAR(50) mssql=VARCHAR(50) null=True pk=False ai=auto fks=
+  PK ConceptRelationID
+TABLE Context
+  COL ContextID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=
+  COL OwnerID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Organisation.OrgID
+  COL RowGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=True pk=False ai=auto fks=Concept.ConceptGUID
+  COL Signature pg=VARCHAR(2000) mssql=VARCHAR(2000) null=True pk=False ai=auto fks=
+  PK ContextID
+TABLE ContextComposition
+  COL ContextID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=Context.ContextID
+  COL ItemID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Item.ItemID
+  COL PropertyID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=Property.PropertyID
+  COL RowGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=True pk=False ai=auto fks=Concept.ConceptGUID
+  PK ContextID,PropertyID
+TABLE DPMAttribute
+  COL AttributeID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=
+  COL ClassID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=DPMClass.ClassID
+  COL HasTranslations pg=BOOLEAN mssql=BIT null=True pk=False ai=auto fks=
+  COL Name pg=VARCHAR(255) mssql=VARCHAR(255) null=True pk=False ai=auto fks=
+  PK AttributeID
+TABLE DPMClass
+  COL ClassID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=
+  COL HasReferences pg=BOOLEAN mssql=BIT null=True pk=False ai=auto fks=
+  COL Name pg=VARCHAR(50) mssql=VARCHAR(50) null=True pk=False ai=auto fks=
+  COL OwnerClassID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=DPMClass.ClassID
+  COL Type pg=VARCHAR(20) mssql=VARCHAR(20) null=True pk=False ai=auto fks=
+  PK ClassID
+TABLE DataType
+  COL Code pg=VARCHAR(20) mssql=VARCHAR(20) null=True pk=False ai=auto fks=
+  COL DataTypeID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=
+  COL IsActive pg=BOOLEAN mssql=BIT null=True pk=False ai=auto fks=
+  COL Name pg=VARCHAR(50) mssql=VARCHAR(50) null=True pk=False ai=auto fks=
+  COL ParentDataTypeID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=DataType.DataTypeID
+  PK DataTypeID
+  UNIQUE Code
+  UNIQUE Name
+TABLE Document
+  COL Code pg=VARCHAR(20) mssql=VARCHAR(20) null=True pk=False ai=auto fks=
+  COL DocumentID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=
+  COL Name pg=VARCHAR(50) mssql=VARCHAR(50) null=True pk=False ai=auto fks=
+  COL OrgID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Organisation.OrgID
+  COL RowGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=True pk=False ai=auto fks=Concept.ConceptGUID
+  COL Type pg=VARCHAR(255) mssql=VARCHAR(255) null=True pk=False ai=auto fks=
+  PK DocumentID
+TABLE DocumentVersion
+  COL Code pg=VARCHAR(20) mssql=VARCHAR(20) null=True pk=False ai=auto fks=
+  COL DocumentID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Document.DocumentID
+  COL DocumentVID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=
+  COL PublicationDate pg=DATE mssql=DATETIME null=True pk=False ai=auto fks=
+  COL RowGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=True pk=False ai=auto fks=Concept.ConceptGUID
+  COL Version pg=VARCHAR(20) mssql=VARCHAR(20) null=True pk=False ai=auto fks=
+  PK DocumentVID
+  UNIQUE DocumentID,PublicationDate
+TABLE Framework
+  COL Code pg=VARCHAR(255) mssql=VARCHAR(255) null=True pk=False ai=auto fks=
+  COL Description pg=VARCHAR(255) mssql=VARCHAR(255) null=True pk=False ai=auto fks=
+  COL FrameworkID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=
+  COL Name pg=VARCHAR(255) mssql=VARCHAR(255) null=True pk=False ai=auto fks=
+  COL OwnerID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Organisation.OrgID
+  COL RowGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=True pk=False ai=auto fks=Concept.ConceptGUID
+  PK FrameworkID
+TABLE Header
+  COL Direction pg=VARCHAR(1) mssql=VARCHAR(1) null=True pk=False ai=auto fks=
+  COL HeaderID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=
+  COL IsAttribute pg=BOOLEAN mssql=BIT null=True pk=False ai=auto fks=
+  COL IsKey pg=BOOLEAN mssql=BIT null=True pk=False ai=auto fks=
+  COL OwnerID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Organisation.OrgID
+  COL RowGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=True pk=False ai=auto fks=Concept.ConceptGUID
+  COL TableID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Table.TableID
+  PK HeaderID
+TABLE HeaderVersion
+  COL Code pg=VARCHAR(10) mssql=VARCHAR(10) null=True pk=False ai=auto fks=
+  COL ContextID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Context.ContextID
+  COL EndReleaseID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Release.ReleaseID
+  COL HeaderID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Header.HeaderID
+  COL HeaderVID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=
+  COL KeyVariableVID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=VariableVersion.VariableVID
+  COL Label pg=VARCHAR(500) mssql=VARCHAR(500) null=True pk=False ai=auto fks=
+  COL PropertyID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Property.PropertyID
+  COL RowGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=True pk=False ai=auto fks=Concept.ConceptGUID
+  COL StartReleaseID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Release.ReleaseID
+  COL SubCategoryVID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=SubCategoryVersion.SubCategoryVID
+  PK HeaderVID
+  UNIQUE HeaderID,StartReleaseID
+TABLE Item
+  COL Description pg=VARCHAR(2000) mssql=VARCHAR(2000) null=True pk=False ai=auto fks=
+  COL IsActive pg=BOOLEAN mssql=BIT null=True pk=False ai=auto fks=
+  COL IsProperty pg=BOOLEAN mssql=BIT null=True pk=False ai=auto fks=
+  COL ItemID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=
+  COL Name pg=VARCHAR(500) mssql=VARCHAR(500) null=True pk=False ai=auto fks=
+  COL OwnerID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Organisation.OrgID
+  COL RowGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=True pk=False ai=auto fks=Concept.ConceptGUID
+  PK ItemID
+TABLE ItemCategory
+  COL CategoryID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Category.CategoryID
+  COL Code pg=VARCHAR(20) mssql=VARCHAR(20) null=True pk=False ai=auto fks=
+  COL EndReleaseID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Release.ReleaseID
+  COL IsDefaultItem pg=BOOLEAN mssql=BIT null=True pk=False ai=auto fks=
+  COL ItemID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=Item.ItemID
+  COL RowGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=True pk=False ai=auto fks=
+  COL Signature pg=VARCHAR(255) mssql=VARCHAR(255) null=True pk=False ai=auto fks=
+  COL StartReleaseID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=Release.ReleaseID
+  PK ItemID,StartReleaseID
+TABLE KeyComposition
+  COL KeyID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=CompoundKey.KeyID
+  COL RowGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=True pk=False ai=auto fks=
+  COL VariableVID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=VariableVersion.VariableVID
+  PK KeyID,VariableVID
+TABLE KeyHeaderMapping
+  COL AssociationID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=TableAssociation.AssociationID
+  COL ForeignKeyHeaderID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=Header.HeaderID
+  COL PrimaryKeyHeaderID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Header.HeaderID
+  COL RowGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=True pk=False ai=auto fks=
+  PK AssociationID,ForeignKeyHeaderID
+TABLE Language
+  COL LanguageCode pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=
+  COL Name pg=VARCHAR(20) mssql=VARCHAR(20) null=True pk=False ai=auto fks=
+  PK LanguageCode
+TABLE ModelViolations
+  COL CategoryCode pg=VARCHAR(30) mssql=VARCHAR(30) null=True pk=False ai=auto fks=
+  COL CategoryID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=
+  COL Cell2Code pg=VARCHAR(50) mssql=VARCHAR(50) null=True pk=False ai=auto fks=
+  COL Cell2ID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=
+  COL CellCode pg=VARCHAR(50) mssql=VARCHAR(50) null=True pk=False ai=auto fks=
+  COL CellID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=
+  COL HeaderCode pg=VARCHAR(20) mssql=VARCHAR(20) null=True pk=False ai=auto fks=
+  COL HeaderContextID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=
+  COL HeaderDirection pg=VARCHAR(1) mssql=VARCHAR(1) null=True pk=False ai=auto fks=
+  COL HeaderID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=
+  COL HeaderPropertyCode pg=VARCHAR(20) mssql=VARCHAR(20) null=True pk=False ai=auto fks=
+  COL HeaderPropertyID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=
+  COL HeaderSubcategoryID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=
+  COL HeaderSubcategoryName pg=VARCHAR(60) mssql=VARCHAR(60) null=True pk=False ai=auto fks=
+  COL HeaderVID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=
+  COL ItemCode pg=VARCHAR(30) mssql=VARCHAR(30) null=True pk=False ai=auto fks=
+  COL ItemID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=
+  COL KeyHeader pg=BOOLEAN mssql=BIT null=True pk=False ai=auto fks=
+  COL NewAspect pg=VARCHAR(80) mssql=VARCHAR(80) null=True pk=False ai=auto fks=
+  COL OldHeaderVID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=
+  COL OldTableVID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=
+  COL TableCode pg=VARCHAR(40) mssql=VARCHAR(40) null=True pk=False ai=auto fks=
+  COL TableVID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=
+  COL VVEndReleaseID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=
+  COL Violation pg=VARCHAR(255) mssql=VARCHAR(255) null=True pk=False ai=auto fks=
+  COL ViolationCode pg=VARCHAR(10) mssql=VARCHAR(10) null=True pk=False ai=auto fks=
+  COL id pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=
+  COL isBlocking pg=BOOLEAN mssql=BIT null=True pk=False ai=auto fks=
+  PK id
+TABLE Module
+  COL FrameworkID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Framework.FrameworkID
+  COL ModuleID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=
+  COL OwnerID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Organisation.OrgID
+  COL RowGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=True pk=False ai=auto fks=Concept.ConceptGUID
+  COL isDocumentModule pg=BOOLEAN mssql=BIT null=True pk=False ai=auto fks=
+  PK ModuleID
+TABLE ModuleParameters
+  COL ModuleVID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=ModuleVersion.ModuleVID
+  COL RowGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=True pk=False ai=auto fks=
+  COL VariableVID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=VariableVersion.VariableVID
+  PK ModuleVID,VariableVID
+TABLE ModuleVersion
+  COL Code pg=VARCHAR(30) mssql=VARCHAR(30) null=True pk=False ai=auto fks=
+  COL Description pg=VARCHAR(255) mssql=VARCHAR(255) null=True pk=False ai=auto fks=
+  COL EndReleaseID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Release.ReleaseID
+  COL FromReferenceDate pg=DATE mssql=DATETIME null=True pk=False ai=auto fks=
+  COL GlobalKeyID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=CompoundKey.KeyID
+  COL IsCalculated pg=BOOLEAN mssql=BIT null=True pk=False ai=auto fks=
+  COL IsReported pg=BOOLEAN mssql=BIT null=True pk=False ai=auto fks=
+  COL ModuleID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Module.ModuleID
+  COL ModuleVID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=
+  COL Name pg=VARCHAR(100) mssql=VARCHAR(100) null=True pk=False ai=auto fks=
+  COL RowGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=True pk=False ai=auto fks=Concept.ConceptGUID
+  COL StartReleaseID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Release.ReleaseID
+  COL ToReferenceDate pg=DATE mssql=DATETIME null=True pk=False ai=auto fks=
+  COL VersionNumber pg=VARCHAR(20) mssql=VARCHAR(20) null=True pk=False ai=auto fks=
+  PK ModuleVID
+  UNIQUE ModuleID,StartReleaseID
+TABLE ModuleVersionComposition
+  COL ModuleVID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=ModuleVersion.ModuleVID
+  COL Order pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=
+  COL RowGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=True pk=False ai=auto fks=
+  COL TableID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=Table.TableID
+  COL TableVID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=TableVersion.TableVID
+  PK ModuleVID,TableID
+TABLE OperandReference
+  COL ItemID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Item.ItemID
+  COL NodeID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=OperationNode.NodeID
+  COL OperandReference pg=VARCHAR(255) mssql=VARCHAR(255) null=True pk=False ai=auto fks=
+  COL OperandReferenceID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=
+  COL PropertyID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Property.PropertyID
+  COL SubCategoryID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=SubCategory.SubCategoryID
+  COL VariableID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Variable.VariableID
+  COL x pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=
+  COL y pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=
+  COL z pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=
+  PK OperandReferenceID
+TABLE OperandReferenceLocation
+  COL CellID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Cell.CellID
+  COL Column pg=VARCHAR(255) mssql=VARCHAR(255) null=True pk=False ai=auto fks=
+  COL OperandReferenceID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=OperandReference.OperandReferenceID
+  COL Row pg=VARCHAR(255) mssql=VARCHAR(255) null=True pk=False ai=auto fks=
+  COL Sheet pg=VARCHAR(255) mssql=VARCHAR(255) null=True pk=False ai=auto fks=
+  COL Table pg=VARCHAR(255) mssql=VARCHAR(255) null=True pk=False ai=auto fks=
+  PK OperandReferenceID
+TABLE Operation
+  COL Code pg=VARCHAR(255) mssql=VARCHAR(255) null=True pk=False ai=auto fks=
+  COL GroupOperID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Operation.OperationID
+  COL OperationID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=
+  COL OwnerID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Organisation.OrgID
+  COL RowGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=True pk=False ai=auto fks=Concept.ConceptGUID
+  COL Source pg=VARCHAR(20) mssql=VARCHAR(20) null=True pk=False ai=auto fks=
+  COL Type pg=VARCHAR(20) mssql=VARCHAR(20) null=True pk=False ai=auto fks=
+  PK OperationID
+TABLE OperationCodePrefix
+  COL Code pg=VARCHAR(20) mssql=VARCHAR(20) null=True pk=False ai=auto fks=
+  COL FrameworkID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Framework.FrameworkID
+  COL ListName pg=VARCHAR(20) mssql=VARCHAR(20) null=True pk=False ai=auto fks=
+  COL OperationCodePrefixID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=
+  PK OperationCodePrefixID
+  UNIQUE Code
+TABLE OperationNode
+  COL AbsoluteTolerance pg=VARCHAR mssql=VARCHAR(max) null=True pk=False ai=auto fks=
+  COL ArgumentID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=OperatorArgument.ArgumentID
+  COL FallbackValue pg=VARCHAR(50) mssql=VARCHAR(50) null=True pk=False ai=auto fks=
+  COL IsLeaf pg=BOOLEAN mssql=BIT null=True pk=False ai=auto fks=
+  COL NodeID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=
+  COL OperandType pg=VARCHAR(20) mssql=VARCHAR(20) null=True pk=False ai=auto fks=
+  COL OperationVID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=OperationVersion.OperationVID
+  COL OperatorID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Operator.OperatorID
+  COL ParentNodeID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=OperationNode.NodeID
+  COL RelativeTolerance pg=VARCHAR mssql=VARCHAR(max) null=True pk=False ai=auto fks=
+  COL Scalar pg=TEXT mssql=TEXT null=True pk=False ai=auto fks=
+  COL UseIntervalArithmetics pg=BOOLEAN mssql=BIT null=True pk=False ai=auto fks=
+  PK NodeID
+TABLE OperationScope
+  COL FromSubmissionDate pg=DATE mssql=DATETIME null=True pk=False ai=auto fks=
+  COL IsActive pg=SMALLINT mssql=SMALLINT null=True pk=False ai=auto fks=
+  COL OperationScopeID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=
+  COL OperationVID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=OperationVersion.OperationVID
+  COL RowGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=True pk=False ai=auto fks=
+  COL Severity pg=VARCHAR(20) mssql=VARCHAR(20) null=True pk=False ai=auto fks=
+  PK OperationScopeID
+TABLE OperationScopeComposition
+  COL ModuleVID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=ModuleVersion.ModuleVID
+  COL OperationScopeID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=OperationScope.OperationScopeID
+  COL RowGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=True pk=False ai=auto fks=
+  PK OperationScopeID,ModuleVID
+TABLE OperationVersion
+  COL Description pg=VARCHAR(1000) mssql=VARCHAR(1000) null=True pk=False ai=auto fks=
+  COL EndReleaseID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Release.ReleaseID
+  COL Endorsement pg=VARCHAR(25) mssql=VARCHAR(25) null=True pk=False ai=auto fks=
+  COL Expression pg=TEXT mssql=TEXT null=True pk=False ai=auto fks=
+  COL IsVariantApproved pg=BOOLEAN mssql=BIT null=True pk=False ai=auto fks=
+  COL OperationID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Operation.OperationID
+  COL OperationVID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=
+  COL PreconditionOperationVID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=OperationVersion.OperationVID
+  COL RowGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=True pk=False ai=auto fks=Concept.ConceptGUID
+  COL SeverityOperationVID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=OperationVersion.OperationVID
+  COL StartReleaseID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Release.ReleaseID
+  PK OperationVID
+  UNIQUE OperationID,StartReleaseID
+TABLE OperationVersionData
+  COL Error pg=VARCHAR(2000) mssql=VARCHAR(2000) null=True pk=False ai=auto fks=
+  COL ErrorCode pg=VARCHAR(50) mssql=VARCHAR(50) null=True pk=False ai=auto fks=
+  COL IsApplying pg=BOOLEAN mssql=BIT null=True pk=False ai=auto fks=
+  COL OperationVID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=OperationVersion.OperationVID
+  COL ProposingStatus pg=VARCHAR(50) mssql=VARCHAR(50) null=True pk=False ai=auto fks=
+  PK OperationVID
+TABLE Operator
+  COL Name pg=VARCHAR(50) mssql=VARCHAR(50) null=True pk=False ai=auto fks=
+  COL OperatorID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=
+  COL Symbol pg=VARCHAR(20) mssql=VARCHAR(20) null=True pk=False ai=auto fks=
+  COL Type pg=VARCHAR(20) mssql=VARCHAR(20) null=True pk=False ai=auto fks=
+  PK OperatorID
+TABLE OperatorArgument
+  COL ArgumentID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=
+  COL IsMandatory pg=BOOLEAN mssql=BIT null=True pk=False ai=auto fks=
+  COL Name pg=VARCHAR(50) mssql=VARCHAR(50) null=True pk=False ai=auto fks=
+  COL OperatorID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Operator.OperatorID
+  COL Order pg=SMALLINT mssql=SMALLINT null=True pk=False ai=auto fks=
+  PK ArgumentID
+TABLE Organisation
+  COL Acronym pg=VARCHAR(20) mssql=VARCHAR(20) null=True pk=False ai=auto fks=
+  COL IDPrefix pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=
+  COL Name pg=VARCHAR(200) mssql=VARCHAR(200) null=True pk=False ai=auto fks=
+  COL OrgID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=
+  COL RowGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=True pk=False ai=auto fks=Concept.ConceptGUID
+  PK OrgID
+  UNIQUE IDPrefix
+  UNIQUE Name
+TABLE Property
+  COL DataTypeID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=DataType.DataTypeID
+  COL IsComposite pg=BOOLEAN mssql=BIT null=True pk=False ai=auto fks=
+  COL IsMetric pg=BOOLEAN mssql=BIT null=True pk=False ai=auto fks=
+  COL OwnerID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Organisation.OrgID
+  COL PeriodType pg=VARCHAR(20) mssql=VARCHAR(20) null=True pk=False ai=auto fks=
+  COL PropertyID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=Item.ItemID
+  COL RowGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=True pk=False ai=auto fks=Concept.ConceptGUID
+  COL ValueLength pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=
+  PK PropertyID
+TABLE PropertyCategory
+  COL CategoryID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Category.CategoryID
+  COL EndReleaseID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Release.ReleaseID
+  COL PropertyID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=Property.PropertyID
+  COL RowGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=True pk=False ai=auto fks=
+  COL StartReleaseID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=Release.ReleaseID
+  PK PropertyID,StartReleaseID
+TABLE Reference
+  COL ConceptGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=False pk=True ai=auto fks=Concept.ConceptGUID
+  COL RowGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=True pk=False ai=auto fks=
+  COL SubdivisionID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=Subdivision.SubdivisionID
+  PK SubdivisionID,ConceptGUID
+TABLE RelatedConcept
+  COL ConceptGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=False pk=True ai=auto fks=Concept.ConceptGUID
+  COL ConceptRelationID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=ConceptRelation.ConceptRelationID
+  COL IsRelatedConcept pg=BOOLEAN mssql=BIT null=True pk=False ai=auto fks=
+  COL RowGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=True pk=False ai=auto fks=
+  PK ConceptGUID,ConceptRelationID
+TABLE Release
+  COL Code pg=VARCHAR(20) mssql=VARCHAR(20) null=True pk=False ai=auto fks=
+  COL Date pg=DATE mssql=DATETIME null=True pk=False ai=auto fks=
+  COL Description pg=VARCHAR(255) mssql=VARCHAR(255) null=True pk=False ai=auto fks=
+  COL Error pg=VARCHAR(4000) mssql=VARCHAR(4000) null=True pk=False ai=auto fks=
+  COL ErrorDate pg=TIMESTAMP WITHOUT TIME ZONE mssql=DATETIME null=True pk=False ai=auto fks=
+  COL IsCurrent pg=BOOLEAN mssql=BIT null=True pk=False ai=auto fks=
+  COL OwnerID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Organisation.OrgID
+  COL ReleaseID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=
+  COL RowGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=True pk=False ai=auto fks=Concept.ConceptGUID
+  COL Status pg=VARCHAR(50) mssql=VARCHAR(50) null=True pk=False ai=auto fks=
+  COL Type pg=VARCHAR(20) mssql=VARCHAR(20) null=True pk=False ai=auto fks=
+  PK ReleaseID
+TABLE Role
+  COL Name pg=VARCHAR(50) mssql=VARCHAR(50) null=True pk=False ai=auto fks=
+  COL RoleID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=
+  PK RoleID
+TABLE SubCategory
+  COL CategoryID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Category.CategoryID
+  COL Code pg=VARCHAR(30) mssql=VARCHAR(30) null=True pk=False ai=auto fks=
+  COL Description pg=VARCHAR(500) mssql=VARCHAR(500) null=True pk=False ai=auto fks=
+  COL Name pg=VARCHAR(500) mssql=VARCHAR(500) null=True pk=False ai=auto fks=
+  COL OwnerID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Organisation.OrgID
+  COL RowGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=True pk=False ai=auto fks=Concept.ConceptGUID
+  COL SubCategoryID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=
+  PK SubCategoryID
+TABLE SubCategoryItem
+  COL ArithmeticOperatorID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Operator.OperatorID
+  COL ComparisonOperatorID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Operator.OperatorID
+  COL ItemID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=Item.ItemID
+  COL Label pg=VARCHAR(200) mssql=VARCHAR(200) null=True pk=False ai=auto fks=
+  COL Order pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=
+  COL ParentItemID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Item.ItemID
+  COL RowGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=True pk=False ai=auto fks=Concept.ConceptGUID
+  COL SubCategoryVID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=SubCategoryVersion.SubCategoryVID
+  PK ItemID,SubCategoryVID
+TABLE SubCategoryVersion
+  COL EndReleaseID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Release.ReleaseID
+  COL RowGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=True pk=False ai=auto fks=Concept.ConceptGUID
+  COL StartReleaseID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Release.ReleaseID
+  COL SubCategoryID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=SubCategory.SubCategoryID
+  COL SubCategoryVID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=
+  PK SubCategoryVID
+  UNIQUE SubCategoryID,StartReleaseID
+TABLE Subdivision
+  COL DocumentVID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=DocumentVersion.DocumentVID
+  COL Number pg=VARCHAR(20) mssql=VARCHAR(20) null=True pk=False ai=auto fks=
+  COL OwnerID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Organisation.OrgID
+  COL ParentSubdivisionID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Subdivision.SubdivisionID
+  COL RowGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=True pk=False ai=auto fks=Concept.ConceptGUID
+  COL StructurePath pg=VARCHAR(255) mssql=VARCHAR(255) null=True pk=False ai=auto fks=
+  COL SubdivisionID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=
+  COL SubdivisionTypeID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=SubdivisionType.SubdivisionTypeID
+  COL TextExcerpt pg=TEXT mssql=TEXT null=True pk=False ai=auto fks=
+  PK SubdivisionID
+TABLE SubdivisionType
+  COL Description pg=VARCHAR(255) mssql=VARCHAR(255) null=True pk=False ai=auto fks=
+  COL Name pg=VARCHAR(50) mssql=VARCHAR(50) null=True pk=False ai=auto fks=
+  COL SubdivisionTypeID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=
+  PK SubdivisionTypeID
+TABLE SuperCategoryComposition
+  COL CategoryID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=Category.CategoryID
+  COL EndReleaseID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Release.ReleaseID
+  COL RowGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=True pk=False ai=auto fks=
+  COL StartReleaseID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Release.ReleaseID
+  COL SuperCategoryID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=Category.CategoryID
+  PK SuperCategoryID,CategoryID
+TABLE Table
+  COL HasOpenColumns pg=BOOLEAN mssql=BIT null=True pk=False ai=auto fks=
+  COL HasOpenRows pg=BOOLEAN mssql=BIT null=True pk=False ai=auto fks=
+  COL HasOpenSheets pg=BOOLEAN mssql=BIT null=True pk=False ai=auto fks=
+  COL IsAbstract pg=BOOLEAN mssql=BIT null=True pk=False ai=auto fks=
+  COL IsFlat pg=BOOLEAN mssql=BIT null=True pk=False ai=auto fks=
+  COL IsNormalised pg=BOOLEAN mssql=BIT null=True pk=False ai=auto fks=
+  COL OwnerID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Organisation.OrgID
+  COL RowGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=True pk=False ai=auto fks=Concept.ConceptGUID
+  COL TableID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=
+  PK TableID
+TABLE TableAssociation
+  COL AssociationID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=
+  COL ChildCardinalityAndOptionality pg=VARCHAR(3) mssql=VARCHAR(3) null=True pk=False ai=auto fks=
+  COL ChildTableVID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=TableVersion.TableVID
+  COL Description pg=VARCHAR(255) mssql=VARCHAR(255) null=True pk=False ai=auto fks=
+  COL IsIdentifying pg=BOOLEAN mssql=BIT null=True pk=False ai=auto fks=
+  COL IsSubtype pg=BOOLEAN mssql=BIT null=True pk=False ai=auto fks=
+  COL Name pg=VARCHAR(50) mssql=VARCHAR(50) null=True pk=False ai=auto fks=
+  COL OwnerID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Organisation.OrgID
+  COL ParentCardinalityAndOptionality pg=VARCHAR(3) mssql=VARCHAR(3) null=True pk=False ai=auto fks=
+  COL ParentTableVID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=TableVersion.TableVID
+  COL RowGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=True pk=False ai=auto fks=Concept.ConceptGUID
+  COL SubtypeDiscriminator pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Header.HeaderID
+  PK AssociationID
+TABLE TableGroup
+  COL Code pg=VARCHAR(255) mssql=VARCHAR(255) null=True pk=False ai=auto fks=
+  COL Description pg=VARCHAR(2000) mssql=VARCHAR(2000) null=True pk=False ai=auto fks=
+  COL EndReleaseID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Release.ReleaseID
+  COL Name pg=VARCHAR(255) mssql=VARCHAR(255) null=True pk=False ai=auto fks=
+  COL OwnerID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Organisation.OrgID
+  COL ParentTableGroupID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=TableGroup.TableGroupID
+  COL RowGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=True pk=False ai=auto fks=Concept.ConceptGUID
+  COL StartReleaseID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Release.ReleaseID
+  COL TableGroupID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=
+  COL Type pg=VARCHAR(20) mssql=VARCHAR(20) null=True pk=False ai=auto fks=
+  PK TableGroupID
+TABLE TableGroupComposition
+  COL EndReleaseID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Release.ReleaseID
+  COL Order pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=
+  COL RowGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=True pk=False ai=auto fks=
+  COL StartReleaseID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Release.ReleaseID
+  COL TableGroupID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=TableGroup.TableGroupID
+  COL TableID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=Table.TableID
+  PK TableGroupID,TableID
+TABLE TableVersion
+  COL AbstractTableID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Table.TableID
+  COL Code pg=VARCHAR(30) mssql=VARCHAR(30) null=True pk=False ai=auto fks=
+  COL ContextID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Context.ContextID
+  COL Description pg=VARCHAR(500) mssql=VARCHAR(500) null=True pk=False ai=auto fks=
+  COL EndReleaseID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Release.ReleaseID
+  COL KeyID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=CompoundKey.KeyID
+  COL Name pg=VARCHAR(255) mssql=VARCHAR(255) null=True pk=False ai=auto fks=
+  COL PropertyID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Property.PropertyID
+  COL RowGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=True pk=False ai=auto fks=Concept.ConceptGUID
+  COL StartReleaseID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Release.ReleaseID
+  COL TableID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Table.TableID
+  COL TableVID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=
+  PK TableVID
+  UNIQUE TableID,StartReleaseID
+TABLE TableVersionCell
+  COL CellCode pg=VARCHAR(100) mssql=VARCHAR(100) null=True pk=False ai=auto fks=
+  COL CellID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=Cell.CellID
+  COL IsExcluded pg=BOOLEAN mssql=BIT null=True pk=False ai=auto fks=
+  COL IsNullable pg=BOOLEAN mssql=BIT null=True pk=False ai=auto fks=
+  COL IsVoid pg=BOOLEAN mssql=BIT null=True pk=False ai=auto fks=
+  COL RowGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=True pk=False ai=auto fks=
+  COL Sign pg=VARCHAR(8) mssql=VARCHAR(8) null=True pk=False ai=auto fks=
+  COL TableVID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=TableVersion.TableVID
+  COL VariableVID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=VariableVersion.VariableVID
+  PK TableVID,CellID
+TABLE TableVersionHeader
+  COL HeaderID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=Header.HeaderID
+  COL HeaderVID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=HeaderVersion.HeaderVID
+  COL IsAbstract pg=BOOLEAN mssql=BIT null=True pk=False ai=auto fks=
+  COL IsUnique pg=BOOLEAN mssql=BIT null=True pk=False ai=auto fks=
+  COL Order pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=
+  COL ParentFirst pg=BOOLEAN mssql=BIT null=True pk=False ai=auto fks=
+  COL ParentHeaderID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Header.HeaderID
+  COL RowGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=True pk=False ai=auto fks=
+  COL TableVID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=TableVersion.TableVID
+  PK TableVID,HeaderID
+TABLE Translation
+  COL AttributeID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=DPMAttribute.AttributeID
+  COL ConceptGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=False pk=True ai=auto fks=Concept.ConceptGUID
+  COL LanguageCode pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=Language.LanguageCode
+  COL RowGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=True pk=False ai=auto fks=
+  COL Translation pg=TEXT mssql=TEXT null=True pk=False ai=auto fks=
+  COL TranslatorID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=Organisation.OrgID
+  PK ConceptGUID,AttributeID,TranslatorID,LanguageCode
+TABLE User
+  COL Name pg=VARCHAR(50) mssql=VARCHAR(50) null=True pk=False ai=auto fks=
+  COL OrgID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Organisation.OrgID
+  COL UserID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=
+  PK UserID
+TABLE UserRole
+  COL RoleID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=Role.RoleID
+  COL UserID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=User.UserID
+  PK UserID,RoleID
+TABLE Variable
+  COL OwnerID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Organisation.OrgID
+  COL RowGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=True pk=False ai=auto fks=Concept.ConceptGUID
+  COL Type pg=VARCHAR(20) mssql=VARCHAR(20) null=True pk=False ai=auto fks=
+  COL VariableID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=
+  PK VariableID
+TABLE VariableCalculation
+  COL FromReferenceDate pg=DATE mssql=DATETIME null=True pk=False ai=auto fks=
+  COL ModuleID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=Module.ModuleID
+  COL OperationVID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=OperationVersion.OperationVID
+  COL RowGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=True pk=False ai=auto fks=
+  COL ToReferenceDate pg=DATE mssql=DATETIME null=True pk=False ai=auto fks=
+  COL VariableID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=Variable.VariableID
+  PK ModuleID,VariableID,OperationVID
+TABLE VariableGeneration
+  COL EndDate pg=TIMESTAMP WITHOUT TIME ZONE mssql=DATETIME null=True pk=False ai=auto fks=
+  COL Error pg=VARCHAR(4000) mssql=VARCHAR(4000) null=True pk=False ai=auto fks=
+  COL ReleaseID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Release.ReleaseID
+  COL StartDate pg=TIMESTAMP WITHOUT TIME ZONE mssql=DATETIME null=True pk=False ai=auto fks=
+  COL Status pg=VARCHAR(50) mssql=VARCHAR(50) null=True pk=False ai=auto fks=
+  COL VariableGenerationID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=
+  PK VariableGenerationID
+TABLE VariableVersion
+  COL Code pg=VARCHAR(20) mssql=VARCHAR(20) null=True pk=False ai=auto fks=
+  COL ContextID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Context.ContextID
+  COL EndReleaseID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Release.ReleaseID
+  COL IsMultiValued pg=BOOLEAN mssql=BIT null=True pk=False ai=auto fks=
+  COL KeyID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=CompoundKey.KeyID
+  COL Name pg=VARCHAR(50) mssql=VARCHAR(50) null=True pk=False ai=auto fks=
+  COL PropertyID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Property.PropertyID
+  COL RowGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=True pk=False ai=auto fks=Concept.ConceptGUID
+  COL StartReleaseID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Release.ReleaseID
+  COL SubCategoryVID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=SubCategoryVersion.SubCategoryVID
+  COL VariableID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Variable.VariableID
+  COL VariableVID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=
+  PK VariableVID
+  UNIQUE VariableID,StartReleaseID

--- a/tests/unit/orm/test_base_to_dict.py
+++ b/tests/unit/orm/test_base_to_dict.py
@@ -11,22 +11,20 @@ from __future__ import annotations
 from typing import Optional
 
 import pytest
-from sqlalchemy import Integer, String, create_engine
-from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column
+from sqlalchemy import Column, Integer, String, create_engine
+from sqlalchemy.orm import Session, declarative_base, deferred
 
+from dpmcore.orm._compat import Mapped, mapped_column
 from dpmcore.orm.base import Base
 
-
-class _IsolatedBase(DeclarativeBase):
-    """Isolated declarative base for to_dict tests.
-
-    Lives on its own ``registry`` / ``MetaData`` so the test table never
-    pollutes ``Base.metadata`` — which schema-validation tests read at
-    pytest collection time. ``Base.to_dict`` is reused unchanged so the
-    test still exercises the real implementation.
-    """
-
-    to_dict = Base.to_dict
+# Isolated declarative base on its own registry / MetaData so the test
+# table never pollutes ``Base.metadata`` — which schema-validation tests
+# read at pytest collection time. ``declarative_base()`` is used (rather
+# than subclassing ``DeclarativeBase``) so the module imports on both
+# SQLAlchemy 1.4 and 2.0; ``Base.to_dict`` is reused unchanged so the test
+# still exercises the real implementation.
+_IsolatedBase = declarative_base()
+_IsolatedBase.to_dict = Base.to_dict
 
 
 class _Item(_IsolatedBase):
@@ -34,7 +32,9 @@ class _Item(_IsolatedBase):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     code: Mapped[Optional[str]] = mapped_column(String(20))
-    payload: Mapped[Optional[str]] = mapped_column(String(2000), deferred=True)
+    # deferred() wraps a classic Column so the deferred strategy resolves
+    # identically on 1.4 and 2.0 (mapped_column(deferred=True) is 2.0-only).
+    payload = deferred(Column(String(2000)))
 
 
 @pytest.fixture

--- a/tests/unit/orm/test_schema_equivalence.py
+++ b/tests/unit/orm/test_schema_equivalence.py
@@ -1,0 +1,85 @@
+"""Schema-equivalence regression guard (issue #104).
+
+dpmcore's ORM must emit an identical database schema on SQLAlchemy 1.4.50
+(the python3-sqlalchemy apt package on Ubuntu 24.04) and on 2.0.x. This
+test serialises ``Base.metadata`` to a canonical, dialect-aware
+description and compares it to a committed snapshot.
+
+Because 1.4 and 2.0 produce byte-identical canonical output, the snapshot
+is a single source of truth: the 2.0 (poetry) CI job and the 1.4 (Noble
+apt) CI job each verify their SQLAlchemy version matches it, which
+together guarantees the two schemas agree. Types are rendered against
+both the PostgreSQL and SQL Server dialects because SQLite — used by the
+rest of the suite — ignores ``VARCHAR`` lengths and is lax about
+``NOT NULL``, hiding exactly the drift this test exists to catch.
+
+Regenerate after an *intentional* schema change (review the diff!) by
+running this module as a script and redirecting stdout to the snapshot
+file ``tests/unit/orm/_schema_snapshot.txt``.
+"""
+
+from pathlib import Path
+
+from sqlalchemy import UniqueConstraint
+from sqlalchemy.dialects import mssql, postgresql
+
+# Importing Base also executes dpmcore.orm.__init__, which registers
+# every model on Base.metadata (needed for the full-schema snapshot).
+from dpmcore.orm import Base
+
+SNAPSHOT = Path(__file__).parent / "_schema_snapshot.txt"
+_DIALECTS = (("pg", postgresql.dialect()), ("mssql", mssql.dialect()))
+
+
+def canonical_schema() -> str:
+    """Return a deterministic, dialect-aware description of the schema."""
+    lines: list[str] = []
+    for table in sorted(Base.metadata.tables.values(), key=lambda t: t.name):
+        lines.append(f"TABLE {table.name}")
+        for col in sorted(table.columns, key=lambda c: c.name):
+            types = " ".join(
+                f"{name}={col.type.compile(dialect=dialect)}"
+                for name, dialect in _DIALECTS
+            )
+            ai = (
+                "auto"
+                if col.autoincrement in (True, "auto")
+                else str(col.autoincrement)
+            )
+            fks = ",".join(
+                sorted(fk.target_fullname for fk in col.foreign_keys)
+            )
+            lines.append(
+                f"  COL {col.name} {types} null={col.nullable} "
+                f"pk={col.primary_key} ai={ai} fks={fks}"
+            )
+        lines.append(
+            "  PK " + ",".join(c.name for c in table.primary_key.columns)
+        )
+        uniques = sorted(
+            tuple(c.name for c in con.columns)
+            for con in table.constraints
+            if isinstance(con, UniqueConstraint)
+        )
+        for cols in uniques:
+            lines.append("  UNIQUE " + ",".join(cols))
+        for idx in sorted(table.indexes, key=lambda i: i.name or ""):
+            cols = ",".join(c.name for c in idx.columns)
+            lines.append(f"  INDEX {idx.name} {cols}")
+    return "\n".join(lines) + "\n"
+
+
+def test_schema_matches_snapshot() -> None:
+    """Current ORM schema must match the committed canonical snapshot."""
+    expected = SNAPSHOT.read_text()
+    actual = canonical_schema()
+    assert actual == expected, (
+        "ORM schema drifted from tests/unit/orm/_schema_snapshot.txt. "
+        "If this change is intentional, regenerate the snapshot (see the "
+        "module docstring) and review the diff carefully — it may mean a "
+        "1.4/2.0 incompatibility or an unintended NOT NULL/type change."
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    print(canonical_schema(), end="")


### PR DESCRIPTION
## Summary

Ubuntu 24.04 (Noble) ships `python3-sqlalchemy` **1.4.50** via apt, but dpmcore's ORM required 2.0-only APIs, forcing the Noble CI job to `pip install --break-system-packages "sqlalchemy>=2.0,<3.0"`. This makes the ORM run unchanged on **both 1.4.50 and 2.0.x**, lowers the floor to `>=1.4.50,<3.0` (2.0 stays the canonical/typed target), and switches the Noble CI to the apt package with no pip override.

Closes #104.

Key changes:
- **`src/dpmcore/orm/_compat.py`** (new) — version shim: aliases `mapped_column`→`Column` and re-exports `Mapped` on 1.4; `TYPE_CHECKING`-guarded so mypy always sees the 2.0 types.
- **`base.py`** — declarative base built per version (`DeclarativeBase` on 2.0, `declarative_base(cls=...)` on 1.4); engines/sessions use `future=True` so 1.4 gets 2.0-style `Connection`/`Session` semantics; `to_dict` uses `object_mapper()`.
- **~291 `relationship()` calls** got explicit target strings (LibCST codemod) — 1.4 does not infer targets from `Mapped[...]` annotations.
- **2 `action_id` columns** made explicit `nullable=False` (the only annotation-inferred NOT NULL).
- **7 files** import `Engine`/`Connection` from `sqlalchemy.engine` (valid on 1.4 + 2.0).
- **`structure.py`** — replaced `Row._tuple()` (2.0-only) with index access.
- **`ubuntu_test_24_04.yml`** — install `python3-sqlalchemy` via apt; drop the pip override.
- **`tests/unit/orm/test_schema_equivalence.py`** (new) — a dialect-aware schema snapshot (compiled against PostgreSQL + SQL Server) proving 1.4 and 2.0 emit an identical schema.

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy --strict`)
- [x] Tests pass (`pytest`) — see Notes re: coverage gate
- [ ] Documentation updated (n/a — internal compatibility change)

## Impact / Risk

- **Breaking changes?** None. No public API / CLI / REST / Django model changes. ORM model behaviour is unchanged.
- **Database schema / migration concerns?** None — the emitted schema is **byte-identical** across 1.4.50 and 2.0.50 (68 tables; column types vs PostgreSQL+SQL Server, nullability, PK/FK/unique/index), verified by the new `test_schema_equivalence.py` and a one-off DDL diff.
- **Release/changelog:** dpmcore now supports SQLAlchemy 1.4.50 (Noble apt) alongside 2.0.x; dependency floor lowered to `>=1.4.50,<3.0`.

## Notes

- **Verification:** full suite green on **2.0.50** (1243 passed, 107 skipped) and on the **Noble-faithful 1.4.50 stack** — sqlalchemy 1.4.50 + pandas 2.1.4 + numpy 1.26.4 (1243 passed, 107 skipped). `mypy --strict` clean on 99 files.
- **pandas gotcha:** the *latest* pandas (2.2+/2.3) dropped SQLAlchemy-1.4 `to_sql` support; Noble's apt **pandas 2.1.4** works. Don't raise the pandas floor without re-checking the 1.4 `to_sql` path. (The Noble CI installs the wheel `--no-dependencies`, so it uses apt pandas 2.1.4.)
- **Coverage:** the 100% branch-coverage gate is currently disabled in `testing.yml` (`--cov-fail-under=0`, pending the `py_dpm` port). Version-specific shim branches carry `# pragma: no cover` so the gate stays green when re-enabled.
- `poetry.lock` only changes its content-hash (SQLAlchemy stays locked at 2.0.50 for the dev/wheel path).
