### PR TITLE
Improvement: fail script generation on scope calculation errors

### DIFF
--- a/src/dpmcore/services/ast_generator.py
+++ b/src/dpmcore/services/ast_generator.py
@@ -214,9 +214,20 @@ class ASTGeneratorService:
                         code, []
                     ),
                 )
-                if not sr.has_error:
-                    ts = self._extract_time_shifts(ast)
-                    scope_pairs.append((item, sr, ts))
+                if sr.has_error:
+                    # A script whose dependency block is silently missing
+                    # is structurally valid but semantically wrong (#122),
+                    # so a scope failure fails the whole generation.
+                    return {
+                        "success": False,
+                        "enriched_ast": None,
+                        "error": (
+                            f"Scope calculation failed for operation "
+                            f"'{code}': {sr.error_message}"
+                        ),
+                    }
+                ts = self._extract_time_shifts(ast)
+                scope_pairs.append((item, sr, ts))
 
             primary_tables_full = self._scope_calc._get_module_tables(
                 primary_module_vid, release_id=release_id

--- a/tests/unit/services/test_ast_generator.py
+++ b/tests/unit/services/test_ast_generator.py
@@ -947,6 +947,38 @@ class TestScript:
         assert out["success"] is False
         assert out["error"] == "bad expr"
 
+    def test_scope_error_fails_generation(self, monkeypatch):
+        """Regression for #122: a scope-calculation error must fail the
+        script generation instead of silently emitting the operation
+        with no dependency information.
+        """
+        self._stub_serialize_ast(
+            monkeypatch,
+            {"class_name": "VarID", "table": "C_01.00", "data": []},
+        )
+        svc, *_ = self._build_svc()
+        svc._semantic.validate.return_value = SimpleNamespace(
+            is_valid=True, error_message=None, parameters=()
+        )
+        svc._semantic.ast = "AST"
+        svc._scope_calc.calculate_from_expression.return_value = (
+            SimpleNamespace(
+                has_error=True,
+                error_message=(
+                    "No module versions found for preconditions items: "
+                    "{'F_40.01'}."
+                ),
+            )
+        )
+        out = svc.script(
+            expressions=[("e1", "v1")],
+            module_code="MOD",
+            module_version="1.0",
+        )
+        assert out["success"] is False
+        assert "'v1'" in out["error"]
+        assert "No module versions found" in out["error"]
+
     def test_invalid_severity_returns_error(self, monkeypatch):
         svc, *_ = self._build_svc()
         out = svc.script(

--- a/tests/unit/services/test_scope_calculator.py
+++ b/tests/unit/services/test_scope_calculator.py
@@ -533,6 +533,76 @@ class TestDetectCrossModuleDependencies:
         assert "T_01" in dm["http://uri/mod_20"]["tables"]
         assert dm["http://uri/mod_20"]["variables"] == {"v1": "x"}
 
+    def test_dependency_table_open_keys_propagate(self):
+        """Regression for #122: a dependency module's table entries must
+        keep their ``open_keys`` so the engine can join on them.
+        """
+        svc, SR = self._make_svc()
+        svc._get_module_tables = lambda vid, release_id=None: {
+            "C_06.02": {
+                "variables": {"5486578": "s"},
+                "open_keys": {"qEGS": "e", "qLGS": "s"},
+            }
+        }
+
+        mv = MagicMock()
+        mv.module_vid = 20
+        mv.version_number = "1.0"
+        mv.from_reference_date = None
+        mv.to_reference_date = None
+
+        q = svc.session.query.return_value
+        q.filter.return_value.all.return_value = [mv]
+
+        sr = SR(
+            scopes=[_scope([10, 20])],
+            is_cross_module=True,
+        )
+        info = svc.detect_cross_module_dependencies(
+            scope_result=sr,
+            primary_module_vid=10,
+        )
+        dep = info["dependency_modules"]["http://uri/mod_20"]
+        assert dep["tables"]["C_06.02"]["open_keys"] == {
+            "qEGS": "e",
+            "qLGS": "s",
+        }
+
+    def test_primary_module_never_a_dependency(self):
+        """Regression for #122: the primary module must not appear in
+        its own cross dependencies or ``dependency_modules``.
+        """
+        svc, SR = self._make_svc()
+        svc._get_module_tables = lambda vid, release_id=None: {
+            "T_01": {"variables": {"v1": "x"}, "open_keys": {}},
+        }
+
+        mv = MagicMock()
+        mv.module_vid = 20
+        mv.version_number = "1.0"
+        mv.from_reference_date = None
+        mv.to_reference_date = None
+
+        q = svc.session.query.return_value
+        q.filter.return_value.all.return_value = [mv]
+
+        sr = SR(
+            scopes=[_scope([10, 20])],
+            is_cross_module=True,
+        )
+        info = svc.detect_cross_module_dependencies(
+            scope_result=sr,
+            primary_module_vid=10,
+            operation_code="EGDQ_0131",
+        )
+        assert "http://uri/mod_10" not in info["dependency_modules"]
+        dep_uris = {
+            m["URI"]
+            for cd in info["cross_instance_dependencies"]
+            for m in cd["modules"]
+        }
+        assert dep_uris == {"http://uri/mod_20"}
+
     def test_module_with_only_variable_less_tables_is_dropped(self):
         """Modules whose tables all have empty ``variables`` are dropped.
 


### PR DESCRIPTION
## Summary

Closes #120, Closes #122, Related to #119, Related to #120

**Broken scope calculation**: the faults reported in #119 and #120 (filing-indicator preconditions never matched, precondition miscounting, incomplete/non-meaningful cross-instance scopes). non-meaningful scope combinations are how FINREP modules could be pulled in as dependencies of their own script.
2. **Script generation silently swallowed scope errors**: when the scope calculation for an expression failed, the operation was still emitted, just with an empty dependency block: no cross-instance dependencies, no dependency modules, and therefore no open keys for C_06.02. But the script looked structurally valid,.


- **PR #123** fixed the scope calculation layer and closed #119. It was also meant to close #120.
- **This PR** fixes the script-generation layer: a scope error now fails the generation with `Scope calculation failed for operation '<code>': <reason>` instead of silently emitting the operation without dependency information. Regression tests pin the #122 invariants: dependency tables keep their open keys, and the primary module never appears in its own dependency modules.

## Evidence

Attached:  EGDQ_0131 script generated against the DPM 4.2.1 database, for both primary modules, with the filing-indicator precondition `{v_F_40.01} and {v_C_06.02}`: once on master **before PR #123** and once with **PR #123 + this PR**.

**Before (`*_before_PR123.json`):** the scope calculation fails internally and is silently dropped, so both scripts carry an **empty dependency block**: `cross_instance_dependencies: []`, `dependency_modules: {}`. No `corep_of` dependency, no C_06.02 entry, no open keys.

**After:**

`EGDQ_0131_FINREP9_3.3.0_script.json` (FINREP primary):

- primary `tables`: only `F_40.01` (open keys `qCIN`, `qLIN`): **F_40.01 appears in no dependency module**
- single cross-instance dependency `corep_of`, whose `C_06.02` entry carries **open keys `qEGS`, `qLGS`**

`EGDQ_0131_COREP_OF_4.1.0_script.json` (COREP primary):

- primary `tables`: `C_06.02` with open keys `qEGS`, `qLGS`
- cross-instance dependencies `finrep9` / `finrep9dp`, declared as alternatives (`alternative_dependencies: [[finrep9, finrep9dp]]`): F_40.01 correctly lives there, since the COREP script genuinely needs it
Summary of the four attached scripts:

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [ ] Documentation updated (if applicable)

## Attachments

[EGDQ_0131_COREP_OF_4.1.0_script_before_PR123.json](https://github.com/user-attachments/files/28792847/EGDQ_0131_COREP_OF_4.1.0_script_before_PR123.json)
[EGDQ_0131_FINREP9_3.3.0_script_before_PR123.json](https://github.com/user-attachments/files/28792849/EGDQ_0131_FINREP9_3.3.0_script_before_PR123.json)
[EGDQ_0131_COREP_OF_4.1.0_script.json](https://github.com/user-attachments/files/28792850/EGDQ_0131_COREP_OF_4.1.0_script.json)
[EGDQ_0131_FINREP9_3.3.0_script.json](https://github.com/user-attachments/files/28792854/EGDQ_0131_FINREP9_3.3.0_script.json)
