### PR TITLE
fix(scopes): dedup and minimise cross-instance scope combinations

### DIFF
--- a/src/dpmcore/dpm_xl/utils/scopes_calculator.py
+++ b/src/dpmcore/dpm_xl/utils/scopes_calculator.py
@@ -546,6 +546,15 @@ class OperationScopeService:
             seen_lists.add(list_key)
             distinct_lists.append(tuple(providers))
 
+        # No constraints means no combination to evaluate. An empty
+        # ``distinct_lists`` would make ``product()`` yield a single empty
+        # tuple, whose empty module set has no reference dates and would
+        # raise on ``from_dates.max()``. Real callers never pass an empty
+        # pool (each is guarded by ``if cross_modules``), so this is a
+        # defensive no-op.
+        if not distinct_lists:
+            return
+
         # Collapse each combination to its module set and evaluate only the
         # first occurrence of a given set, so a combination never yields more
         # than one scope.

--- a/src/dpmcore/dpm_xl/utils/scopes_calculator.py
+++ b/src/dpmcore/dpm_xl/utils/scopes_calculator.py
@@ -529,11 +529,37 @@ class OperationScopeService:
             for vid, grp in code_groups:
                 precond_by_module[int(vid)] = set(grp["Code"].dropna())
 
-        values = cross_modules.values()
-        for combination in product(*values):
-            unique_combination = set(combination)
+        # Many referenced table codes share the *same* provider list (one
+        # FINREP module commonly hosts every F_04.* table). The Cartesian
+        # product over the raw per-code lists would then choose a provider
+        # for each code independently and emit the identical module set once
+        # per redundant choice — thousands of duplicates for the same scope.
+        # Collapsing identical provider lists first removes that multiplicity
+        # without changing which module sets are reachable: two codes with
+        # the same providers impose the same "pick one of these" constraint.
+        distinct_lists: list[tuple[int, ...]] = []
+        seen_lists: set[frozenset[int]] = set()
+        for providers in cross_modules.values():
+            list_key = frozenset(providers)
+            if list_key in seen_lists:
+                continue
+            seen_lists.add(list_key)
+            distinct_lists.append(tuple(providers))
+
+        # Collapse each combination to its module set and evaluate only the
+        # first occurrence of a given set, so a combination never yields more
+        # than one scope.
+        seen_sets: set[frozenset[int]] = set()
+        valid_sets: list[frozenset[int]] = []
+        ref_from_by_set: dict[frozenset[int], Any] = {}
+        for combination in product(*distinct_lists):
+            module_set = frozenset(combination)
+            if module_set in seen_sets:
+                continue
+            seen_sets.add(module_set)
+
             combination_info = modules_dataframe[
-                modules_dataframe[MODULE_VID].isin(combination)
+                modules_dataframe[MODULE_VID].isin(module_set)
             ]
             from_dates = combination_info[FROM_REFERENCE_DATE].to_numpy()
             to_dates = combination_info[TO_REFERENCE_DATE].to_numpy()
@@ -560,13 +586,28 @@ class OperationScopeService:
             # the combination, else it cannot evaluate the operation.
             if req_preconditions:
                 covered: set[Any] = set()
-                for module in unique_combination:
+                for module in module_set:
                     covered |= precond_by_module.get(module, set())
                 if not covered.issuperset(req_preconditions):
                     continue
 
-            operation_scope = self.create_operation_scope(ref_from_date)
-            for module in unique_combination:
+            valid_sets.append(module_set)
+            ref_from_by_set[module_set] = ref_from_date
+
+        # Each retained combination already covers every required key (the
+        # product picks one provider per distinct constraint). A combination
+        # that strictly contains another retained one therefore only pairs in
+        # a module a smaller covering combination already does without — e.g.
+        # two alternative modules that each host the whole referenced table
+        # set. Drop such non-minimal supersets so the alternatives surface as
+        # separate scopes instead of one bloated multi-module scope.
+        for module_set in valid_sets:
+            if any(other < module_set for other in valid_sets):
+                continue
+            operation_scope = self.create_operation_scope(
+                ref_from_by_set[module_set]
+            )
+            for module in module_set:
                 module_row = module_lookup.get(module)
                 if module_row is None:
                     continue

--- a/tests/unit/dpm_xl/test_scopes_lifecycle.py
+++ b/tests/unit/dpm_xl/test_scopes_lifecycle.py
@@ -455,3 +455,107 @@ class TestCrossModuleCoverage:
             required_precondition_codes={"P1"},
         )
         assert len(svc.operation_scopes) == 1
+
+    @staticmethod
+    def _two_provider_df():
+        # Modules 100 and 200 both host every table; 300 hosts the last.
+        # All three overlap in time (open-ended windows from the same date).
+        return pd.DataFrame(
+            [
+                (100, "MOD_A", "1.0", "2026-03-31", None),
+                (200, "MOD_B", "1.0", "2026-03-31", None),
+                (300, "MOD_C", "1.0", "2026-03-31", None),
+            ],
+            columns=[
+                "ModuleVID",
+                "ModuleCode",
+                "VersionNumber",
+                "FromReferenceDate",
+                "ToReferenceDate",
+            ],
+        )
+
+    @staticmethod
+    def _capture_scope_sets(svc):
+        """Record each emitted scope's module set.
+
+        The mocked ORM back-populates neither
+        ``operation_scope_compositions`` nor distinct ``OperationScope``
+        objects (the mocked class returns one shared instance), so both
+        ``create_operation_scope`` and
+        ``create_operation_scope_composition`` are stubbed: the former
+        hands out a unique sentinel per scope, the latter records module
+        VIDs grouped by that sentinel's identity.
+        """
+        members: dict[int, set] = {}
+
+        def make_scope(submission_date):
+            scope = object()
+            svc.operation_scopes.append(scope)
+            return scope
+
+        def spy(operation_scope, module_vid, module_info=None):
+            members.setdefault(id(operation_scope), set()).add(module_vid)
+
+        svc.create_operation_scope = make_scope
+        svc.create_operation_scope_composition = spy
+        return members
+
+    def test_shared_provider_lists_do_not_explode(self):
+        """Many codes sharing one provider list must not multiply scopes.
+
+        Regression: the Cartesian product picked a provider per code
+        independently, so N codes each hosted by the same two modules
+        emitted the identical module set 2**N times. Here ten codes share
+        ``[100, 200]`` and one code is hosted by ``300`` — the engine must
+        emit the two minimal covers (``{100, 300}`` / ``{200, 300}``), not
+        2**10 duplicates nor the bloated ``{100, 200, 300}`` superset.
+        """
+        codes = [f"T{i}" for i in range(10)]
+        cross_modules = {c: [100, 200] for c in codes}
+        cross_modules["LAST"] = [300]
+        required = set(codes) | {"LAST"}
+
+        SvcClass = _get_svc_class()
+        svc = SvcClass(session=MagicMock())
+        members = self._capture_scope_sets(svc)
+        svc.process_cross_module(
+            cross_modules=cross_modules,
+            modules_dataframe=self._two_provider_df(),
+            required_keys=required,
+        )
+
+        assert len(svc.operation_scopes) == 2
+        scope_sets = {frozenset(m) for m in members.values()}
+        assert scope_sets == {frozenset({100, 300}), frozenset({200, 300})}
+
+    def test_non_minimal_superset_is_dropped(self):
+        """A combination strictly containing another is not emitted.
+
+        ``A`` is hosted by both 10 and 20; ``B`` only by 20. The covers are
+        ``{10, 20}`` and ``{20}`` — but ``{20}`` alone covers both keys, so
+        the superset ``{10, 20}`` is redundant and dropped.
+        """
+        df = pd.DataFrame(
+            [
+                (10, "MOD_A", "1.0", "2026-03-31", None),
+                (20, "MOD_B", "1.0", "2026-03-31", None),
+            ],
+            columns=[
+                "ModuleVID",
+                "ModuleCode",
+                "VersionNumber",
+                "FromReferenceDate",
+                "ToReferenceDate",
+            ],
+        )
+        SvcClass = _get_svc_class()
+        svc = SvcClass(session=MagicMock())
+        members = self._capture_scope_sets(svc)
+        svc.process_cross_module(
+            cross_modules={"A": [10, 20], "B": [20]},
+            modules_dataframe=df,
+            required_keys={"A", "B"},
+        )
+        assert len(svc.operation_scopes) == 1
+        assert [frozenset(m) for m in members.values()] == [frozenset({20})]

--- a/tests/unit/dpm_xl/test_scopes_lifecycle.py
+++ b/tests/unit/dpm_xl/test_scopes_lifecycle.py
@@ -385,6 +385,23 @@ class TestCrossModuleCoverage:
         )
         assert len(svc.operation_scopes) == 1
 
+    def test_empty_cross_modules_emits_no_scope(self):
+        """An empty pool is a safe no-op rather than a hard crash.
+
+        With no provider lists, ``product()`` would yield a single empty
+        combination whose empty module set has no reference dates and
+        would raise on ``from_dates.max()``. The method must instead
+        return without emitting a scope.
+        """
+        SvcClass = _get_svc_class()
+        svc = SvcClass(session=MagicMock())
+        svc.process_cross_module(
+            cross_modules={},
+            modules_dataframe=self._modules_df(),
+            required_keys=None,
+        )
+        assert svc.operation_scopes == []
+
     def test_non_overlapping_dates_emit_no_scope(self):
         """Modules whose reference-date windows do not overlap are never
         reported together (e.g. different lifecycle generations), so the


### PR DESCRIPTION
Closes #128

## Summary

Calculating operation scopes for a DPM-XL expression that references many tables across modules could return **1000+ scopes** where only a handful are real. `OperationScopeService.process_cross_module` enumerated the full Cartesian product of each table code's provider modules and emitted one `OperationScope` per product tuple. When several modules each host many of the referenced codes — and they share a lifecycle generation and overlapping reference-date windows — the product collapses (via `set()`) to the **same** module-set thousands of times, and also produces non-minimal supersets that mix mutually-alternative modules. The example expression at release 4.2 returned **1024 scopes** (3 distinct module-sets, 1022 of them the identical 3-module set) when the correct answer is **2**. The defect is in pure-Python logic, independent of the database backend, and was introduced with the cross-instance scope work (PR #123).

## Fixes

- Collapse identical per-code provider lists before enumerating combinations. Many referenced codes share the same provider list (one FINREP module commonly hosts every `F_04.*` table), and the raw product would pick a provider per code independently and emit the identical module set once per redundant choice. Collapsing identical lists first removes that multiplicity without changing which module sets are reachable — two codes with the same providers impose the same "pick one of these" constraint.
- De-duplicate emitted module sets: each combination is collapsed to its module set and only the first occurrence is evaluated, so a combination never yields more than one scope.
- Drop non-minimal supersets: a retained combination already covers every required key, so a combination that strictly contains another only pairs in a module a smaller covering combination already does without (e.g. two alternative modules that each host the whole referenced table set). Dropping such supersets surfaces the alternatives as separate scopes instead of one bloated multi-module scope.
- Added a defensive guard that returns early on an empty cross-module pool, so the method is a safe no-op instead of raising on an empty reference-date array (addresses the Copilot review note).
- Added regression tests covering the shared-provider-list explosion, the non-minimal-superset drop, and the empty-pool guard.

With these changes the issue's expression returns the two expected minimal covers (`{AE, FINREP9}` / `{AE, FINREP9DP}`) instead of 1024 scopes.

## Notes

- The collapse is safe with respect to the result: a minimal cover never needs two different modules from the same provider list, so any module set reachable only via the un-collapsed product is a strict superset of a collapsed one and is removed by the minimality filter. The final set of minimal scopes is identical — just computed without the explosion.
- Behaviour is unchanged for intra-module scopes and for cross-module expressions that already produced a single minimal cover.

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [ ] Documentation updated (if applicable)
