### PR TITLE
Fix: scope calculation errors

### DIFF
--- a/src/dpmcore/dpm_xl/model_queries.py
+++ b/src/dpmcore/dpm_xl/model_queries.py
@@ -64,6 +64,23 @@ if TYPE_CHECKING:
 # Helper utilities
 # ------------------------------------------------------------------ #
 
+# The DPM 2.0 Refit schema stores the filing-indicator variable type as
+# the single token "filingindicator". Some source exports spell it
+# "Filing Indicator" (with a space and capitals), so matching is done on
+# a case- and whitespace-normalised form rather than a fixed literal.
+_FILING_INDICATOR_TYPE = "filingindicator"
+
+
+def _is_filing_indicator() -> Any:
+    """Return a SQLAlchemy clause matching filing-indicator variables.
+
+    Normalises ``Variable.type`` (lower-cased, spaces removed) before
+    comparison so the match is robust to spelling variants across DPM
+    source exports (``"Filing Indicator"`` vs ``"filingindicator"``).
+    """
+    normalized = func.lower(func.replace(Variable.type, " ", ""))
+    return normalized == _FILING_INDICATOR_TYPE
+
 
 def _get_engine_cache_key(session: "Session") -> Hashable:
     """Return a hashable key that identifies the engine.
@@ -343,8 +360,8 @@ class VariableVersionQuery:
         """Find a filing-indicator variable by code.
 
         Looks for a VariableVersion whose code matches
-        *variable_code* and whose Variable type is
-        ``'Filing Indicator'``.
+        *variable_code* and whose Variable type is a
+        filing indicator (see :func:`_is_filing_indicator`).
 
         Args:
             session: SQLAlchemy session.
@@ -366,7 +383,7 @@ class VariableVersionQuery:
             )
             .filter(
                 VariableVersion.code == variable_code,
-                Variable.type == "Filing Indicator",
+                _is_filing_indicator(),
             )
         )
         if release_id is not None:
@@ -485,7 +502,7 @@ class VariableVersionQuery:
                 Variable,
                 VariableVersion.variable_id == Variable.variable_id,
             )
-            .filter(Variable.type == "Filing Indicator")
+            .filter(_is_filing_indicator())
         )
         if release_id is not None:
             query = query.filter(
@@ -879,7 +896,7 @@ class ModuleVersionQuery:
                 VariableVersion.variable_id == Variable.variable_id,
             )
             .filter(VariableVersion.code.in_(precondition_items))
-            .filter(Variable.type == "Filing Indicator")
+            .filter(_is_filing_indicator())
         )
         if release_id is not None:
             query = query.filter(

--- a/src/dpmcore/dpm_xl/utils/scopes_calculator.py
+++ b/src/dpmcore/dpm_xl/utils/scopes_calculator.py
@@ -112,8 +112,11 @@ class OperationScopeService:
 
             # When using table_codes, unique operands are based on table codes, not table VIDs
             if table_codes:
-                unique_operands_number = len(table_codes) + len(
-                    precondition_items
+                # A module hosts an intra-instance scope only when it
+                # covers every distinct referenced table code AND every
+                # distinct precondition (filing-indicator) code.
+                unique_operands_number = len(set(table_codes)) + len(
+                    set(precondition_items)
                 )
 
                 # First pass: categorize modules by table code and lifecycle
@@ -128,13 +131,24 @@ class OperationScopeService:
                     modules_info_dataframe.groupby(MODULE_VID),
                 )
                 for module_vid, group_df in code_groups:
+                    # Referenced table codes this module contains. Drop
+                    # NaN: precondition rows carry their code in "Code",
+                    # not "TableCode", so leaving the NaN in would inflate
+                    # the count by one spurious bucket.
                     table_codes_in_module: list[str] = (
                         cast(
                             list[str],
-                            group_df["TableCode"].unique().tolist(),
+                            group_df["TableCode"].dropna().unique().tolist(),
                         )
                         if "TableCode" in group_df.columns
                         else []
+                    )
+                    # Distinct precondition codes this module provides
+                    # (filing indicators live in the "Code" column).
+                    precondition_codes_in_module = (
+                        int(group_df["Code"].dropna().nunique())
+                        if "Code" in group_df.columns
+                        else 0
                     )
 
                     # Get module lifecycle info
@@ -147,7 +161,11 @@ class OperationScopeService:
                     # Determine if this is a "new" module starting in this release
                     is_starting = start_release == release_id
 
-                    if len(table_codes_in_module) == unique_operands_number:
+                    operands_in_module = (
+                        len(table_codes_in_module)
+                        + precondition_codes_in_module
+                    )
+                    if operands_in_module == unique_operands_number:
                         # Intra-module: include ALL modules active in the release
                         intra_modules.append(module_vid)
                     else:
@@ -233,48 +251,102 @@ class OperationScopeService:
             if len(intra_modules):
                 self.process_repeated(intra_modules, modules_info_dataframe)
 
+            required_preconditions = set(precondition_items)
             if cross_modules:
-                # When using table_codes with lifecycle grouping
-                if table_codes and (
-                    "_starting" in cross_modules or "_ending" in cross_modules
-                ):
-                    # Process each generation separately
-                    if "_starting" in cross_modules:
-                        self.process_cross_module(
-                            cross_modules=cross_modules["_starting"],
-                            modules_dataframe=modules_info_dataframe,
-                        )
-                    if "_ending" in cross_modules:
-                        self.process_cross_module(
-                            cross_modules=cross_modules["_ending"],
-                            modules_dataframe=modules_info_dataframe,
-                        )
-                # Legacy table_codes without lifecycle grouping
-                elif table_codes or set(cross_modules.keys()) == set(
-                    tables_vids
-                ):
-                    self.process_cross_module(
-                        cross_modules=cross_modules,
-                        modules_dataframe=modules_info_dataframe,
-                    )
-                else:
-                    # add the missing table_vids to cross_modules
-                    for table_vid in tables_vids:
-                        if table_vid not in cross_modules:
-                            cross_modules[table_vid] = (
-                                modules_info_dataframe[
-                                    modules_info_dataframe[VARIABLE_VID]
-                                    == table_vid
-                                ][MODULE_VID]
-                                .unique()
-                                .tolist()
+                if table_codes:
+                    required_codes = set(table_codes)
+                    if (
+                        "_starting" in cross_modules
+                        or "_ending" in cross_modules
+                    ):
+                        # Lifecycle grouping: complete and process each
+                        # generation independently.
+                        for generation in ("_starting", "_ending"):
+                            pool = cross_modules.get(generation)
+                            if not pool:
+                                continue
+                            self._supplement_missing_codes(
+                                pool, required_codes, modules_info_dataframe
                             )
+                            self.process_cross_module(
+                                cross_modules=pool,
+                                modules_dataframe=modules_info_dataframe,
+                                required_keys=required_codes,
+                                required_precondition_codes=(
+                                    required_preconditions
+                                ),
+                            )
+                    else:
+                        # Complete each partial module into a cross-instance
+                        # scope by pulling its missing table codes from the
+                        # modules that provide them (Issue #119/#120), then
+                        # build the combinations.
+                        self._supplement_missing_codes(
+                            cross_modules,
+                            required_codes,
+                            modules_info_dataframe,
+                        )
+                        self.process_cross_module(
+                            cross_modules=cross_modules,
+                            modules_dataframe=modules_info_dataframe,
+                            required_keys=required_codes,
+                            required_precondition_codes=required_preconditions,
+                        )
+                else:
+                    # Table-VID path: supplement any referenced table VID
+                    # not yet present, then build the cross combinations.
+                    self._supplement_missing_codes(
+                        cross_modules,
+                        set(tables_vids),
+                        modules_info_dataframe,
+                        key_column=VARIABLE_VID,
+                    )
                     self.process_cross_module(
                         cross_modules=cross_modules,
                         modules_dataframe=modules_info_dataframe,
+                        required_keys=set(tables_vids),
+                        required_precondition_codes=required_preconditions,
                     )
 
         return self.get_scopes_with_status()
+
+    @staticmethod
+    def _supplement_missing_codes(
+        pool: dict[Any, list[int]],
+        required_codes: set[Any],
+        modules_dataframe: pd.DataFrame,
+        key_column: str = "TableCode",
+    ) -> None:
+        """Add providers for referenced operands absent from *pool*.
+
+        A partial module contributes only the operands it actually holds,
+        so an operand it lacks would be missing from the Cartesian product
+        and yield an incomplete single-module scope. For each such operand,
+        register every module that provides it — looked up in *key_column*
+        (``"TableCode"`` for the table-code path, the variable-VID column
+        for the table-VID path) — so the product pairs the partial module
+        with a provider into a complete cross-instance scope
+        (Issue #119/#120). Operands already present are left untouched to
+        avoid re-pairing a partial module with itself.
+
+        Pairing modules from non-overlapping lifecycle generations is
+        prevented downstream: :meth:`process_cross_module` drops any
+        combination whose reference-date windows do not overlap.
+        """
+        if key_column not in modules_dataframe.columns:
+            return
+        for code in required_codes:
+            if code in pool:
+                continue
+            providers: list[int] = (
+                modules_dataframe[modules_dataframe[key_column] == code][
+                    MODULE_VID
+                ]
+                .unique()
+                .tolist()
+            )
+            if providers:
+                pool[code] = providers
 
     def extract_module_info(
         self,
@@ -402,11 +474,33 @@ class OperationScopeService:
         self,
         cross_modules: dict[Any, list[int]],
         modules_dataframe: pd.DataFrame,
+        required_keys: Iterable[Any] | None = None,
+        required_precondition_codes: Iterable[Any] | None = None,
     ) -> None:
         """Method to calculate OperationScope and OperationScopeComposition tables for a cross module operation
         :param cross_modules: dictionary with table version ids as key and its module version ids as values
         :param modules_dataframe: dataframe with modules data.
+        :param required_keys: full set of referenced operand keys (table
+            codes or table VIDs) the combination must cover. When the
+            cross-module pool does not span every required key, no single
+            module nor combination of modules can evaluate the operation,
+            so no scope is emitted. ``None`` disables the check.
+        :param required_precondition_codes: gating precondition (filing
+            indicator) codes; a combination is emitted only if its modules
+            collectively report all of them (Issue #120). ``None``/empty
+            disables the check.
         """
+        # Table coverage: each generated combination provides exactly the
+        # pool's key set (one module per key), and supplementation in
+        # ``calculate_operation_scope`` already ensures the pool spans every
+        # required table code. This guard is a defensive backstop — if the
+        # pool still lacks a required key (a code with no provider at all),
+        # no combination can evaluate the operation, so emit nothing.
+        if required_keys is not None and not set(cross_modules).issuperset(
+            required_keys
+        ):
+            return
+
         modules_dataframe[FROM_REFERENCE_DATE] = pd.to_datetime(
             modules_dataframe[FROM_REFERENCE_DATE],
             format="mixed",
@@ -423,8 +517,21 @@ class OperationScopeService:
             if vid not in module_lookup:
                 module_lookup[vid] = row
 
+        # Distinct precondition codes each module reports, so a combination
+        # can be checked for full precondition coverage.
+        req_preconditions = set(required_precondition_codes or [])
+        precond_by_module: dict[int, set[Any]] = {}
+        if req_preconditions and "Code" in modules_dataframe.columns:
+            code_groups = cast(
+                Iterable[tuple[int, pd.DataFrame]],
+                modules_dataframe.groupby(MODULE_VID),
+            )
+            for vid, grp in code_groups:
+                precond_by_module[int(vid)] = set(grp["Code"].dropna())
+
         values = cross_modules.values()
         for combination in product(*values):
+            unique_combination = set(combination)
             combination_info = modules_dataframe[
                 modules_dataframe[MODULE_VID].isin(combination)
             ]
@@ -433,21 +540,32 @@ class OperationScopeService:
             ref_from_date = from_dates.max()
             ref_to_date = to_dates.min()
 
-            is_valid_combination = True
-            for from_date, to_date in zip(from_dates, to_dates, strict=False):
-                if to_date < ref_from_date or (
-                    (not pd.isna(ref_to_date)) and from_date > ref_to_date
-                ):
-                    is_valid_combination = False
-                    break  # No need to check remaining dates
+            # Modules in a combination must share an overlapping
+            # reference-date window; otherwise they are never reported
+            # together (e.g. different lifecycle generations) and the
+            # combination is not a real scope (Issue #119/#120).
+            overlaps = all(
+                not (
+                    to_date < ref_from_date
+                    or ((not pd.isna(ref_to_date)) and from_date > ref_to_date)
+                )
+                for from_date, to_date in zip(
+                    from_dates, to_dates, strict=False
+                )
+            )
+            if not overlaps:
+                continue
 
-            from_submission_date: Any
-            if is_valid_combination:
-                from_submission_date = ref_from_date
-            else:
-                from_submission_date = None
-            operation_scope = self.create_operation_scope(from_submission_date)
-            unique_combination = set(combination)
+            # Every gating precondition must be reported by some module in
+            # the combination, else it cannot evaluate the operation.
+            if req_preconditions:
+                covered: set[Any] = set()
+                for module in unique_combination:
+                    covered |= precond_by_module.get(module, set())
+                if not covered.issuperset(req_preconditions):
+                    continue
+
+            operation_scope = self.create_operation_scope(ref_from_date)
             for module in unique_combination:
                 module_row = module_lookup.get(module)
                 if module_row is None:

--- a/src/dpmcore/services/scope_calculator.py
+++ b/src/dpmcore/services/scope_calculator.py
@@ -273,7 +273,21 @@ class ScopeCalculatorService:
         is_cross = scope_result.is_cross_module
         ts = time_shifts or {}
 
-        if not is_cross or scope_result.has_error:
+        # Issue #120: when the primary module can evaluate the operation
+        # on its own (it appears as a single-module scope), prefer the
+        # intra-instance reading even if cross-instance scopes also exist
+        # for other modules. Only when the primary appears *solely* in
+        # multi-module scopes is it a genuine cross-instance dependency.
+        primary_has_intra = not scope_result.has_error and any(
+            {
+                c.module_vid
+                for c in getattr(s, "operation_scope_compositions", [])
+            }
+            == {primary_module_vid}
+            for s in scope_result.scopes or []
+        )
+
+        if scope_result.has_error or not is_cross or primary_has_intra:
             alternative_deps: List[List[str]] = []
             if compute_alternative_deps and not scope_result.has_error:
                 alternative_deps = self.detect_alternative_dependencies(
@@ -284,7 +298,9 @@ class ScopeCalculatorService:
             return {
                 **empty_result,
                 "intra_instance_validations": (
-                    [] if is_cross or not operation_code else [operation_code]
+                    [operation_code]
+                    if operation_code and (not is_cross or primary_has_intra)
+                    else []
                 ),
                 "alternative_dependencies": alternative_deps,
             }

--- a/tests/integration/queries/test_precondition_filing_indicator.py
+++ b/tests/integration/queries/test_precondition_filing_indicator.py
@@ -1,0 +1,114 @@
+"""Filing-indicator precondition resolution (model_queries Fix 1).
+
+The DPM 2.0 Refit source stores the filing-indicator variable type as the
+single token ``"filingindicator"``. ``ModuleVersionQuery`` previously
+filtered on the literal ``"Filing Indicator"`` (spaced/capitalised),
+which never matched, so preconditions could never be resolved. These
+tests pin the normalised match used by ``_is_filing_indicator``.
+"""
+
+import datetime
+
+import pytest
+
+from dpmcore.dpm_xl.model_queries import (
+    ModuleVersionQuery,
+    VariableVersionQuery,
+)
+from dpmcore.orm.packaging import ModuleParameters, ModuleVersion
+from dpmcore.orm.variables import Variable, VariableVersion
+
+pytestmark = pytest.mark.integration
+
+
+def _seed(session):
+    """Insert one module reporting two filing indicators.
+
+    The two filing indicators deliberately use *different* spellings of
+    the type (``"filingindicator"`` and ``"Filing Indicator"``) to prove
+    the normalised comparison matches both. A third ``"fact"`` variable
+    shares a code but must never be returned.
+    """
+    session.add_all(
+        [
+            Variable(variable_id=1, type="filingindicator"),
+            Variable(variable_id=2, type="Filing Indicator"),
+            Variable(variable_id=3, type="fact"),
+            VariableVersion(
+                variable_vid=1,
+                variable_id=1,
+                code="C_02.00",
+                start_release_id=1,
+                end_release_id=None,
+            ),
+            VariableVersion(
+                variable_vid=2,
+                variable_id=2,
+                code="C_25.00",
+                start_release_id=1,
+                end_release_id=None,
+            ),
+            # Same code as a filing indicator but type "fact" -> excluded.
+            VariableVersion(
+                variable_vid=3,
+                variable_id=3,
+                code="C_02.00",
+                start_release_id=1,
+                end_release_id=None,
+            ),
+            ModuleVersion(
+                module_vid=100,
+                module_id=1,
+                code="COREP_OF",
+                version_number="1.0",
+                start_release_id=1,
+                end_release_id=None,
+                from_reference_date=datetime.date(2023, 6, 30),
+                to_reference_date=None,
+            ),
+            ModuleParameters(module_vid=100, variable_vid=1),
+            ModuleParameters(module_vid=100, variable_vid=2),
+            ModuleParameters(module_vid=100, variable_vid=3),
+        ]
+    )
+    session.flush()
+
+
+def test_filing_indicators_resolve_for_both_spellings(memory_session):
+    _seed(memory_session)
+
+    df = ModuleVersionQuery.get_precondition_module_versions(
+        memory_session,
+        ["C_02.00", "C_25.00"],
+        release_id=1,
+    )
+
+    # Both filing indicators resolve, regardless of type spelling.
+    assert set(df["Code"]) == {"C_02.00", "C_25.00"}
+    assert set(df["ModuleCode"]) == {"COREP_OF"}
+
+
+def test_fact_typed_variable_is_not_a_precondition(memory_session):
+    _seed(memory_session)
+
+    df = ModuleVersionQuery.get_precondition_module_versions(
+        memory_session,
+        ["C_02.00"],
+        release_id=1,
+    )
+
+    # Only the filing-indicator C_02.00 (variable_vid 1), never the
+    # "fact" variable that shares the code (variable_vid 3).
+    assert list(df["Code"]) == ["C_02.00"]
+    assert df["variable_vid"].tolist() == [1]
+
+
+def test_check_precondition_finds_filing_indicator(memory_session):
+    _seed(memory_session)
+
+    row = VariableVersionQuery.check_precondition(
+        memory_session, "C_25.00", release_id=1
+    )
+
+    assert row is not None
+    assert row.Code == "C_25.00"

--- a/tests/unit/dpm_xl/test_scopes_lifecycle.py
+++ b/tests/unit/dpm_xl/test_scopes_lifecycle.py
@@ -71,6 +71,32 @@ def _make_module_df(rows):
     )
 
 
+def _make_combined_df(rows):
+    """Build a DataFrame mirroring the concat of table-code and
+    precondition queries.
+
+    Table rows carry their code in ``TableCode`` (``Code`` is NaN);
+    precondition rows carry it in ``Code`` (``TableCode`` is NaN) — the
+    exact shape ``extract_module_info`` produces when both table codes
+    and precondition items are present.
+    """
+    return pd.DataFrame(
+        rows,
+        columns=[
+            "ModuleVID",
+            "variable_vid",
+            "TableCode",
+            "Code",
+            "ModuleCode",
+            "VersionNumber",
+            "StartReleaseID",
+            "EndReleaseID",
+            "FromReferenceDate",
+            "ToReferenceDate",
+        ],
+    )
+
+
 def _get_svc_class():
     """Import OperationScopeService avoiding ORM chain."""
     mod_name = "dpmcore.dpm_xl.utils.scopes_calculator"
@@ -169,3 +195,263 @@ class TestLifecycleSupplement:
 
         assert len(captured_repeated) == 1
         assert 10 in captured_repeated[0]
+
+
+class TestPreconditionCoverage:
+    """Precondition codes count toward intra coverage (not the NaN
+    bucket of the TableCode column).
+    """
+
+    def test_full_module_with_two_preconditions_is_intra(self):
+        """A module covering every table code AND every precondition
+        code is intra, even with two preconditions.
+
+        Regression: previously ``unique_operands_number`` summed tables
+        and preconditions while the membership test counted
+        ``TableCode.unique()``, where all precondition rows collapse to
+        a single NaN. With two preconditions the full module failed the
+        test and was wrongly pushed into the cross-module pool.
+        """
+        rows = [
+            # Full module: tables A, B + preconditions pA, pB.
+            (
+                10,
+                100,
+                "A",
+                None,
+                "MOD_FULL",
+                "1.0",
+                1,
+                None,
+                "2020-01-01",
+                None,
+            ),
+            (
+                10,
+                200,
+                "B",
+                None,
+                "MOD_FULL",
+                "1.0",
+                1,
+                None,
+                "2020-01-01",
+                None,
+            ),
+            (
+                10,
+                0,
+                None,
+                "pA",
+                "MOD_FULL",
+                "1.0",
+                1,
+                None,
+                "2020-01-01",
+                None,
+            ),
+            (
+                10,
+                0,
+                None,
+                "pB",
+                "MOD_FULL",
+                "1.0",
+                1,
+                None,
+                "2020-01-01",
+                None,
+            ),
+            # Partial sibling: only table A + precondition pA.
+            (
+                20,
+                100,
+                "A",
+                None,
+                "MOD_PART",
+                "1.0",
+                1,
+                None,
+                "2020-01-01",
+                None,
+            ),
+            (
+                20,
+                0,
+                None,
+                "pA",
+                "MOD_PART",
+                "1.0",
+                1,
+                None,
+                "2020-01-01",
+                None,
+            ),
+        ]
+        df = _make_combined_df(rows)
+
+        SvcClass = _get_svc_class()
+        svc = SvcClass(session=MagicMock())
+
+        captured_intra = []
+        captured_cross = []
+        svc.process_repeated = lambda mvids, minfo: captured_intra.extend(
+            mvids
+        )
+        svc.process_cross_module = lambda **kwargs: captured_cross.append(
+            kwargs
+        )
+        svc.get_scopes_with_status = MagicMock(return_value=([], []))
+        svc.extract_module_info = MagicMock(return_value=df)
+
+        svc.calculate_operation_scope(
+            tables_vids=[],
+            precondition_items=["pA", "pB"],
+            release_id=1,
+            table_codes=["A", "B"],
+        )
+
+        # Full module is intra; partial module is not.
+        assert 10 in captured_intra
+        assert 20 not in captured_intra
+        # The partial module (20) contributes table code "A"; the missing
+        # code "B" is supplemented from the full module (10) so the cross
+        # pool covers the full operand set {A, B} and the product pairs
+        # 20 with 10 into a complete cross-instance scope (Issue #119/#120).
+        # No spurious NaN key leaks in from the precondition rows.
+        assert captured_cross
+        cross_modules = captured_cross[0]["cross_modules"]
+        assert set(cross_modules) == {"A", "B"}
+        assert cross_modules["A"] == [20]
+        assert 10 in cross_modules["B"]
+
+
+class TestCrossModuleCoverage:
+    """process_cross_module only emits combinations that cover every
+    required operand key.
+    """
+
+    @staticmethod
+    def _modules_df():
+        return pd.DataFrame(
+            [
+                (10, "MOD_A", "1.0", "2020-01-01", None),
+                (20, "MOD_B", "1.0", "2020-01-01", None),
+            ],
+            columns=[
+                "ModuleVID",
+                "ModuleCode",
+                "VersionNumber",
+                "FromReferenceDate",
+                "ToReferenceDate",
+            ],
+        )
+
+    def test_incomplete_coverage_emits_no_scope(self):
+        """A pool missing a required key produces no scope.
+
+        ``{"A": [20]}`` cannot satisfy required keys ``{"A", "B"}`` — the
+        partial module 20 would otherwise become a spurious single-module
+        scope that cannot evaluate the operation.
+        """
+        SvcClass = _get_svc_class()
+        svc = SvcClass(session=MagicMock())
+        svc.process_cross_module(
+            cross_modules={"A": [20]},
+            modules_dataframe=self._modules_df(),
+            required_keys={"A", "B"},
+        )
+        assert svc.operation_scopes == []
+
+    def test_complete_coverage_emits_scope(self):
+        """A pool spanning every required key produces a scope."""
+        SvcClass = _get_svc_class()
+        svc = SvcClass(session=MagicMock())
+        svc.process_cross_module(
+            cross_modules={"A": [10], "B": [20]},
+            modules_dataframe=self._modules_df(),
+            required_keys={"A", "B"},
+        )
+        assert len(svc.operation_scopes) == 1
+
+    def test_none_required_keys_disables_guard(self):
+        """``required_keys=None`` keeps the legacy unguarded behaviour."""
+        SvcClass = _get_svc_class()
+        svc = SvcClass(session=MagicMock())
+        svc.process_cross_module(
+            cross_modules={"A": [20]},
+            modules_dataframe=self._modules_df(),
+            required_keys=None,
+        )
+        assert len(svc.operation_scopes) == 1
+
+    def test_non_overlapping_dates_emit_no_scope(self):
+        """Modules whose reference-date windows do not overlap are never
+        reported together (e.g. different lifecycle generations), so the
+        combination is dropped rather than emitted (Issue #119/#120).
+        """
+        df = pd.DataFrame(
+            [
+                (10, "MOD_OLD", "1.0", "2020-01-01", "2024-12-31"),
+                (30, "MOD_NEW", "2.0", "2025-01-01", None),
+            ],
+            columns=[
+                "ModuleVID",
+                "ModuleCode",
+                "VersionNumber",
+                "FromReferenceDate",
+                "ToReferenceDate",
+            ],
+        )
+        SvcClass = _get_svc_class()
+        svc = SvcClass(session=MagicMock())
+        svc.process_cross_module(
+            cross_modules={"A": [10], "B": [30]},
+            modules_dataframe=df,
+            required_keys={"A", "B"},
+        )
+        assert svc.operation_scopes == []
+
+    @staticmethod
+    def _modules_df_with_preconditions():
+        # Module 10 reports filing indicator "P1"; module 20 reports none.
+        return pd.DataFrame(
+            [
+                (10, "MOD_A", "1.0", "2020-01-01", None, "P1"),
+                (20, "MOD_B", "1.0", "2020-01-01", None, None),
+            ],
+            columns=[
+                "ModuleVID",
+                "ModuleCode",
+                "VersionNumber",
+                "FromReferenceDate",
+                "ToReferenceDate",
+                "Code",
+            ],
+        )
+
+    def test_missing_precondition_emits_no_scope(self):
+        """A combination that does not report a gating precondition cannot
+        evaluate the operation, so it is dropped (Issue #120).
+        """
+        SvcClass = _get_svc_class()
+        svc = SvcClass(session=MagicMock())
+        svc.process_cross_module(
+            cross_modules={"T": [20]},  # module 20 reports no precondition
+            modules_dataframe=self._modules_df_with_preconditions(),
+            required_keys={"T"},
+            required_precondition_codes={"P1"},
+        )
+        assert svc.operation_scopes == []
+
+    def test_precondition_covered_emits_scope(self):
+        """A combination reporting every gating precondition is emitted."""
+        SvcClass = _get_svc_class()
+        svc = SvcClass(session=MagicMock())
+        svc.process_cross_module(
+            cross_modules={"T": [10]},  # module 10 reports P1
+            modules_dataframe=self._modules_df_with_preconditions(),
+            required_keys={"T"},
+            required_precondition_codes={"P1"},
+        )
+        assert len(svc.operation_scopes) == 1

--- a/tests/unit/services/test_prefer_intra.py
+++ b/tests/unit/services/test_prefer_intra.py
@@ -1,0 +1,96 @@
+"""Prefer-intra classification in detect_cross_module_dependencies.
+
+Issue #120: when a validation yields both an intra-instance scope (the
+primary module can evaluate it alone) and cross-instance scopes (a sibling
+module needs the primary to complete coverage), the primary module's script
+must treat it as intra-instance, while the sibling's script treats it as a
+cross-instance dependency.
+
+Imports the service normally (works on Python 3.11+) to avoid the legacy
+ORM-stubbing shim used elsewhere in the suite.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from dpmcore.services import scope_calculator as sc_mod
+from dpmcore.services.scope_calculator import (
+    ScopeCalculatorService,
+    ScopeResult,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _scope(module_vids):
+    """A scope whose compositions cover *module_vids*."""
+    return SimpleNamespace(
+        operation_scope_compositions=[
+            SimpleNamespace(module_vid=v) for v in module_vids
+        ]
+    )
+
+
+@pytest.fixture
+def svc(monkeypatch):
+    monkeypatch.setattr(
+        sc_mod,
+        "resolve_release_id",
+        lambda session, release_id=None, release_code=None: release_id,
+    )
+    service = ScopeCalculatorService(MagicMock())
+    service._get_module_uri = lambda module_vid, release_id=None, mv=None: (
+        f"uri/{module_vid}"
+    )
+    service._get_module_tables = lambda module_vid, release_id=None: {
+        "T_01": {"variables": {"v1": "x"}, "open_keys": {}},
+    }
+    return service
+
+
+class TestPreferIntra:
+    """A validation with both intra and cross scopes for the same module."""
+
+    def test_primary_with_intra_scope_is_intra_despite_cross(self, svc):
+        # COREP(10) has an intra scope AND a cross scope [10, 20].
+        sr = ScopeResult(
+            scopes=[_scope([10]), _scope([10, 20])],
+            is_cross_module=True,
+        )
+        info = svc.detect_cross_module_dependencies(
+            scope_result=sr,
+            primary_module_vid=10,
+            operation_code="v1",
+        )
+        assert info["intra_instance_validations"] == ["v1"]
+        assert info["cross_instance_dependencies"] == []
+
+    def test_primary_only_in_cross_is_a_dependency(self, svc):
+        # IF(20) appears only in the cross scope [10, 20] -> depends on 10.
+        mv = MagicMock()
+        mv.module_vid = 10
+        mv.code = "COREP_OF"
+        mv.version_number = "4.1.0"
+        mv.from_reference_date = None
+        mv.to_reference_date = None
+        svc.session.query.return_value.filter.return_value.all.return_value = [
+            mv
+        ]
+        sr = ScopeResult(
+            scopes=[_scope([10]), _scope([10, 20])],
+            is_cross_module=True,
+        )
+        info = svc.detect_cross_module_dependencies(
+            scope_result=sr,
+            primary_module_vid=20,
+            operation_code="v1",
+        )
+        assert info["intra_instance_validations"] == []
+        uris = [
+            m["URI"]
+            for c in info["cross_instance_dependencies"]
+            for m in c["modules"]
+        ]
+        assert "uri/10" in uris


### PR DESCRIPTION
Closes #119 #120 

## Summary

<!-- Short description of the change and why it's needed. -->

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [ ] Documentation updated (if applicable)

## Overview
**1. Filing-indicator preconditions were never matched.**
`model_queries.py` filtered preconditions with `Variable.type == "Filing Indicator"` (spaced + capitalised). As a result they never counted toward a module's coverage, so a module that really did host the whole operation was not seen as intra-instance.

**2. Preconditions were miscounted (NaN bucket).**
The target count was `len(table_codes) + len(precondition_items)`, but the per-module check only counted `TableCode.unique()`. Precondition rows keep their code in the `Code` column and are NaN in `TableCode`, so all preconditions collapsed into one NaN bucket. With one or more preconditions the counts never matched and a full module was wrongly pushed into the cross-module pool.

**3. Cross-instance scopes were incomplete or spurious.**
- Partial modules (holding only some of the referenced tables) were combined directly, without first pulling in modules that provide the tables they are missing → incomplete "cross" scopes.
- Modules from non-overlapping lifecycle generations (different reference-date windows) were combined even though they are never reported together.
- Invalid combinations were still emitted, just with `from_submission_date = None`, instead of being dropped.

**4. Intra/cross conflict in script generation (#120).**
When the primary module could evaluate the operation on its own (intra) AND also showed up in cross scopes (because a sibling module needs it), the operation was classified ambiguously. For scripts, the primary's script should treat it as intra; only the sibling's script should treat it as a cross-instance dependency.

### v0580_m  (#119 and #120)

```
with {default: 0, interval: true}:
{tC_18.00, r0010, c0070, s0001} = {tC_02.00.a, r0540, c0010}
```

**Before (reported in #120):** conflict — COREP_OF came out as BOTH intra-module and cross-module at the same time (because IF has only one of the two tables, so running it under IF would require COREP_OF). The script generation had no rule to resolve the conflict.

**After:**

```
total_scopes=2  is_cross_module=True
  Scope 1 [INTRA] from=2026-03-31: COREP_OF-4.1.0
  Scope 2 [CROSS] from=2026-03-31: COREP_OF-4.1.0, IF_CLASS2-1.4.0
```

For script generation the prefer-intra rule then gives:
- COREP_OF → **intra-instance** (no dependency)
- IF_CLASS2 → **cross-instance** dependency on COREP_OF

### v09808_m  (#119)

```
with {default:0, interval:true}:
{tC_34.02.a, (c0020..c0220), (r0010), s*} + ... + {tC_34.02.a, ..., (r0030), s*}
+ {tC_34.02.b, ..., (r0040), s*} + ... + {tC_34.02.b, ..., (r0100), s*}
= {tC_34.02.b, ..., (r0110), s*}
```

**Before:** the precondition/counting bug plus the incomplete cross logic produced spurious cross-instance scopes instead of clean intra scopes.

**After:**

```
total_scopes=2  is_cross_module=False
  Scope 1 [INTRA] from=2026-03-31: IF_CLASS2-1.4.0
  Scope 2 [INTRA] from=2026-03-31: COREP_OF-4.1.0
```