### PR TITLE
Fix: sql server param limit

### DIFF
--- a/src/dpmcore/dpm_xl/model_queries.py
+++ b/src/dpmcore/dpm_xl/model_queries.py
@@ -44,6 +44,7 @@ from dpmcore.orm.packaging import (
     ModuleVersion,
     ModuleVersionComposition,
 )
+from dpmcore.orm.query_utils import chunked_in
 from dpmcore.orm.rendering import (
     Cell,
     HeaderVersion,
@@ -742,23 +743,18 @@ class ModuleVersionQuery:
         if not tables_vids:
             return pd.DataFrame(columns=cols)
 
-        query = (
-            session.query(
-                ModuleVersion.module_vid.label("ModuleVID"),
-                ModuleVersionComposition.table_vid.label("variable_vid"),
-                ModuleVersion.code.label("ModuleCode"),
-                ModuleVersion.version_number.label("VersionNumber"),
-                ModuleVersion.from_reference_date.label("FromReferenceDate"),
-                ModuleVersion.to_reference_date.label("ToReferenceDate"),
-                ModuleVersion.start_release_id.label("StartReleaseID"),
-                ModuleVersion.end_release_id.label("EndReleaseID"),
-            )
-            .join(
-                ModuleVersionComposition,
-                ModuleVersion.module_vid
-                == ModuleVersionComposition.module_vid,
-            )
-            .filter(ModuleVersionComposition.table_vid.in_(tables_vids))
+        query = session.query(
+            ModuleVersion.module_vid.label("ModuleVID"),
+            ModuleVersionComposition.table_vid.label("variable_vid"),
+            ModuleVersion.code.label("ModuleCode"),
+            ModuleVersion.version_number.label("VersionNumber"),
+            ModuleVersion.from_reference_date.label("FromReferenceDate"),
+            ModuleVersion.to_reference_date.label("ToReferenceDate"),
+            ModuleVersion.start_release_id.label("StartReleaseID"),
+            ModuleVersion.end_release_id.label("EndReleaseID"),
+        ).join(
+            ModuleVersionComposition,
+            ModuleVersion.module_vid == ModuleVersionComposition.module_vid,
         )
         if release_id is not None:
             query = query.filter(
@@ -770,7 +766,9 @@ class ModuleVersionQuery:
                     ),
                 )
             )
-        results = query.all()
+        results = chunked_in(
+            query, ModuleVersionComposition.table_vid, tables_vids
+        )
         df = pd.DataFrame(results, columns=cols)
         return _apply_fallback_for_equal_dates(session, df)
 
@@ -825,7 +823,6 @@ class ModuleVersionQuery:
                 TableVersion,
                 ModuleVersionComposition.table_vid == TableVersion.table_vid,
             )
-            .filter(TableVersion.code.in_(table_codes))
         )
         if release_id is not None:
             query = query.filter(
@@ -837,7 +834,7 @@ class ModuleVersionQuery:
                     ),
                 )
             )
-        results = query.all()
+        results = chunked_in(query, TableVersion.code, table_codes)
         df = pd.DataFrame(results, columns=cols)
         return _apply_fallback_for_equal_dates(session, df)
 
@@ -978,14 +975,14 @@ def _apply_fallback_for_equal_dates(
 
     vids_needing = [int(v) for v in rows_needing[module_vid_col].unique()]
 
-    current_modules = (
+    current_modules = chunked_in(
         session.query(
             ModuleVersion.module_vid,
             ModuleVersion.module_id,
             ModuleVersion.start_release_id,
-        )
-        .filter(ModuleVersion.module_vid.in_(vids_needing))
-        .all()
+        ),
+        ModuleVersion.module_vid,
+        vids_needing,
     )
     current_info = {
         r.module_vid: (r.module_id, r.start_release_id)
@@ -993,14 +990,15 @@ def _apply_fallback_for_equal_dates(
     }
 
     unique_mids = list({info[0] for info in current_info.values()})
-    prev_versions = (
-        session.query(ModuleVersion)
-        .filter(ModuleVersion.module_id.in_(unique_mids))
-        .order_by(
+    # The per-module_id ORDER BY survives chunking because each module_id
+    # falls entirely within one chunk (the chunk column is module_id).
+    prev_versions = chunked_in(
+        session.query(ModuleVersion).order_by(
             ModuleVersion.module_id,
             ModuleVersion.start_release_id.desc(),
-        )
-        .all()
+        ),
+        ModuleVersion.module_id,
+        unique_mids,
     )
 
     by_mid: dict[int, list[ModuleVersion]] = {}

--- a/src/dpmcore/orm/query_utils.py
+++ b/src/dpmcore/orm/query_utils.py
@@ -1,0 +1,57 @@
+"""Helpers for building backend-safe ORM queries.
+
+SQL Server caps a single statement at 2,100 bound parameters, so an
+unbounded ``IN (...)`` filter (one bound parameter per element) fails on
+the ``mssql+pyodbc`` backend once the collection grows past that limit.
+:func:`chunked_in` splits such a filter into fixed-size batches that stay
+well below the cap on every supported backend.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+from sqlalchemy.orm import Query
+
+IN_CHUNK_SIZE = 900
+"""Maximum number of values bound into a single ``IN (...)`` clause.
+
+SQL Server caps a statement at 2,100 bound parameters and SQLite's
+default limit is 999. 900 is safe on every supported backend and still
+leaves headroom for the other bound parameters in the same statement
+(release filters, literal codes, and so on).
+"""
+
+
+def chunked_in(
+    query: Query[Any],
+    column: Any,
+    values: Iterable[Any],
+) -> list[Any]:
+    """Run *query* once per :data:`IN_CHUNK_SIZE` batch of *values*.
+
+    Works around SQL Server's 2,100-bound-parameter-per-statement limit
+    by splitting ``column.in_(values)`` into batches and concatenating
+    the rows. This is only valid when the result is the simple *union*
+    of the rows matching the ``IN`` set — i.e. the query has no
+    ``LIMIT``/``OFFSET``, no aggregate or ``GROUP BY`` over the set, and
+    no globally-significant ``ORDER BY``. Because the batches partition
+    *values* disjointly, each matching row appears in exactly one batch,
+    so the concatenation equals the single-statement result.
+
+    Args:
+        query: A query that does **not** already contain the chunked
+            filter; the ``column.in_(...)`` filter is added per batch.
+        column: The column the ``IN`` filter applies to.
+        values: The collection bound into the ``IN`` clause. An empty
+            collection issues no query and yields an empty list.
+
+    Returns:
+        The concatenated rows from every batch, in batch order.
+    """
+    values = list(values)
+    rows: list[Any] = []
+    for start in range(0, len(values), IN_CHUNK_SIZE):
+        chunk = values[start : start + IN_CHUNK_SIZE]
+        rows.extend(query.filter(column.in_(chunk)).all())
+    return rows

--- a/src/dpmcore/orm/query_utils.py
+++ b/src/dpmcore/orm/query_utils.py
@@ -35,21 +35,28 @@ def chunked_in(
     the rows. This is only valid when the result is the simple *union*
     of the rows matching the ``IN`` set — i.e. the query has no
     ``LIMIT``/``OFFSET``, no aggregate or ``GROUP BY`` over the set, and
-    no globally-significant ``ORDER BY``. Because the batches partition
-    *values* disjointly, each matching row appears in exactly one batch,
-    so the concatenation equals the single-statement result.
+    no globally-significant ``ORDER BY``.
+
+    *values* is de-duplicated (preserving first-seen order) before
+    batching so the batches partition the distinct values disjointly.
+    Each matching row therefore appears in exactly one batch and the
+    concatenation equals the single-statement result — a single SQL
+    ``IN (...)`` likewise ignores duplicate bound values, so this keeps
+    the chunked path faithful to it even when the caller passes a
+    collection with duplicates that would otherwise straddle batches.
 
     Args:
         query: A query that does **not** already contain the chunked
             filter; the ``column.in_(...)`` filter is added per batch.
         column: The column the ``IN`` filter applies to.
-        values: The collection bound into the ``IN`` clause. An empty
-            collection issues no query and yields an empty list.
+        values: The collection bound into the ``IN`` clause. Duplicates
+            are collapsed; an empty collection issues no query and
+            yields an empty list.
 
     Returns:
         The concatenated rows from every batch, in batch order.
     """
-    values = list(values)
+    values = list(dict.fromkeys(values))
     rows: list[Any] = []
     for start in range(0, len(values), IN_CHUNK_SIZE):
         chunk = values[start : start + IN_CHUNK_SIZE]

--- a/src/dpmcore/server/routers/structure.py
+++ b/src/dpmcore/server/routers/structure.py
@@ -462,11 +462,10 @@ def _owner_ids_from_acronyms(
 ) -> List[int]:
     """Resolve acronyms to org IDs for get_release_organisations."""
     from dpmcore.orm.infrastructure import Organisation
+    from dpmcore.orm.query_utils import chunked_in
 
-    orgs = (
-        svc.session.query(Organisation)
-        .filter(Organisation.acronym.in_(acronyms))
-        .all()
+    orgs = chunked_in(
+        svc.session.query(Organisation), Organisation.acronym, acronyms
     )
     return [o.org_id for o in orgs]
 

--- a/src/dpmcore/services/layout_exporter/queries.py
+++ b/src/dpmcore/services/layout_exporter/queries.py
@@ -223,9 +223,12 @@ def _load_member_codes(
         .filter(ItemCategory.end_release_id.is_(None))
         # When an item has several in-domain rows the dict's last write
         # wins, so order to make that winner deterministic (highest
-        # ``(category_id, code)``). The ORDER BY survives chunking
-        # because every item_id falls entirely within one chunk (the
-        # chunk column is item_id), so each item's rows stay contiguous.
+        # ``(category_id, code)``). This holds under chunking because
+        # each item_id is queried in exactly one batch (the chunk column
+        # is item_id): all of an item's rows land in that one batch's
+        # ordered result, so the ORDER BY puts the item's highest row
+        # last. Cross-batch order is irrelevant since no item spans
+        # batches.
         .order_by(ItemCategory.category_id, ItemCategory.code)
     )
     rows = chunked_in(base, ItemCategory.item_id, item_ids)

--- a/src/dpmcore/services/layout_exporter/queries.py
+++ b/src/dpmcore/services/layout_exporter/queries.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, Optional
 from sqlalchemy import and_
 from sqlalchemy.orm import Session
 
+from dpmcore.orm.query_utils import chunked_in
 from dpmcore.services.layout_exporter.models import DimensionMember
 
 if TYPE_CHECKING:
@@ -179,16 +180,15 @@ def _load_dimension_codes(
 
     from dpmcore.orm.glossary import Category, ItemCategory
 
-    rows = (
+    base = (
         session.query(ItemCategory.item_id, ItemCategory.code)
         .join(Category, Category.category_id == ItemCategory.category_id)
         .filter(
-            ItemCategory.item_id.in_(property_ids),
             Category.code == "_PR",
             ItemCategory.end_release_id.is_(None),
         )
-        .all()
     )
+    rows = chunked_in(base, ItemCategory.item_id, property_ids)
     return {r[0]: r[1] for r in rows if r[1]}
 
 
@@ -208,19 +208,15 @@ def _load_member_codes(
 
     from dpmcore.orm.glossary import ItemCategory
 
-    rows = (
-        session.query(
-            ItemCategory.item_id,
-            ItemCategory.code,
-            ItemCategory.category_id,
-        )
-        .filter(
-            ItemCategory.item_id.in_(item_ids),
-            ItemCategory.category_id.in_(domain_category_ids),
-            ItemCategory.end_release_id.is_(None),
-        )
-        .all()
+    base = session.query(
+        ItemCategory.item_id,
+        ItemCategory.code,
+        ItemCategory.category_id,
+    ).filter(
+        ItemCategory.category_id.in_(domain_category_ids),
+        ItemCategory.end_release_id.is_(None),
     )
+    rows = chunked_in(base, ItemCategory.item_id, item_ids)
     return {r[0]: r[1] for r in rows if r[1]}
 
 
@@ -254,7 +250,7 @@ def load_categorisations(
     DimItem = aliased(Item, name="dim_item")
     MemberItem = aliased(Item, name="member_item")
 
-    rows = (
+    base = (
         session.query(
             ContextComposition.context_id,
             ContextComposition.property_id,
@@ -286,9 +282,8 @@ def load_categorisations(
             Category.category_id == PropertyCategory.category_id,
         )
         .outerjoin(DataType, DataType.data_type_id == Property.data_type_id)
-        .filter(ContextComposition.context_id.in_(context_ids))
-        .all()
     )
+    rows = chunked_in(base, ContextComposition.context_id, context_ids)
 
     # Collect IDs for code lookups
     prop_ids: set[int] = set()
@@ -336,7 +331,7 @@ def load_property_as_categorisation(
     from dpmcore.orm.glossary import Category, Item, Property, PropertyCategory
     from dpmcore.orm.infrastructure import DataType
 
-    rows = (
+    base = (
         session.query(
             Item.item_id,
             Item.name,  # member label (e.g., "Carrying amount")
@@ -356,9 +351,8 @@ def load_property_as_categorisation(
             Category.category_id == PropertyCategory.category_id,
         )
         .outerjoin(DataType, DataType.data_type_id == Property.data_type_id)
-        .filter(Item.item_id.in_(property_ids))
-        .all()
     )
+    rows = chunked_in(base, Item.item_id, property_ids)
 
     # Load member codes: for "Main Property", the property itself
     # IS the member, so its code in category '_PR' is the
@@ -406,7 +400,7 @@ def load_dp_categorisations(
     DimItem = aliased(Item, name="dim_item")
     MemberItem = aliased(Item, name="member_item")
 
-    rows = (
+    base = (
         session.query(
             VariableVersion.variable_vid,
             ContextComposition.property_id,
@@ -442,9 +436,8 @@ def load_dp_categorisations(
             Category.category_id == PropertyCategory.category_id,
         )
         .outerjoin(DataType, DataType.data_type_id == Property.data_type_id)
-        .filter(VariableVersion.variable_vid.in_(variable_vids))
-        .all()
     )
+    rows = chunked_in(base, VariableVersion.variable_vid, variable_vids)
 
     # Collect IDs for code lookups
     prop_ids: set[int] = set()
@@ -490,7 +483,7 @@ def load_subcategory_info(
 
     from dpmcore.orm.glossary import Category, SubCategory, SubCategoryVersion
 
-    rows = (
+    base = (
         session.query(
             SubCategoryVersion.subcategory_vid,
             SubCategory.code,
@@ -503,8 +496,9 @@ def load_subcategory_info(
             SubCategory.subcategory_id == SubCategoryVersion.subcategory_id,
         )
         .join(Category, Category.category_id == SubCategory.category_id)
-        .filter(SubCategoryVersion.subcategory_vid.in_(subcategory_vids))
-        .all()
+    )
+    rows = chunked_in(
+        base, SubCategoryVersion.subcategory_vid, subcategory_vids
     )
     # Prefer description over name (some subcategories only have one populated)
     return {r[0]: (r[1] or "", r[2] or r[4] or "", r[3] or "") for r in rows}
@@ -523,13 +517,10 @@ def load_key_variable_property_ids(
 
     from dpmcore.orm.variables import VariableVersion
 
-    rows = (
-        session.query(
-            VariableVersion.variable_vid, VariableVersion.property_id
-        )
-        .filter(VariableVersion.variable_vid.in_(variable_vids))
-        .all()
+    base = session.query(
+        VariableVersion.variable_vid, VariableVersion.property_id
     )
+    rows = chunked_in(base, VariableVersion.variable_vid, variable_vids)
     return {r[0]: r[1] for r in rows if r[1]}
 
 
@@ -549,7 +540,7 @@ def load_variable_info(
     from dpmcore.orm.infrastructure import DataType
     from dpmcore.orm.variables import VariableVersion
 
-    rows = (
+    base = (
         session.query(
             VariableVersion.variable_vid,
             VariableVersion.variable_id,
@@ -562,7 +553,6 @@ def load_variable_info(
         )
         .outerjoin(DataType, DataType.data_type_id == Property.data_type_id)
         .outerjoin(Item, Item.item_id == VariableVersion.property_id)
-        .filter(VariableVersion.variable_vid.in_(variable_vids))
-        .all()
     )
+    rows = chunked_in(base, VariableVersion.variable_vid, variable_vids)
     return {r[0]: (r[1], r[2] or "", r[3] or "") for r in rows}

--- a/src/dpmcore/services/layout_exporter/queries.py
+++ b/src/dpmcore/services/layout_exporter/queries.py
@@ -208,16 +208,28 @@ def _load_member_codes(
 
     from dpmcore.orm.glossary import ItemCategory
 
-    base = session.query(
-        ItemCategory.item_id,
-        ItemCategory.code,
-        ItemCategory.category_id,
-    ).filter(
-        ItemCategory.category_id.in_(domain_category_ids),
-        ItemCategory.end_release_id.is_(None),
+    # Match the domain in Python rather than via a second ``IN (...)`` so
+    # the chunked statement binds only the item-id batch (plus the
+    # release filter) and never approaches SQL Server's 2,100-parameter
+    # cap, however many domains the export spans. ``category_id`` is
+    # already selected, so this is the same predicate moved off SQL.
+    domain = set(domain_category_ids)
+    base = (
+        session.query(
+            ItemCategory.item_id,
+            ItemCategory.code,
+            ItemCategory.category_id,
+        )
+        .filter(ItemCategory.end_release_id.is_(None))
+        # When an item has several in-domain rows the dict's last write
+        # wins, so order to make that winner deterministic (highest
+        # ``(category_id, code)``). The ORDER BY survives chunking
+        # because every item_id falls entirely within one chunk (the
+        # chunk column is item_id), so each item's rows stay contiguous.
+        .order_by(ItemCategory.category_id, ItemCategory.code)
     )
     rows = chunked_in(base, ItemCategory.item_id, item_ids)
-    return {r[0]: r[1] for r in rows if r[1]}
+    return {r[0]: r[1] for r in rows if r[1] and r[2] in domain}
 
 
 # ------------------------------------------------------------------ #

--- a/src/dpmcore/services/meili_json.py
+++ b/src/dpmcore/services/meili_json.py
@@ -21,6 +21,7 @@ from dpmcore.orm.operations import (
     OperationVersion,
 )
 from dpmcore.orm.packaging import Module, ModuleVersion
+from dpmcore.orm.query_utils import chunked_in
 
 
 class MeiliJsonError(Exception):
@@ -146,19 +147,6 @@ def calculate_applicable(modules: List[Dict[str, Any]]) -> bool:  # noqa: C901
     return max_from_date < str(min_to_date)
 
 
-_SQLITE_CHUNK_SIZE = 999
-
-
-def _chunked_query(base_query: Any, column: Any, ids: Any) -> List[Any]:
-    """Split a large IN clause into 999-item batches for SQLite."""
-    ids_list = list(ids)
-    result: List[Any] = []
-    for i in range(0, len(ids_list), _SQLITE_CHUNK_SIZE):
-        chunk = ids_list[i : i + _SQLITE_CHUNK_SIZE]
-        result.extend(base_query.filter(column.in_(chunk)).all())
-    return result
-
-
 class MeiliJsonService:
     """Generate the operations JSON consumed by Meilisearch."""
 
@@ -274,7 +262,7 @@ class MeiliJsonService:
         if not operation_vids:
             return ctx
 
-        scopes = _chunked_query(
+        scopes = chunked_in(
             self._session.query(OperationScope),
             OperationScope.operation_vid,
             operation_vids,
@@ -285,7 +273,7 @@ class MeiliJsonService:
 
         scope_ids = [scope.operation_scope_id for scope in scopes]
         if scope_ids:
-            compositions = _chunked_query(
+            compositions = chunked_in(
                 self._session.query(OperationScopeComposition).options(
                     selectinload(OperationScopeComposition.module_version)
                     .selectinload(ModuleVersion.module)
@@ -318,7 +306,7 @@ class MeiliJsonService:
         }
 
         if parent_operation_ids:
-            parent_versions = _chunked_query(
+            parent_versions = chunked_in(
                 self._session.query(OperationVersion)
                 .options(selectinload(OperationVersion.operation))
                 .order_by(
@@ -338,7 +326,7 @@ class MeiliJsonService:
                         parent_version
                     )
 
-        all_versions = _chunked_query(
+        all_versions = chunked_in(
             self._session.query(OperationVersion)
             .options(
                 selectinload(OperationVersion.operation)
@@ -370,7 +358,7 @@ class MeiliJsonService:
             operation_vids
         )
         if previous_version_opvids:
-            previous_scopes = _chunked_query(
+            previous_scopes = chunked_in(
                 self._session.query(OperationScope),
                 OperationScope.operation_vid,
                 previous_version_opvids,
@@ -383,7 +371,7 @@ class MeiliJsonService:
                 scope.operation_scope_id for scope in previous_scopes
             ]
             if extra_scope_ids:
-                extra_compositions = _chunked_query(
+                extra_compositions = chunked_in(
                     self._session.query(OperationScopeComposition).options(
                         selectinload(OperationScopeComposition.module_version)
                         .selectinload(ModuleVersion.module)
@@ -403,7 +391,7 @@ class MeiliJsonService:
                         composition.operation_scope_id
                     ].append(composition)
 
-        nodes = _chunked_query(
+        nodes = chunked_in(
             self._session.query(OperationNode),
             OperationNode.operation_vid,
             all_opvids_for_info,
@@ -415,7 +403,7 @@ class MeiliJsonService:
             node_ids.append(node.node_id)
 
         if node_ids:
-            refs = _chunked_query(
+            refs = chunked_in(
                 self._session.query(OperandReference),
                 OperandReference.node_id,
                 node_ids,
@@ -430,7 +418,7 @@ class MeiliJsonService:
                 ref_ids.append(reference.operand_reference_id)
 
             if ref_ids:
-                locations = _chunked_query(
+                locations = chunked_in(
                     self._session.query(OperandReferenceLocation),
                     OperandReferenceLocation.operand_reference_id,
                     ref_ids,

--- a/src/dpmcore/services/scope_calculator.py
+++ b/src/dpmcore/services/scope_calculator.py
@@ -28,6 +28,7 @@ from dpmcore.orm.packaging import (
     ModuleVersion,
     ModuleVersionComposition,
 )
+from dpmcore.orm.query_utils import chunked_in
 from dpmcore.orm.rendering import (
     TableVersion,
     TableVersionCell,
@@ -321,10 +322,10 @@ class ScopeCalculatorService:
         dep_modules: Dict[str, Any] = {}
 
         sorted_vids = sorted(valid_vids)
-        mv_rows = (
-            self.session.query(ModuleVersion)
-            .filter(ModuleVersion.module_vid.in_(sorted_vids))
-            .all()
+        mv_rows = chunked_in(
+            self.session.query(ModuleVersion),
+            ModuleVersion.module_vid,
+            sorted_vids,
         )
         mv_by_vid = {mv.module_vid: mv for mv in mv_rows}
 
@@ -527,10 +528,10 @@ class ScopeCalculatorService:
 
         mv_by_vid: Dict[int, Any] = {}
         if needed:
-            mv_rows = (
-                self.session.query(ModuleVersion)
-                .filter(ModuleVersion.module_vid.in_(needed))
-                .all()
+            mv_rows = chunked_in(
+                self.session.query(ModuleVersion),
+                ModuleVersion.module_vid,
+                needed,
             )
             mv_by_vid = {mv.module_vid: mv for mv in mv_rows}
 
@@ -593,7 +594,7 @@ class ScopeCalculatorService:
             tvid: {} for tvid in table_vids
         }
         if table_vids:
-            var_rows = (
+            var_base = (
                 self.session.query(
                     TableVersionCell.table_vid,
                     Variable.variable_id,
@@ -617,9 +618,10 @@ class ScopeCalculatorService:
                     DataType,
                     Property.data_type_id == DataType.data_type_id,
                 )
-                .filter(TableVersionCell.table_vid.in_(table_vids))
                 .distinct()
-                .all()
+            )
+            var_rows = chunked_in(
+                var_base, TableVersionCell.table_vid, table_vids
             )
             for row in var_rows:
                 tvid = row[0]
@@ -680,7 +682,6 @@ class ScopeCalculatorService:
                 TableVersion,
                 KeyComposition.key_id == TableVersion.key_id,
             )
-            .filter(TableVersion.code.in_(table_codes))
         )
 
         if release_id is not None:
@@ -692,11 +693,8 @@ class ScopeCalculatorService:
                 TableVersion.start_release_id <= release_id,
             )
 
-        rows = (
-            query.distinct()
-            .order_by(TableVersion.code, ItemCategory.code)
-            .all()
-        )
+        query = query.distinct().order_by(TableVersion.code, ItemCategory.code)
+        rows = chunked_in(query, TableVersion.code, table_codes)
         for row in rows:
             tcode = row.table_code
             pcode = row.property_code

--- a/src/dpmcore/services/semantic.py
+++ b/src/dpmcore/services/semantic.py
@@ -25,6 +25,7 @@ from dpmcore.orm.operations import (
     OperationScopeComposition,
     OperationVersion,
 )
+from dpmcore.orm.query_utils import chunked_in
 from dpmcore.services.syntax import SyntaxService
 
 if TYPE_CHECKING:
@@ -349,7 +350,7 @@ class SemanticService:
         found. The ``LIKE`` filter guarantees a non-null expression (``LIKE``
         rejects NULL), so the cast to ``str`` is sound.
         """
-        rows = (
+        base = (
             self.session.query(OperationVersion.expression)
             .join(
                 OperationScope,
@@ -360,16 +361,24 @@ class SemanticService:
                 OperationScope.operation_scope_id
                 == OperationScopeComposition.operation_scope_id,
             )
-            .filter(OperationScopeComposition.module_vid.in_(module_vids))
             .filter(
                 _whitespace_insensitive(OperationVersion.expression).like(
                     _PARAM_MARKER
                 )
             )
             .distinct()
-            .all()
         )
-        return [expression for (expression,) in cast("list[tuple[str]]", rows)]
+        rows = chunked_in(
+            base, OperationScopeComposition.module_vid, module_vids
+        )
+        # Chunking the module_vid IN clause splits the query, so the
+        # per-statement DISTINCT no longer dedups across chunks; collapse
+        # repeated expressions here while preserving order.
+        return list(
+            dict.fromkeys(
+                expression for (expression,) in cast("list[tuple[str]]", rows)
+            )
+        )
 
     def _declarations(self, expression: str) -> dict[str, str]:
         """Extract ``{code: declared_type}`` from one persisted expression.

--- a/src/dpmcore/services/structure.py
+++ b/src/dpmcore/services/structure.py
@@ -51,6 +51,7 @@ from dpmcore.orm.packaging import (
     ModuleVersion,
     ModuleVersionComposition,
 )
+from dpmcore.orm.query_utils import chunked_in
 from dpmcore.orm.release_sort_order import compute_sort_order
 from dpmcore.orm.rendering import (
     Cell,
@@ -331,10 +332,8 @@ class StructureService:
         unique = [oid for oid in set(owner_ids) if oid is not None]
         if not unique:
             return []
-        orgs = (
-            self.session.query(Organisation)
-            .filter(Organisation.org_id.in_(unique))
-            .all()
+        orgs = chunked_in(
+            self.session.query(Organisation), Organisation.org_id, unique
         )
         return [_organisation_to_dict(o) for o in orgs]
 
@@ -395,10 +394,10 @@ class StructureService:
             (ics_by_cat, items_by_id) — ItemCategory rows grouped by
             category_id and Item rows keyed by item_id.
         """
-        ics = (
-            self.session.query(ItemCategory)
-            .filter(ItemCategory.category_id.in_(cat_ids))
-            .all()
+        ics = chunked_in(
+            self.session.query(ItemCategory),
+            ItemCategory.category_id,
+            cat_ids,
         )
 
         ics_by_cat: Dict[int, List[ItemCategory]] = defaultdict(
@@ -413,10 +412,8 @@ class StructureService:
 
         items_by_id: Dict[int, Item] = {}
         if item_ids:
-            items = (
-                self.session.query(Item)
-                .filter(Item.item_id.in_(list(item_ids)))
-                .all()
+            items = chunked_in(
+                self.session.query(Item), Item.item_id, list(item_ids)
             )
             items_by_id = {i.item_id: i for i in items}
 
@@ -763,16 +760,15 @@ class StructureService:
         """
         if not table_vids:
             return {}
-        rows = (
+        base = (
             self.session.query(TableVersionHeader, Header, HeaderVersion)
             .join(Header, Header.header_id == TableVersionHeader.header_id)
             .join(
                 HeaderVersion,
                 HeaderVersion.header_vid == TableVersionHeader.header_vid,
             )
-            .filter(TableVersionHeader.table_vid.in_(table_vids))
-            .all()
         )
+        rows = chunked_in(base, TableVersionHeader.table_vid, table_vids)
         out: Dict[
             int, List[Tuple[TableVersionHeader, Header, HeaderVersion]]
         ] = defaultdict(list)
@@ -790,12 +786,10 @@ class StructureService:
         """
         if not table_vids:
             return {}
-        rows = (
-            self.session.query(TableVersionCell, Cell)
-            .join(Cell, Cell.cell_id == TableVersionCell.cell_id)
-            .filter(TableVersionCell.table_vid.in_(table_vids))
-            .all()
+        base = self.session.query(TableVersionCell, Cell).join(
+            Cell, Cell.cell_id == TableVersionCell.cell_id
         )
+        rows = chunked_in(base, TableVersionCell.table_vid, table_vids)
         out: Dict[int, List[Tuple[TableVersionCell, Cell]]] = defaultdict(list)
         for tvc, c in rows:
             out[tvc.table_vid].append((tvc, c))
@@ -876,10 +870,10 @@ class StructureService:
         # Bulk-load VariableVersion rows once.
         vv_by_vid: Dict[int, VariableVersion] = {}
         if all_variable_vids:
-            for vv in (
-                self.session.query(VariableVersion)
-                .filter(VariableVersion.variable_vid.in_(all_variable_vids))
-                .all()
+            for vv in chunked_in(
+                self.session.query(VariableVersion),
+                VariableVersion.variable_vid,
+                all_variable_vids,
             ):
                 vv_by_vid[vv.variable_vid] = vv
             # Variables expose their property reference too — fold
@@ -983,12 +977,10 @@ class StructureService:
         """Resolve ``{property_id: Item.name}`` for a set of property ids."""
         if not property_ids:
             return {}
-        rows = (
-            self.session.query(Item.item_id, Item.name)
-            .join(Property, Property.property_id == Item.item_id)
-            .filter(Item.item_id.in_(property_ids))
-            .all()
+        base = self.session.query(Item.item_id, Item.name).join(
+            Property, Property.property_id == Item.item_id
         )
+        rows = chunked_in(base, Item.item_id, property_ids)
         return {r[0]: r[1] for r in rows}
 
     def _load_subcategory_enumerations(
@@ -1013,7 +1005,7 @@ class StructureService:
         from dpmcore.dpm_xl.utils.filters import filter_by_release
 
         # SubCategoryVersion → SubCategory → parent Category.
-        info_rows = (
+        info_base = (
             self.session.query(SubCategoryVersion, SubCategory, Category)
             .join(
                 SubCategory,
@@ -1021,20 +1013,24 @@ class StructureService:
                 == SubCategoryVersion.subcategory_id,
             )
             .join(Category, Category.category_id == SubCategory.category_id)
-            .filter(SubCategoryVersion.subcategory_vid.in_(subcategory_vids))
-            .all()
+        )
+        info_rows = chunked_in(
+            info_base, SubCategoryVersion.subcategory_vid, subcategory_vids
         )
         subcat_info: Dict[
             int, Tuple[SubCategoryVersion, SubCategory, Category]
         ] = {sv.subcategory_vid: (sv, sc, cat) for sv, sc, cat in info_rows}
 
-        # SubCategoryItem rows + Item names, ordered.
-        item_rows = (
+        # SubCategoryItem rows + Item names, ordered. The per-subcategory
+        # ORDER BY survives chunking because each subcategory_vid falls
+        # entirely within one chunk (the chunk column is subcategory_vid).
+        item_base = (
             self.session.query(SubCategoryItem, Item)
             .join(Item, Item.item_id == SubCategoryItem.item_id)
-            .filter(SubCategoryItem.subcategory_vid.in_(subcategory_vids))
             .order_by(SubCategoryItem.subcategory_vid, SubCategoryItem.order)
-            .all()
+        )
+        item_rows = chunked_in(
+            item_base, SubCategoryItem.subcategory_vid, subcategory_vids
         )
         items_by_subcat: Dict[int, List[Tuple[SubCategoryItem, Item]]] = (
             defaultdict(list)
@@ -1049,9 +1045,7 @@ class StructureService:
         }
         item_codes: Dict[Tuple[int, int], ItemCategory] = {}
         if parent_cat_ids:
-            ic_q = self.session.query(ItemCategory).filter(
-                ItemCategory.category_id.in_(parent_cat_ids)
-            )
+            ic_q = self.session.query(ItemCategory)
             ic_q = filter_by_release(
                 ic_q,
                 start_col=ItemCategory.start_release_id,
@@ -1059,7 +1053,9 @@ class StructureService:
                 release_id=release_id,
                 active_only_fallback=True,
             )
-            for ic in ic_q.all():
+            for ic in chunked_in(
+                ic_q, ItemCategory.category_id, parent_cat_ids
+            ):
                 item_codes[(ic.item_id, ic.category_id)] = ic
 
         result: Dict[int, Dict[str, Any]] = {}
@@ -1106,10 +1102,10 @@ class StructureService:
         """
         if not variable_vids:
             return []
-        vvs = (
-            self.session.query(VariableVersion)
-            .filter(VariableVersion.variable_vid.in_(variable_vids))
-            .all()
+        vvs = chunked_in(
+            self.session.query(VariableVersion),
+            VariableVersion.variable_vid,
+            variable_vids,
         )
         vv_by_vid = {vv.variable_vid: vv for vv in vvs}
         property_ids = {vv.property_id for vv in vvs if vv.property_id}
@@ -1263,15 +1259,9 @@ class StructureService:
 
         if not parent_ids:
             return {}
-        q = (
-            self.session.query(
-                TableGroup.parent_table_group_id, TableGroup.table_group_id
-            )
-            .filter(TableGroup.parent_table_group_id.in_(parent_ids))
-            .order_by(
-                TableGroup.parent_table_group_id, TableGroup.table_group_id
-            )
-        )
+        q = self.session.query(
+            TableGroup.parent_table_group_id, TableGroup.table_group_id
+        ).order_by(TableGroup.parent_table_group_id, TableGroup.table_group_id)
         if target_release is not None:
             q = filter_by_release(
                 q,
@@ -1280,7 +1270,11 @@ class StructureService:
                 release_id=target_release.release_id,
             )
         out: Dict[int, List[int]] = defaultdict(list)
-        for parent_id, child_id in q.all():
+        # Chunking on parent_table_group_id keeps each parent's children
+        # within one chunk, so the per-parent ORDER BY is preserved.
+        for parent_id, child_id in chunked_in(
+            q, TableGroup.parent_table_group_id, parent_ids
+        ):
             out[parent_id].append(child_id)
         return dict(out)
 
@@ -1332,16 +1326,16 @@ class StructureService:
             bucket_ids = [g.table_group_id for g in bucket]
 
             # Compositions at this release.
-            comp_q = self.session.query(TableGroupComposition).filter(
-                TableGroupComposition.table_group_id.in_(bucket_ids)
-            )
+            comp_q = self.session.query(TableGroupComposition)
             comp_q = filter_by_release(
                 comp_q,
                 start_col=TableGroupComposition.start_release_id,
                 end_col=TableGroupComposition.end_release_id,
                 release_id=rid,
             )
-            comps = comp_q.all()
+            comps = chunked_in(
+                comp_q, TableGroupComposition.table_group_id, bucket_ids
+            )
 
             comps_by_group: Dict[int, List[TableGroupComposition]] = (
                 defaultdict(list)
@@ -1354,10 +1348,8 @@ class StructureService:
 
             tv_by_table_id: Dict[int, TableVersion] = {}
             if table_ids:
-                tv_q = (
-                    self.session.query(TableVersion)
-                    .options(joinedload(TableVersion.table))
-                    .filter(TableVersion.table_id.in_(table_ids))
+                tv_q = self.session.query(TableVersion).options(
+                    joinedload(TableVersion.table)
                 )
                 tv_q = filter_by_release(
                     tv_q,
@@ -1365,7 +1357,7 @@ class StructureService:
                     end_col=TableVersion.end_release_id,
                     release_id=rid,
                 )
-                for tv in tv_q.all():
+                for tv in chunked_in(tv_q, TableVersion.table_id, table_ids):
                     tv_by_table_id[tv.table_id] = tv
 
             entries_by_tvid: Dict[int, Dict[str, Any]] = {}
@@ -1395,9 +1387,7 @@ class StructureService:
                 tables_by_group[g.table_group_id] = ordered_entries
 
             # Child TableGroups at this release.
-            child_q = self.session.query(TableGroup).filter(
-                TableGroup.parent_table_group_id.in_(bucket_ids)
-            )
+            child_q = self.session.query(TableGroup)
             child_q = filter_by_release(
                 child_q,
                 start_col=TableGroup.start_release_id,
@@ -1408,7 +1398,9 @@ class StructureService:
                 TableGroup.parent_table_group_id, TableGroup.table_group_id
             )
             child_stubs: Dict[int, List[Dict[str, Any]]] = defaultdict(list)
-            for cg in child_q.all():
+            for cg in chunked_in(
+                child_q, TableGroup.parent_table_group_id, bucket_ids
+            ):
                 child_stubs[cg.parent_table_group_id].append(
                     {
                         "id": cg.table_group_id,
@@ -1579,14 +1571,15 @@ class StructureService:
             return {}
 
         module_vids = [mv.module_vid for mv in module_versions]
-        comp_rows = (
-            self.session.query(ModuleVersionComposition)
-            .filter(ModuleVersionComposition.module_vid.in_(module_vids))
-            .order_by(
+        # Chunking on module_vid keeps each module's compositions within
+        # one chunk, so the per-module ORDER BY is preserved.
+        comp_rows = chunked_in(
+            self.session.query(ModuleVersionComposition).order_by(
                 ModuleVersionComposition.module_vid,
                 ModuleVersionComposition.order,
-            )
-            .all()
+            ),
+            ModuleVersionComposition.module_vid,
+            module_vids,
         )
 
         ordered_vids_by_module: Dict[int, List[int]] = defaultdict(list)
@@ -1600,11 +1593,12 @@ class StructureService:
         if not all_table_vids:
             return {}
 
-        tvs = (
-            self.session.query(TableVersion)
-            .options(joinedload(TableVersion.table))
-            .filter(TableVersion.table_vid.in_(all_table_vids))
-            .all()
+        tvs = chunked_in(
+            self.session.query(TableVersion).options(
+                joinedload(TableVersion.table)
+            ),
+            TableVersion.table_vid,
+            all_table_vids,
         )
         table_entries = self._build_table_entries_batch(
             tvs, detail=detail, target_release=target_release
@@ -1692,15 +1686,16 @@ class StructureService:
         """``{operator_id: [argument_dict, ...]}`` in one query."""
         if not operator_ids:
             return {}
-        rows = (
-            self.session.query(OperatorArgument)
-            .filter(OperatorArgument.operator_id.in_(operator_ids))
-            .order_by(
+        # Chunking on operator_id keeps each operator's arguments within
+        # one chunk, so the per-operator ORDER BY is preserved.
+        rows = chunked_in(
+            self.session.query(OperatorArgument).order_by(
                 OperatorArgument.operator_id,
                 OperatorArgument.order,
                 OperatorArgument.argument_id,
-            )
-            .all()
+            ),
+            OperatorArgument.operator_id,
+            operator_ids,
         )
         out: Dict[int, List[Dict[str, Any]]] = defaultdict(list)
         for a in rows:
@@ -1897,9 +1892,7 @@ class StructureService:
 
         if not operation_ids:
             return {}
-        q = self.session.query(OperationVersion).filter(
-            OperationVersion.operation_id.in_(operation_ids)
-        )
+        q = self.session.query(OperationVersion)
         if target_release is not None:
             q = filter_by_release(
                 q,
@@ -1911,7 +1904,7 @@ class StructureService:
             OperationVersion.operation_id, OperationVersion.start_release_id
         )
         out: Dict[int, List[OperationVersion]] = defaultdict(list)
-        for v in q.all():
+        for v in chunked_in(q, OperationVersion.operation_id, operation_ids):
             out[cast(int, v.operation_id)].append(v)
         return dict(out)
 
@@ -1922,11 +1915,12 @@ class StructureService:
         """``{operation_vid: [OperationNode, ...]}`` in one query."""
         if not operation_vids:
             return {}
-        rows = (
-            self.session.query(OperationNode)
-            .filter(OperationNode.operation_vid.in_(operation_vids))
-            .order_by(OperationNode.operation_vid, OperationNode.node_id)
-            .all()
+        rows = chunked_in(
+            self.session.query(OperationNode).order_by(
+                OperationNode.operation_vid, OperationNode.node_id
+            ),
+            OperationNode.operation_vid,
+            operation_vids,
         )
         out: Dict[int, List[OperationNode]] = defaultdict(list)
         for n in rows:
@@ -1940,14 +1934,13 @@ class StructureService:
         """``{node_id: [OperandReference, ...]}`` in one query."""
         if not node_ids:
             return {}
-        rows = (
-            self.session.query(OperandReference)
-            .filter(OperandReference.node_id.in_(node_ids))
-            .order_by(
+        rows = chunked_in(
+            self.session.query(OperandReference).order_by(
                 OperandReference.node_id,
                 OperandReference.operand_reference_id,
-            )
-            .all()
+            ),
+            OperandReference.node_id,
+            node_ids,
         )
         out: Dict[int, List[OperandReference]] = defaultdict(list)
         for r in rows:
@@ -1966,15 +1959,12 @@ class StructureService:
         """
         if not reference_ids:
             return {}
-        rows = (
-            self.session.query(OperandReferenceLocation)
-            .filter(
-                OperandReferenceLocation.operand_reference_id.in_(
-                    reference_ids
-                )
-            )
-            .order_by(OperandReferenceLocation.operand_reference_id)
-            .all()
+        rows = chunked_in(
+            self.session.query(OperandReferenceLocation).order_by(
+                OperandReferenceLocation.operand_reference_id
+            ),
+            OperandReferenceLocation.operand_reference_id,
+            reference_ids,
         )
         out: Dict[int, List[OperandReferenceLocation]] = defaultdict(list)
         for loc in rows:
@@ -2065,13 +2055,12 @@ class StructureService:
         """``{parent_data_type_id: [child_id, ...]}`` in one query."""
         if not parent_ids:
             return {}
-        rows = (
+        rows = chunked_in(
             self.session.query(
                 DataType.parent_data_type_id, DataType.data_type_id
-            )
-            .filter(DataType.parent_data_type_id.in_(parent_ids))
-            .order_by(DataType.parent_data_type_id, DataType.data_type_id)
-            .all()
+            ).order_by(DataType.parent_data_type_id, DataType.data_type_id),
+            DataType.parent_data_type_id,
+            parent_ids,
         )
         out: Dict[int, List[int]] = defaultdict(list)
         for parent_id, child_id in rows:
@@ -2085,11 +2074,12 @@ class StructureService:
         """``{parent_data_type_id: [child_stub, ...]}`` in one query."""
         if not parent_ids:
             return {}
-        rows = (
-            self.session.query(DataType)
-            .filter(DataType.parent_data_type_id.in_(parent_ids))
-            .order_by(DataType.parent_data_type_id, DataType.data_type_id)
-            .all()
+        rows = chunked_in(
+            self.session.query(DataType).order_by(
+                DataType.parent_data_type_id, DataType.data_type_id
+            ),
+            DataType.parent_data_type_id,
+            parent_ids,
         )
         out: Dict[int, List[Dict[str, Any]]] = defaultdict(list)
         for dt in rows:
@@ -2210,10 +2200,10 @@ class StructureService:
 
         # Bulk-load compositions for all matched contexts.
         context_ids = [c.context_id for c in contexts]
-        comp_rows = (
-            self.session.query(ContextComposition)
-            .filter(ContextComposition.context_id.in_(context_ids))
-            .all()
+        comp_rows = chunked_in(
+            self.session.query(ContextComposition),
+            ContextComposition.context_id,
+            context_ids,
         )
         comps_by_context: Dict[int, List[ContextComposition]] = defaultdict(
             list
@@ -2279,7 +2269,7 @@ class StructureService:
         """
         if not property_ids:
             return {}
-        rows = (
+        base = (
             self.session.query(
                 ItemCategory.item_id,
                 ItemCategory.start_release_id,
@@ -2287,12 +2277,9 @@ class StructureService:
                 ItemCategory.code,
             )
             .join(Item, Item.item_id == ItemCategory.item_id)
-            .filter(
-                ItemCategory.item_id.in_(property_ids),
-                Item.is_property.is_(True),
-            )
-            .all()
+            .filter(Item.is_property.is_(True))
         )
+        rows = chunked_in(base, ItemCategory.item_id, property_ids)
         out: Dict[int, List[Tuple[int, Optional[int], str]]] = defaultdict(
             list
         )
@@ -2311,15 +2298,15 @@ class StructureService:
         """
         if not property_ids:
             return {}
-        rows = (
+        rows = chunked_in(
             self.session.query(
                 PropertyCategory.property_id,
                 PropertyCategory.start_release_id,
                 PropertyCategory.end_release_id,
                 PropertyCategory.category_id,
-            )
-            .filter(PropertyCategory.property_id.in_(property_ids))
-            .all()
+            ),
+            PropertyCategory.property_id,
+            property_ids,
         )
         out: Dict[int, List[Tuple[int, Optional[int], int]]] = defaultdict(
             list
@@ -2342,16 +2329,16 @@ class StructureService:
         """
         if not item_ids:
             return {}
-        rows = (
+        rows = chunked_in(
             self.session.query(
                 ItemCategory.item_id,
                 ItemCategory.category_id,
                 ItemCategory.start_release_id,
                 ItemCategory.end_release_id,
                 ItemCategory.code,
-            )
-            .filter(ItemCategory.item_id.in_(item_ids))
-            .all()
+            ),
+            ItemCategory.item_id,
+            item_ids,
         )
         out: Dict[Tuple[int, int], List[Tuple[int, Optional[int], str]]] = (
             defaultdict(list)
@@ -2600,10 +2587,7 @@ class StructureService:
                 Category,
                 Category.category_id == PropertyCategory.category_id,
             )
-            .filter(
-                PropertyCategory.property_id.in_(property_ids),
-                Category.is_enumerated.is_(True),
-            )
+            .filter(Category.is_enumerated.is_(True))
         )
         pc_q = filter_by_release(
             pc_q,
@@ -2615,7 +2599,9 @@ class StructureService:
         # Deterministic pick when a property links to multiple
         # enumerated categories: lowest category_id wins.
         enum_category_by_property: Dict[int, Category] = {}
-        for pc, cat in pc_q.all():
+        for pc, cat in chunked_in(
+            pc_q, PropertyCategory.property_id, property_ids
+        ):
             existing = enum_category_by_property.get(pc.property_id)
             if existing is None or cat.category_id < existing.category_id:
                 enum_category_by_property[pc.property_id] = cat
@@ -2625,10 +2611,8 @@ class StructureService:
         category_ids = {
             cat.category_id for cat in enum_category_by_property.values()
         }
-        ic_q = (
-            self.session.query(ItemCategory, Item)
-            .join(Item, Item.item_id == ItemCategory.item_id)
-            .filter(ItemCategory.category_id.in_(category_ids))
+        ic_q = self.session.query(ItemCategory, Item).join(
+            Item, Item.item_id == ItemCategory.item_id
         )
         ic_q = filter_by_release(
             ic_q,
@@ -2640,7 +2624,9 @@ class StructureService:
         items_by_category: Dict[int, List[Tuple[ItemCategory, Item]]] = (
             defaultdict(list)
         )
-        for ic, item in ic_q.all():
+        for ic, item in chunked_in(
+            ic_q, ItemCategory.category_id, category_ids
+        ):
             items_by_category[ic.category_id].append((ic, item))
 
         result: Dict[int, Dict[str, Any]] = {}
@@ -2844,10 +2830,10 @@ class StructureService:
         """``{key_id: CompoundKey.signature}`` in one query."""
         if not key_ids:
             return {}
-        rows = (
-            self.session.query(CompoundKey.key_id, CompoundKey.signature)
-            .filter(CompoundKey.key_id.in_(key_ids))
-            .all()
+        rows = chunked_in(
+            self.session.query(CompoundKey.key_id, CompoundKey.signature),
+            CompoundKey.key_id,
+            key_ids,
         )
         return {row[0]: row[1] for row in rows}
 
@@ -2967,7 +2953,6 @@ class StructureService:
             self.session.query(ModuleVersion)
             .join(Module, Module.module_id == ModuleVersion.module_id)
             .options(joinedload(ModuleVersion.module))
-            .filter(Module.framework_id.in_(framework_ids))
         )
         if target_release is not None:
             q = filter_by_release(
@@ -2982,7 +2967,11 @@ class StructureService:
             ModuleVersion.module_id,
             ModuleVersion.start_release_id,
         )
-        module_versions: List[ModuleVersion] = q.all()
+        # Chunking on framework_id keeps each framework's modules within
+        # one chunk, so the per-framework ORDER BY is preserved.
+        module_versions: List[ModuleVersion] = chunked_in(
+            q, Module.framework_id, framework_ids
+        )
         if not module_versions:
             return {}
 
@@ -3031,12 +3020,12 @@ class StructureService:
         """``{framework_id: {"id", "code", "name"}}`` in one query."""
         if not framework_ids:
             return {}
-        rows = (
+        rows = chunked_in(
             self.session.query(
                 Framework.framework_id, Framework.code, Framework.name
-            )
-            .filter(Framework.framework_id.in_(framework_ids))
-            .all()
+            ),
+            Framework.framework_id,
+            framework_ids,
         )
         return {
             fid: {"id": fid, "code": code, "name": name}
@@ -3050,15 +3039,14 @@ class StructureService:
         """``{module_vid: [variable_vid, ...]}`` in one query."""
         if not module_vids:
             return {}
-        rows = (
+        rows = chunked_in(
             self.session.query(
                 ModuleParameters.module_vid, ModuleParameters.variable_vid
-            )
-            .filter(ModuleParameters.module_vid.in_(module_vids))
-            .order_by(
+            ).order_by(
                 ModuleParameters.module_vid, ModuleParameters.variable_vid
-            )
-            .all()
+            ),
+            ModuleParameters.module_vid,
+            module_vids,
         )
         out: Dict[int, List[int]] = defaultdict(list)
         for mvid, vvid in rows:

--- a/tests/integration/services/layout_exporter/test_queries.py
+++ b/tests/integration/services/layout_exporter/test_queries.py
@@ -161,6 +161,60 @@ def test_load_member_codes_populated(memory_session):
     assert out == {500: "m1"}
 
 
+def test_load_member_codes_out_of_domain_filtered(memory_session):
+    """Rows whose category isn't in the domain set are dropped."""
+    seed_releases(memory_session)
+    make_member(
+        memory_session,
+        item_id=500,
+        name="InDomain",
+        domain_category_id=20,
+        code="keep",
+    )
+    make_member(
+        memory_session,
+        item_id=501,
+        name="OutOfDomain",
+        domain_category_id=99,
+        code="drop",
+    )
+    memory_session.commit()
+    # 99 is not in the requested domain set, so 501 is filtered in Python.
+    out = queries._load_member_codes(memory_session, {500, 501}, {20})
+    assert out == {500: "keep"}
+
+
+def test_load_member_codes_multiple_domains_deterministic(memory_session):
+    """An item in several in-domain categories resolves deterministically.
+
+    The highest ``(category_id, code)`` wins last-write-wins, regardless
+    of the backend's physical row order.
+    """
+    from dpmcore.orm.glossary import ItemCategory
+
+    seed_releases(memory_session)
+    # One item categorised under two domains the export spans.
+    make_member(
+        memory_session,
+        item_id=500,
+        name="MultiDomain",
+        domain_category_id=20,
+        code="aaa",
+    )
+    # Distinct start release: ItemCategory is unique on (item, start).
+    memory_session.add(
+        ItemCategory(
+            item_id=500,
+            start_release_id=2,
+            category_id=21,
+            code="bbb",
+        ),
+    )
+    memory_session.commit()
+    out = queries._load_member_codes(memory_session, {500}, {20, 21})
+    assert out == {500: "bbb"}
+
+
 # ---------------------------------------------------------------- #
 # load_categorisations
 # ---------------------------------------------------------------- #

--- a/tests/unit/meili/test_meili_json_service.py
+++ b/tests/unit/meili/test_meili_json_service.py
@@ -8,7 +8,6 @@ from dpmcore.services.meili_json import (
     BulkDataContext,
     MeiliJsonError,
     MeiliJsonService,
-    _chunked_query,
     _iso_date,
     calculate_applicable,
     create_substrings,
@@ -199,39 +198,10 @@ def test_calculate_applicable_multiple_modules_valid_range():
     assert calculate_applicable(modules) is True
 
 
-# ---------------------------------------------------------------------------
-# _chunked_query
-# ---------------------------------------------------------------------------
-
-
-def test_chunked_query_single_chunk():
-    mock_query = MagicMock()
-    mock_query.filter.return_value.all.return_value = ["row1", "row2"]
-
-    result = _chunked_query(mock_query, MagicMock(), [1, 2, 3])
-
-    assert mock_query.filter.call_count == 1
-    assert result == ["row1", "row2"]
-
-
-def test_chunked_query_splits_into_multiple_chunks():
-    mock_query = MagicMock()
-    mock_query.filter.return_value.all.return_value = ["row"]
-
-    ids = list(range(1001))  # 1001 > 999 → 2 chunks
-    result = _chunked_query(mock_query, MagicMock(), ids)
-
-    assert mock_query.filter.call_count == 2
-    assert len(result) == 2
-
-
-def test_chunked_query_empty_ids_returns_empty():
-    mock_query = MagicMock()
-
-    result = _chunked_query(mock_query, MagicMock(), [])
-
-    mock_query.filter.assert_not_called()
-    assert result == []
+# Chunked IN batching is now provided by the shared
+# ``dpmcore.orm.query_utils.chunked_in`` helper and is unit-tested in
+# tests/unit/orm/test_query_utils.py. The service-level test below
+# verifies that the bulk loader drives that helper correctly.
 
 
 # ---------------------------------------------------------------------------
@@ -1181,7 +1151,7 @@ def test_bulk_load_related_data_populates_all_lookup_contexts():
     service = MeiliJsonService(_FakeSession())
 
     with patch(
-        "dpmcore.services.meili_json._chunked_query",
+        "dpmcore.services.meili_json.chunked_in",
         side_effect=fake_chunked_query,
     ):
         ctx = service._bulk_load_related_data(

--- a/tests/unit/orm/test_query_utils.py
+++ b/tests/unit/orm/test_query_utils.py
@@ -1,0 +1,76 @@
+"""Unit tests for :func:`dpmcore.orm.query_utils.chunked_in`.
+
+The helper splits an ``IN (...)`` filter into batches to stay under SQL
+Server's 2,100-bound-parameter limit. These tests run on SQLite and
+prove the chunked result is identical to a single unchunked statement,
+exercising the batch boundary with a deliberately tiny chunk size.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import Integer, String, create_engine
+from sqlalchemy.orm import Session, declarative_base
+
+from dpmcore.orm import query_utils
+from dpmcore.orm._compat import Mapped, mapped_column
+from dpmcore.orm.query_utils import chunked_in
+
+# Isolated registry so the throwaway table never pollutes Base.metadata.
+_IsolatedBase = declarative_base()
+
+
+class _Widget(_IsolatedBase):
+    __tablename__ = "_widgets_chunked_in_test"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    group: Mapped[str] = mapped_column(String(10))
+
+
+@pytest.fixture
+def session() -> Session:
+    """An in-memory SQLite session seeded with ten widgets."""
+    engine = create_engine("sqlite:///:memory:")
+    _IsolatedBase.metadata.create_all(engine, tables=[_Widget.__table__])
+    db = Session(bind=engine)
+    for i in range(1, 11):
+        db.add(_Widget(id=i, group="A" if i % 2 else "B"))
+    db.commit()
+    return db
+
+
+def test_empty_values_issues_no_query(session: Session) -> None:
+    """An empty collection yields an empty list and runs no statement."""
+    assert chunked_in(session.query(_Widget), _Widget.id, []) == []
+
+
+def test_single_chunk_returns_all_matches(session: Session) -> None:
+    """Below the chunk size, results match a plain ``IN`` query."""
+    ids = [2, 4, 6]
+    rows = chunked_in(session.query(_Widget), _Widget.id, ids)
+    assert sorted(w.id for w in rows) == ids
+
+
+def test_multiple_chunks_equal_unchunked(
+    session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Spanning several batches equals the single-statement result."""
+    monkeypatch.setattr(query_utils, "IN_CHUNK_SIZE", 2)
+    ids = [1, 2, 3, 5, 7, 9]
+    chunked = chunked_in(session.query(_Widget), _Widget.id, ids)
+    unchunked = session.query(_Widget).filter(_Widget.id.in_(ids)).all()
+    assert sorted(w.id for w in chunked) == sorted(w.id for w in unchunked)
+    assert sorted(w.id for w in chunked) == ids
+
+
+def test_base_query_filters_preserved_across_chunks(
+    session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Filters already on the base query apply to every batch."""
+    monkeypatch.setattr(query_utils, "IN_CHUNK_SIZE", 2)
+    base = session.query(_Widget).filter(_Widget.group == "A")
+    rows = chunked_in(base, _Widget.id, [1, 2, 3, 4, 5, 6])
+    # Only odd ids are group "A".
+    assert sorted(w.id for w in rows) == [1, 3, 5]

--- a/tests/unit/orm/test_query_utils.py
+++ b/tests/unit/orm/test_query_utils.py
@@ -64,6 +64,21 @@ def test_multiple_chunks_equal_unchunked(
     assert sorted(w.id for w in chunked) == ids
 
 
+def test_duplicates_across_chunks_yield_each_row_once(
+    session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Duplicate values that straddle batches don't duplicate rows.
+
+    Without de-duplication ``[1, 2, 1]`` at chunk size 2 would query id
+    1 in both batches and return its row twice, diverging from a single
+    ``IN (...)`` (which ignores duplicate bound values).
+    """
+    monkeypatch.setattr(query_utils, "IN_CHUNK_SIZE", 2)
+    rows = chunked_in(session.query(_Widget), _Widget.id, [1, 2, 1])
+    assert sorted(w.id for w in rows) == [1, 2]
+
+
 def test_base_query_filters_preserved_across_chunks(
     session: Session,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Closes #126 

## Summary

SQL Server caps a single statement at 2,100 bound parameters, so the layout exporter crashed (`pyodbc 07002`) whenever a module referenced more than ~2,100 variable versions — every ID was bound into one unbounded `IN (...)`. This PR introduces a shared chunking helper and migrates the high-volume, data-sized `IN` call sites across the codebase to use it.

## What was done

- Added `dpmcore.orm.query_utils.chunked_in` (with `IN_CHUNK_SIZE = 900`) — splits a `column.in_(values)` filter into fixed-size batches that stay well under the cap on every backend, and concatenates the results. Values are de-duplicated (order-preserving) so the chunked result matches single-statement `IN` semantics even when callers pass duplicates that would straddle batches.
- Migrated the unbounded `IN` lookups in the layout exporter, structure/semantic/scope-calculator services, Meili JSON, the DPM-XL model queries, and the structure router to `chunked_in`.
- Reworked `_load_member_codes` so the domain filter is applied in Python instead of a second unbounded `IN`, keeping the chunked statement under the cap regardless of how many domains an export spans. Its member-code result is now deterministic (highest `(category_id, code)` wins) rather than dependent on backend row order.
- Replaced the SQLite-only chunker in the Meili JSON service with the shared helper and updated tests accordingly.

## Notes

- Two remaining `IN` sites flagged against #126 are intentionally left: `dpm_xl/utils/filters.py` binds only release IDs (bounded to the number of releases, never near the cap) and is a query-builder that can't use `chunked_in`; `dpm_xl/ast/operands.py` is a pandas-compiled `.distinct()` path that needs a separate chunk-and-concat approach. Tracked as a follow-up — this PR is **part of** #126, not a full close.

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [ ] Documentation updated (if applicable)

