### PR TITLE
fix(semantic): reject contradictory where clauses on a shared key

### DIFF
--- a/src/dpmcore/dpm_xl/ast/where_clause.py
+++ b/src/dpmcore/dpm_xl/ast/where_clause.py
@@ -1,7 +1,15 @@
 from __future__ import annotations
 
-from dpmcore.dpm_xl.ast.nodes import Dimension
+from dpmcore.dpm_xl.ast.nodes import (
+    AST,
+    BinOp,
+    Constant,
+    Dimension,
+    ParExpr,
+    Scalar,
+)
 from dpmcore.dpm_xl.ast.template import ASTTemplate
+from dpmcore.dpm_xl.utils import tokens
 
 
 class WhereClauseChecker(ASTTemplate):
@@ -11,3 +19,134 @@ class WhereClauseChecker(ASTTemplate):
 
     def visit_Dimension(self, node: Dimension) -> None:
         self.key_components.append(node.dimension_code)
+
+
+def _equality_value(node: AST) -> str | None:
+    """Return the literal value of a where-condition equality operand.
+
+    Only operands that denote a single concrete value are recognised: an
+    item reference (``Scalar``) or a literal (``Constant``). Anything else
+    (a dimension, a sub-expression, ...) returns ``None`` so the equality
+    is not treated as a pin.
+
+    Args:
+        node: One side of an ``=`` condition.
+
+    Returns:
+        The value as a string, or ``None`` when it is not a literal value.
+    """
+    if isinstance(node, Scalar):
+        return node.item
+    if isinstance(node, Constant):
+        return str(node.value)
+    return None
+
+
+def _equality_pin(node: BinOp) -> tuple[str, str] | None:
+    """Return ``(dimension_code, value)`` for a ``dimension = value`` node.
+
+    The dimension may appear on either side of the ``=``. Returns ``None``
+    when the equality is not between exactly one ``Dimension`` and one
+    literal value (e.g. ``value = value`` or ``dimension = dimension``).
+
+    Args:
+        node: An ``=`` ``BinOp`` from a where condition.
+
+    Returns:
+        The pinned dimension code and value, or ``None``.
+    """
+    if isinstance(node.left, Dimension):
+        value = _equality_value(node.right)
+        if value is not None:
+            return node.left.dimension_code, value
+    if isinstance(node.right, Dimension):
+        value = _equality_value(node.left)
+        if value is not None:
+            return node.right.dimension_code, value
+    return None
+
+
+def _accumulate_pins(
+    node: AST, pins: dict[str, str], ambiguous: set[str]
+) -> None:
+    """Collect ``dimension = value`` pins guaranteed by ``node``.
+
+    Walks the conjunctive (``and``) skeleton of a where condition. Each
+    literal equality contributes a pin; a dimension pinned to two different
+    values within the same condition is recorded as ``ambiguous`` and later
+    dropped. Disjunctions (``or``) and every other shape contribute nothing,
+    so the result only ever lists values that *must* hold for every record.
+
+    Args:
+        node: The condition (sub-)tree to inspect.
+        pins: Accumulator of dimension -> pinned value.
+        ambiguous: Accumulator of dimensions seen with conflicting values.
+    """
+    if isinstance(node, ParExpr):
+        _accumulate_pins(node.expression, pins, ambiguous)
+        return
+    if not isinstance(node, BinOp):
+        return
+    if node.op == tokens.AND:
+        _accumulate_pins(node.left, pins, ambiguous)
+        _accumulate_pins(node.right, pins, ambiguous)
+        return
+    if node.op == tokens.EQ:
+        pin = _equality_pin(node)
+        if pin is not None:
+            dim, value = pin
+            if dim in pins and pins[dim] != value:
+                ambiguous.add(dim)
+            else:
+                pins[dim] = value
+
+
+def collect_where_equality_pins(condition: AST) -> dict[str, str]:
+    """Map each dimension a where condition pins to a single literal value.
+
+    Only top-level ``dimension = value`` equalities (optionally joined by
+    ``and`` or wrapped in parentheses) are reported. Any other shape -- an
+    ``or``, a ``!=``, a comparison, an ``in`` set, or a dimension pinned to
+    two conflicting values -- contributes no pin. The conservative result
+    lets a binary operator detect a guaranteed-empty inner join (two
+    operands pinning a shared key to different values) without false
+    positives.
+
+    Args:
+        condition: The where-clause condition AST.
+
+    Returns:
+        Dimension code -> the single value every record must take for it.
+    """
+    pins: dict[str, str] = {}
+    ambiguous: set[str] = set()
+    _accumulate_pins(condition, pins, ambiguous)
+    for dim in ambiguous:
+        pins.pop(dim, None)
+    return pins
+
+
+def merge_where_constraints(
+    base: dict[str, str], new: dict[str, str]
+) -> dict[str, str]:
+    """Combine the pins of a nested operand with those of an outer where.
+
+    Both sets of pins must hold simultaneously, so a dimension pinned to two
+    different values (e.g. ``[where qA = X][where qA = Y]``) is dropped
+    rather than picking a winner -- the operand is then treated as having no
+    reliable pin for it.
+
+    Args:
+        base: Pins already carried by the inner operand.
+        new: Pins added by the enclosing where clause.
+
+    Returns:
+        The merged pin mapping.
+    """
+    merged = dict(base)
+    for dim, value in new.items():
+        if dim in merged and merged[dim] != value:
+            del merged[dim]
+        else:
+            merged[dim] = value
+    return merged

--- a/src/dpmcore/dpm_xl/operators/base.py
+++ b/src/dpmcore/dpm_xl/operators/base.py
@@ -348,6 +348,7 @@ class Binary(Operator):
             result_structure = cls._check_structures(
                 left.structure, right.structure, origin
             )
+            cls._check_contradictory_where(left, right)
             if left.records is not None and right.records is not None:
                 if (
                     not cls.do_not_check_with_return_type
@@ -417,6 +418,33 @@ class Binary(Operator):
             return None, None
         else:
             return None, None
+
+    @classmethod
+    def _check_contradictory_where(
+        cls, left: RecordSet, right: RecordSet
+    ) -> None:
+        """Reject a binary op whose operands pin a shared key disjointly.
+
+        Two ``where`` filters that fix the same key component to different
+        literal values can never align: the inner join over that key yields
+        no rows, so the operation is dead. This raises the same "no match"
+        error the data-path empty-join check would (``2-2``), but during
+        structure-only validation where no records are loaded.
+
+        Args:
+            left: Left recordset operand.
+            right: Right recordset operand.
+
+        Raises:
+            SemanticError: ``2-2`` when a shared key is pinned to differing
+                values on the two operands.
+        """
+        shared = left.where_constraints.keys() & right.where_constraints.keys()
+        for dim in shared:
+            if left.where_constraints[dim] != right.where_constraints[dim]:
+                raise SemanticError(
+                    "2-2", op=cls.op, left=left.name, right=right.name
+                )
 
     @classmethod
     def check_same_components(

--- a/src/dpmcore/dpm_xl/semantic_analyzer.py
+++ b/src/dpmcore/dpm_xl/semantic_analyzer.py
@@ -43,6 +43,10 @@ from dpmcore.dpm_xl.ast.nodes import (
     Scalar as ScalarNode,
 )
 from dpmcore.dpm_xl.ast.template import ASTTemplate
+from dpmcore.dpm_xl.ast.where_clause import (
+    collect_where_equality_pins,
+    merge_where_constraints,
+)
 from dpmcore.dpm_xl.operators.clause import Sub as SubOperator
 from dpmcore.dpm_xl.symbols import (
     Component,
@@ -703,6 +707,13 @@ class InputAnalyzer(ASTTemplate, ABC):
             key_names=node.key_components,
             new_names=None,
             condition=condition,
+        )
+        # Record which dimensions this filter pins to a single value, merged
+        # with any carried by the inner operand (e.g. chained where clauses),
+        # so a binary operator can spot a contradictory inner join.
+        result.where_constraints = merge_where_constraints(
+            getattr(operand, "where_constraints", {}),
+            collect_where_equality_pins(node.condition),
         )
         return result
 

--- a/src/dpmcore/dpm_xl/symbols.py
+++ b/src/dpmcore/dpm_xl/symbols.py
@@ -212,6 +212,10 @@ class RecordSet(Operand):
         self.errors: Any = None
         self.interval: bool | None = None
         self.default: Any = None
+        # Dimensions this recordset pins to a single literal value via a
+        # ``where`` equality (dimension code -> value). Used by binary
+        # operators to detect an inner join that can never match.
+        self.where_constraints: dict[str, str] = {}
         self.has_only_global_components = all(
             component.is_global
             for component in structure.get_key_components().values()

--- a/tests/integration/validation/test_semantic_contradictory_where.py
+++ b/tests/integration/validation/test_semantic_contradictory_where.py
@@ -1,0 +1,52 @@
+"""Issue #121 — contradictory ``where`` clauses must yield a semantic error.
+
+When a binary operator combines two operands that each pin the same key
+component to a *different* literal value (``[where qEEA = A]`` and
+``[where qEEA = B]``), the inner join over that key can never match a row,
+so the validation is dead. The semantic analyzer must reject it (``2-2``)
+rather than silently accepting it.
+"""
+
+from dpmcore.services.semantic import SemanticService
+
+RELEASE = "4.2.1"
+
+# The reported dead validation, ``v6200_m`` (current version).
+V6200_M = (
+    "with {c0110, default: 0, interval: true}: sum ({tC_101.00}) <= "
+    "({tC_08.01.a, r0010}[where qEEA = [eba_qAE:qx2023]] + "
+    "{tC_08.01.a, r0010}[where qEEA = [eba_qAE:qx2022]]) * 2"
+)
+
+
+def test_contradictory_where_yields_2_2(fixture_session):
+    """``v6200_m`` pins qEEA to qx2023 vs qx2022 -> empty inner join."""
+    result = SemanticService(fixture_session).validate(
+        V6200_M, release_code=RELEASE
+    )
+    assert not result.is_valid
+    assert result.error_code == "2-2"
+
+
+def test_same_where_value_is_valid(fixture_session):
+    """Both operands pinned to the same value still align -> valid."""
+    expression = (
+        "{tC_08.01.a, r0010}[where qEEA = [eba_qAE:qx2023]] + "
+        "{tC_08.01.a, r0010}[where qEEA = [eba_qAE:qx2023]]"
+    )
+    result = SemanticService(fixture_session).validate(
+        expression, release_code=RELEASE
+    )
+    assert result.is_valid, result.error_message
+
+
+def test_single_where_operand_is_valid(fixture_session):
+    """Only one operand pinned -> the other spans all values -> valid."""
+    expression = (
+        "{tC_08.01.a, r0010}[where qEEA = [eba_qAE:qx2023]] + "
+        "{tC_08.01.a, r0010}"
+    )
+    result = SemanticService(fixture_session).validate(
+        expression, release_code=RELEASE
+    )
+    assert result.is_valid, result.error_message

--- a/tests/unit/ast/test_where_clause_pins.py
+++ b/tests/unit/ast/test_where_clause_pins.py
@@ -1,0 +1,96 @@
+"""Unit tests for where-clause equality-pin extraction.
+
+``collect_where_equality_pins`` reduces a where condition to the dimensions
+it pins to a single literal value; ``merge_where_constraints`` combines the
+pins of a nested operand with those of an enclosing where. Both feed the
+binary-operator contradiction check (issue #121).
+"""
+
+from dpmcore.dpm_xl.ast.nodes import (
+    BinOp,
+    Constant,
+    Dimension,
+    ParExpr,
+    Scalar,
+)
+from dpmcore.dpm_xl.ast.where_clause import (
+    collect_where_equality_pins,
+    merge_where_constraints,
+)
+from dpmcore.dpm_xl.utils import tokens
+
+
+def _item_eq(dim: str, value: str) -> BinOp:
+    """``dimension = [item]`` condition node."""
+    return BinOp(Dimension(dim), tokens.EQ, Scalar(value, "Item"))
+
+
+class TestCollectWhereEqualityPins:
+    def test_single_item_equality(self):
+        pins = collect_where_equality_pins(_item_eq("qEEA", "eba_qAE:qx2023"))
+        assert pins == {"qEEA": "eba_qAE:qx2023"}
+
+    def test_dimension_on_the_right(self):
+        """The dimension may sit on either side of the ``=``."""
+        node = BinOp(
+            Scalar("eba_qAE:qx2023", "Item"), tokens.EQ, Dimension("qEEA")
+        )
+        assert collect_where_equality_pins(node) == {"qEEA": "eba_qAE:qx2023"}
+
+    def test_literal_constant_value(self):
+        node = BinOp(Dimension("qA"), tokens.EQ, Constant("Integer", 5))
+        assert collect_where_equality_pins(node) == {"qA": "5"}
+
+    def test_conjunction_collects_each_dimension(self):
+        node = BinOp(_item_eq("qA", "X"), tokens.AND, _item_eq("qB", "Y"))
+        assert collect_where_equality_pins(node) == {"qA": "X", "qB": "Y"}
+
+    def test_repeated_dimension_same_value_kept(self):
+        node = BinOp(_item_eq("qA", "X"), tokens.AND, _item_eq("qA", "X"))
+        assert collect_where_equality_pins(node) == {"qA": "X"}
+
+    def test_repeated_dimension_conflicting_value_dropped(self):
+        """A dimension pinned two different ways is unreliable -> dropped."""
+        node = BinOp(_item_eq("qA", "X"), tokens.AND, _item_eq("qA", "Y"))
+        assert collect_where_equality_pins(node) == {}
+
+    def test_parenthesised_condition_unwrapped(self):
+        assert collect_where_equality_pins(ParExpr(_item_eq("qA", "X"))) == {
+            "qA": "X"
+        }
+
+    def test_disjunction_yields_no_pins(self):
+        node = BinOp(_item_eq("qA", "X"), tokens.OR, _item_eq("qB", "Y"))
+        assert collect_where_equality_pins(node) == {}
+
+    def test_inequality_yields_no_pins(self):
+        node = BinOp(Dimension("qA"), tokens.NEQ, Scalar("X", "Item"))
+        assert collect_where_equality_pins(node) == {}
+
+    def test_dimension_to_dimension_yields_no_pins(self):
+        node = BinOp(Dimension("qA"), tokens.EQ, Dimension("qB"))
+        assert collect_where_equality_pins(node) == {}
+
+    def test_value_to_value_yields_no_pins(self):
+        node = BinOp(Scalar("X", "Item"), tokens.EQ, Scalar("Y", "Item"))
+        assert collect_where_equality_pins(node) == {}
+
+    def test_non_binop_condition_yields_no_pins(self):
+        assert collect_where_equality_pins(Constant("Boolean", True)) == {}
+
+
+class TestMergeWhereConstraints:
+    def test_distinct_dimensions_unite(self):
+        assert merge_where_constraints({"qA": "X"}, {"qB": "Y"}) == {
+            "qA": "X",
+            "qB": "Y",
+        }
+
+    def test_same_dimension_same_value_kept(self):
+        assert merge_where_constraints({"qA": "X"}, {"qA": "X"}) == {"qA": "X"}
+
+    def test_same_dimension_conflicting_value_dropped(self):
+        assert merge_where_constraints({"qA": "X"}, {"qA": "Y"}) == {}
+
+    def test_empty_base(self):
+        assert merge_where_constraints({}, {"qA": "X"}) == {"qA": "X"}

--- a/tests/unit/dpm_xl/test_validate_structures.py
+++ b/tests/unit/dpm_xl/test_validate_structures.py
@@ -12,8 +12,8 @@ from dpmcore.dpm_xl.symbols import (
     RecordSet,
     Structure,
 )
-from dpmcore.dpm_xl.types.scalar import Number
-from dpmcore.dpm_xl.utils.tokens import STANDARD
+from dpmcore.dpm_xl.types.scalar import Item, Number
+from dpmcore.dpm_xl.utils.tokens import DPM, STANDARD
 from dpmcore.errors import SemanticError
 
 
@@ -47,3 +47,48 @@ class TestValidateStructuresDifferentRecordCounts:
         right = _make_recordset(3)
         with pytest.raises(SemanticError, match="different number of headers"):
             BinPlus.validate_structures(left, right)
+
+
+def _make_pinned_recordset(pins: dict[str, str]) -> RecordSet:
+    """Recordset sharing one DPM key (``qEEA``) with given where-pins."""
+    structure = Structure(
+        [
+            KeyComponent("r", Number(), STANDARD, "test"),
+            KeyComponent("qEEA", Item(), DPM, "test"),
+            FactComponent(Number(), "test"),
+        ]
+    )
+    rs = RecordSet(structure, "test", "test")
+    rs.where_constraints = pins
+    return rs
+
+
+class TestValidateStructuresContradictoryWhere:
+    """Issue #121: disjoint where-pins on a shared key are a dead join."""
+
+    def test_disjoint_pins_raise_2_2(self):
+        left = _make_pinned_recordset({"qEEA": "qx2023"})
+        right = _make_pinned_recordset({"qEEA": "qx2022"})
+        with pytest.raises(SemanticError, match="no match between"):
+            BinPlus.validate_structures(left, right)
+
+    def test_disjoint_pins_raise_2_2_for_comparison(self):
+        left = _make_pinned_recordset({"qEEA": "qx2023"})
+        right = _make_pinned_recordset({"qEEA": "qx2022"})
+        with pytest.raises(SemanticError, match="no match between"):
+            LessEqual.validate_structures(left, right)
+
+    def test_same_pin_value_does_not_raise(self):
+        left = _make_pinned_recordset({"qEEA": "qx2023"})
+        right = _make_pinned_recordset({"qEEA": "qx2023"})
+        BinPlus.validate_structures(left, right)  # must not raise
+
+    def test_pin_on_one_side_only_does_not_raise(self):
+        left = _make_pinned_recordset({"qEEA": "qx2023"})
+        right = _make_pinned_recordset({})
+        BinPlus.validate_structures(left, right)  # must not raise
+
+    def test_no_pins_does_not_raise(self):
+        left = _make_pinned_recordset({})
+        right = _make_pinned_recordset({})
+        BinPlus.validate_structures(left, right)  # must not raise


### PR DESCRIPTION
## Summary

Closes #121 

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [ ] Documentation updated (if applicable)

## Impact / Risk

- Breaking changes? (public API / CLI / REST endpoints / Django models)
- Database schema or migration concerns?
- Notes for release/changelog?

## Notes

<!-- Follow-ups, TODOs, or anything reviewers should know. -->
