### PR TITLE
fix(scopes): repair cross-instance ghost module versions in either di…

### DIFF
--- a/src/dpmcore/dpm_xl/model_queries.py
+++ b/src/dpmcore/dpm_xl/model_queries.py
@@ -10,6 +10,7 @@ legacy ``session.query()`` API for compatibility.
 from __future__ import annotations
 
 import warnings
+from datetime import date
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -945,17 +946,97 @@ class ModuleVersionQuery:
         return pd.DataFrame(results, columns=cols)
 
 
+def _select_version_in_effect(
+    siblings: list[ModuleVersion],
+    ghost_date: date | None,
+) -> ModuleVersion | None:
+    """Return the sibling whose real window covers ``ghost_date``.
+
+    Considers non-degenerate sibling versions (``from != to``) whose
+    validity window contains the ghost's collapsed reference date,
+    regardless of lifecycle direction. Ties prefer an open-ended
+    window, then the latest start date, then the highest start
+    release.
+
+    Args:
+        siblings: Versions of the same module.
+        ghost_date: The ghost's collapsed reference date.
+
+    Returns:
+        The version in effect, or ``None`` if none covers the date.
+    """
+    if ghost_date is None:
+        return None
+    candidates = [
+        mv
+        for mv in siblings
+        if mv.from_reference_date is not None
+        and mv.from_reference_date != mv.to_reference_date
+        and mv.from_reference_date <= ghost_date
+        and (
+            mv.to_reference_date is None or mv.to_reference_date >= ghost_date
+        )
+    ]
+    if not candidates:
+        return None
+    return max(
+        candidates,
+        key=lambda mv: (
+            mv.to_reference_date is None,
+            mv.from_reference_date,
+            mv.start_release_id or 0,
+        ),
+    )
+
+
+def _select_previous_version(
+    siblings: list[ModuleVersion],
+    cur_srid: int,
+) -> ModuleVersion | None:
+    """Return the nearest non-ghost predecessor by start release.
+
+    Last-resort fallback for ghosts whose reference date no sibling
+    window covers. ``siblings`` is ordered by ``start_release_id``
+    descending, so the first qualifying match is the closest earlier
+    version.
+
+    Args:
+        siblings: Versions of the same module.
+        cur_srid: Start release ID of the ghost version.
+
+    Returns:
+        The nearest earlier non-ghost version, or ``None``.
+    """
+    for mv in siblings:
+        if (
+            mv.start_release_id is not None
+            and mv.start_release_id < cur_srid
+            and mv.from_reference_date != mv.to_reference_date
+        ):
+            return mv
+    return None
+
+
 def _apply_fallback_for_equal_dates(
     session: "Session",
     df: pd.DataFrame,
     module_vid_col: str = "ModuleVID",
 ) -> pd.DataFrame:
-    """Replace ghost modules where dates are equal.
+    """Replace ghost module versions with the version in effect.
 
-    When ``FromReferenceDate == ToReferenceDate`` for a
-    module version, find the previous version of the same
-    module and substitute its metadata while preserving
+    A "ghost" version has a collapsed validity window
+    (``FromReferenceDate == ToReferenceDate``): it was superseded on
+    its own start date and never really applies. For each ghost row,
+    substitute the metadata of the sibling version (same module) that
+    is actually in effect on that reference date, preserving the
     association columns.
+
+    Selection is date-driven, so it repairs ghosts in either
+    lifecycle direction -- a forward successor that starts on the same
+    date (issue #131) or a backward predecessor whose window still
+    covers the date -- without depending on the opaque ``ReleaseID``
+    ordering. Only when no sibling window covers the date does it fall
+    back to the nearest non-ghost predecessor by start release.
 
     Args:
         session: SQLAlchemy session.
@@ -980,12 +1061,17 @@ def _apply_fallback_for_equal_dates(
             ModuleVersion.module_vid,
             ModuleVersion.module_id,
             ModuleVersion.start_release_id,
+            ModuleVersion.from_reference_date,
         ),
         ModuleVersion.module_vid,
         vids_needing,
     )
     current_info = {
-        r.module_vid: (r.module_id, r.start_release_id)
+        r.module_vid: (
+            r.module_id,
+            r.start_release_id,
+            r.from_reference_date,
+        )
         for r in current_modules
     }
 
@@ -1001,24 +1087,23 @@ def _apply_fallback_for_equal_dates(
         unique_mids,
     )
 
-    by_mid: dict[int, list[ModuleVersion]] = {}
+    # ``prev_versions`` is filtered by ``module_id IN (...)``, which never
+    # matches NULL, so every row carries a concrete module_id. The key type
+    # stays optional only to mirror the nullable ORM column.
+    by_mid: dict[int | None, list[ModuleVersion]] = {}
     for mv in prev_versions:
-        if mv.module_id is None:
-            continue
         by_mid.setdefault(mv.module_id, []).append(mv)
 
     replacement: dict[int, ModuleVersion] = {}
-    for cur_vid, (mid, cur_srid) in current_info.items():
-        if mid is None or cur_srid is None:
+    for cur_vid, (mid, cur_srid, ghost_date) in current_info.items():
+        if mid is None:
             continue
-        for mv in by_mid.get(mid, []):
-            if (
-                mv.start_release_id is not None
-                and mv.start_release_id < cur_srid
-            ):
-                if mv.from_reference_date != mv.to_reference_date:
-                    replacement[cur_vid] = mv
-                    break
+        siblings = by_mid.get(mid, [])
+        chosen = _select_version_in_effect(siblings, ghost_date)
+        if chosen is None and cur_srid is not None:
+            chosen = _select_previous_version(siblings, cur_srid)
+        if chosen is not None:
+            replacement[cur_vid] = chosen
 
     if not replacement:
         return df

--- a/src/dpmcore/dpm_xl/model_queries.py
+++ b/src/dpmcore/dpm_xl/model_queries.py
@@ -1075,7 +1075,9 @@ def _apply_fallback_for_equal_dates(
         for r in current_modules
     }
 
-    unique_mids = list({info[0] for info in current_info.values()})
+    unique_mids = list(
+        {info[0] for info in current_info.values() if info[0] is not None}
+    )
     # The per-module_id ORDER BY survives chunking because each module_id
     # falls entirely within one chunk (the chunk column is module_id).
     prev_versions = chunked_in(

--- a/tests/integration/queries/test_module_version_fallback.py
+++ b/tests/integration/queries/test_module_version_fallback.py
@@ -10,7 +10,6 @@ window still covers the date, and must leave non-ghost rows untouched.
 import datetime as dt
 
 import pandas as pd
-import pytest
 
 from dpmcore.dpm_xl.model_queries import _apply_fallback_for_equal_dates
 from dpmcore.orm.packaging import ModuleVersion
@@ -325,9 +324,6 @@ class TestApplyFallbackForEqualDates:
         out = _apply_fallback_for_equal_dates(memory_session, df)
         assert out.iloc[0]["ModuleVID"] == 602
 
-    @pytest.mark.filterwarnings(
-        "ignore:.*IN-predicate.*:sqlalchemy.exc.SAWarning"
-    )
     def test_null_module_id_ghost_kept(self, memory_session):
         memory_session.add(
             _mv(

--- a/tests/integration/queries/test_module_version_fallback.py
+++ b/tests/integration/queries/test_module_version_fallback.py
@@ -1,0 +1,360 @@
+"""Integration tests for ``_apply_fallback_for_equal_dates`` (issue #131).
+
+A "ghost" module version (``FromReferenceDate == ToReferenceDate``) is
+repaired by substituting the sibling version actually in effect on that
+date. The repair must work for a forward successor that starts on the same
+date (the #131 regression) as well as for a backward predecessor whose
+window still covers the date, and must leave non-ghost rows untouched.
+"""
+
+import datetime as dt
+
+import pandas as pd
+import pytest
+
+from dpmcore.dpm_xl.model_queries import _apply_fallback_for_equal_dates
+from dpmcore.orm.packaging import ModuleVersion
+
+_COLS = [
+    "ModuleVID",
+    "variable_vid",
+    "ModuleCode",
+    "VersionNumber",
+    "FromReferenceDate",
+    "ToReferenceDate",
+    "StartReleaseID",
+    "EndReleaseID",
+]
+
+
+def _mv(vid, mid, srid, erid, ver, frm, to):
+    """Build a ModuleVersion ORM row."""
+    return ModuleVersion(
+        module_vid=vid,
+        module_id=mid,
+        start_release_id=srid,
+        end_release_id=erid,
+        code="MOD",
+        version_number=ver,
+        from_reference_date=frm,
+        to_reference_date=to,
+    )
+
+
+def _row(vid, code, ver, frm, to, srid, erid):
+    """Build a result-frame row matching ``_COLS``."""
+    return (vid, vid, code, ver, frm, to, srid, erid)
+
+
+def _seed(session):
+    """Insert the module-version fixtures used across these tests."""
+    session.add_all(
+        [
+            # Module 63 (FINREP9DP shape): forward successor, same start date.
+            _mv(
+                506,
+                63,
+                5,
+                100,
+                "1.0.0",
+                dt.date(2026, 3, 31),
+                dt.date(2026, 3, 31),
+            ),
+            _mv(513, 63, 100, None, "1.1.0", dt.date(2026, 3, 31), None),
+            # Module 12 (FINREP9 shape): backward predecessor covers the date.
+            _mv(
+                356,
+                12,
+                1,
+                3,
+                "3.1.0",
+                dt.date(2022, 12, 31),
+                dt.date(2026, 3, 30),
+            ),
+            _mv(
+                404,
+                12,
+                3,
+                5,
+                "3.2.0",
+                dt.date(2024, 12, 31),
+                dt.date(2024, 12, 31),
+            ),
+            _mv(462, 12, 5, None, "3.3.0", dt.date(2026, 3, 31), None),
+            # Module 70: no window covers the date -> release-order fallback.
+            _mv(
+                700,
+                70,
+                1,
+                2,
+                "1.0",
+                dt.date(2020, 1, 1),
+                dt.date(2021, 12, 31),
+            ),
+            _mv(
+                701,
+                70,
+                2,
+                None,
+                "2.0",
+                dt.date(2024, 6, 30),
+                dt.date(2024, 6, 30),
+            ),
+            # Module 80: lone ghost with no possible replacement.
+            _mv(
+                800,
+                80,
+                1,
+                None,
+                "1.0",
+                dt.date(2024, 1, 1),
+                dt.date(2024, 1, 1),
+            ),
+        ]
+    )
+    session.flush()
+
+
+class TestApplyFallbackForEqualDates:
+    """End-to-end repair behaviour against an in-memory schema."""
+
+    def test_empty_frame_returned_unchanged(self, memory_session):
+        df = pd.DataFrame(columns=_COLS)
+        out = _apply_fallback_for_equal_dates(memory_session, df)
+        assert out.empty
+
+    def test_no_ghost_rows_returned_unchanged(self, memory_session):
+        _seed(memory_session)
+        df = pd.DataFrame(
+            [_row(513, "MOD", "1.1.0", dt.date(2026, 3, 31), None, 100, None)],
+            columns=_COLS,
+        )
+        out = _apply_fallback_for_equal_dates(memory_session, df)
+        assert out is df
+
+    def test_forward_successor_replaces_ghost(self, memory_session):
+        _seed(memory_session)
+        df = pd.DataFrame(
+            [
+                _row(
+                    506,
+                    "FINREP9DP",
+                    "1.0.0",
+                    dt.date(2026, 3, 31),
+                    dt.date(2026, 3, 31),
+                    5,
+                    100,
+                )
+            ],
+            columns=_COLS,
+        )
+        out = _apply_fallback_for_equal_dates(memory_session, df)
+        r = out.iloc[0]
+        assert r["ModuleVID"] == 513
+        assert r["VersionNumber"] == "1.1.0"
+        assert r["FromReferenceDate"] == dt.date(2026, 3, 31)
+        assert pd.isna(r["ToReferenceDate"])
+        assert r["StartReleaseID"] == 100
+        assert pd.isna(r["EndReleaseID"])
+
+    def test_backward_predecessor_replaces_ghost(self, memory_session):
+        _seed(memory_session)
+        df = pd.DataFrame(
+            [
+                _row(
+                    404,
+                    "FINREP9",
+                    "3.2.0",
+                    dt.date(2024, 12, 31),
+                    dt.date(2024, 12, 31),
+                    3,
+                    5,
+                )
+            ],
+            columns=_COLS,
+        )
+        out = _apply_fallback_for_equal_dates(memory_session, df)
+        r = out.iloc[0]
+        assert r["ModuleVID"] == 356
+        assert r["VersionNumber"] == "3.1.0"
+        assert r["ToReferenceDate"] == dt.date(2026, 3, 30)
+
+    def test_release_order_fallback_when_no_window_covers(
+        self, memory_session
+    ):
+        _seed(memory_session)
+        df = pd.DataFrame(
+            [
+                _row(
+                    701,
+                    "MOD70",
+                    "2.0",
+                    dt.date(2024, 6, 30),
+                    dt.date(2024, 6, 30),
+                    2,
+                    None,
+                )
+            ],
+            columns=_COLS,
+        )
+        out = _apply_fallback_for_equal_dates(memory_session, df)
+        r = out.iloc[0]
+        assert r["ModuleVID"] == 700
+        assert r["VersionNumber"] == "1.0"
+
+    def test_lone_ghost_without_replacement_kept(self, memory_session):
+        _seed(memory_session)
+        df = pd.DataFrame(
+            [
+                _row(
+                    800,
+                    "MOD80",
+                    "1.0",
+                    dt.date(2024, 1, 1),
+                    dt.date(2024, 1, 1),
+                    1,
+                    None,
+                )
+            ],
+            columns=_COLS,
+        )
+        out = _apply_fallback_for_equal_dates(memory_session, df)
+        # No replacement found at all -> original frame returned unchanged.
+        assert out is df
+        assert out.iloc[0]["ModuleVID"] == 800
+
+    def test_mixed_ghost_and_non_ghost_rows(self, memory_session):
+        _seed(memory_session)
+        df = pd.DataFrame(
+            [
+                _row(
+                    506,
+                    "FINREP9DP",
+                    "1.0.0",
+                    dt.date(2026, 3, 31),
+                    dt.date(2026, 3, 31),
+                    5,
+                    100,
+                ),  # ghost -> replaced by 513
+                _row(
+                    462,
+                    "FINREP9",
+                    "3.3.0",
+                    dt.date(2026, 3, 31),
+                    None,
+                    5,
+                    None,
+                ),  # non-ghost -> untouched
+                _row(
+                    800,
+                    "MOD80",
+                    "1.0",
+                    dt.date(2024, 1, 1),
+                    dt.date(2024, 1, 1),
+                    1,
+                    None,
+                ),  # ghost without replacement -> kept
+            ],
+            columns=_COLS,
+        )
+        out = _apply_fallback_for_equal_dates(memory_session, df)
+        assert out.iloc[0]["ModuleVID"] == 513
+        assert out.iloc[1]["ModuleVID"] == 462
+        assert out.iloc[2]["ModuleVID"] == 800
+
+    def test_replacement_without_release_id_columns(self, memory_session):
+        _seed(memory_session)
+        cols = [
+            "ModuleVID",
+            "ModuleCode",
+            "VersionNumber",
+            "FromReferenceDate",
+            "ToReferenceDate",
+        ]
+        df = pd.DataFrame(
+            [
+                (
+                    506,
+                    "FINREP9DP",
+                    "1.0.0",
+                    dt.date(2026, 3, 31),
+                    dt.date(2026, 3, 31),
+                )
+            ],
+            columns=cols,
+        )
+        out = _apply_fallback_for_equal_dates(memory_session, df)
+        r = out.iloc[0]
+        assert r["ModuleVID"] == 513
+        assert r["VersionNumber"] == "1.1.0"
+        assert "StartReleaseID" not in out.columns
+
+    def test_null_start_release_does_not_block_window_repair(
+        self, memory_session
+    ):
+        # A ghost with no start release must still be repaired by date.
+        memory_session.add_all(
+            [
+                _mv(
+                    601,
+                    65,
+                    None,
+                    None,
+                    "1.0.0",
+                    dt.date(2026, 3, 31),
+                    dt.date(2026, 3, 31),
+                ),
+                _mv(602, 65, 100, None, "1.1.0", dt.date(2026, 3, 31), None),
+            ]
+        )
+        memory_session.flush()
+        df = pd.DataFrame(
+            [
+                _row(
+                    601,
+                    "MODX",
+                    "1.0.0",
+                    dt.date(2026, 3, 31),
+                    dt.date(2026, 3, 31),
+                    None,
+                    None,
+                )
+            ],
+            columns=_COLS,
+        )
+        out = _apply_fallback_for_equal_dates(memory_session, df)
+        assert out.iloc[0]["ModuleVID"] == 602
+
+    @pytest.mark.filterwarnings(
+        "ignore:.*IN-predicate.*:sqlalchemy.exc.SAWarning"
+    )
+    def test_null_module_id_ghost_kept(self, memory_session):
+        memory_session.add(
+            _mv(
+                900,
+                None,
+                1,
+                None,
+                "1.0",
+                dt.date(2024, 1, 1),
+                dt.date(2024, 1, 1),
+            )
+        )
+        memory_session.flush()
+        df = pd.DataFrame(
+            [
+                _row(
+                    900,
+                    "MOD90",
+                    "1.0",
+                    dt.date(2024, 1, 1),
+                    dt.date(2024, 1, 1),
+                    1,
+                    None,
+                )
+            ],
+            columns=_COLS,
+        )
+        out = _apply_fallback_for_equal_dates(memory_session, df)
+        assert out is df
+        assert out.iloc[0]["ModuleVID"] == 900

--- a/tests/unit/dpm_xl/test_module_version_fallback.py
+++ b/tests/unit/dpm_xl/test_module_version_fallback.py
@@ -1,0 +1,90 @@
+"""Unit tests for the ghost-version selection helpers (issue #131).
+
+``_select_version_in_effect`` and ``_select_previous_version`` back
+``_apply_fallback_for_equal_dates``. A "ghost" module version has a
+collapsed validity window (``from == to``) because it was superseded on
+its own start date; these helpers locate the sibling version actually in
+effect on that date. The selection is date-driven so it works whether the
+real version is a forward successor (the #131 regression) or a backward
+predecessor, and it never relies on the opaque ``ReleaseID`` ordering.
+"""
+
+import datetime as dt
+
+from dpmcore.dpm_xl.model_queries import (
+    _select_previous_version,
+    _select_version_in_effect,
+)
+from dpmcore.orm.packaging import ModuleVersion
+
+_D = dt.date(2026, 3, 31)
+
+
+def _mv(vid, srid, erid, ver, frm, to, mid=10):
+    """Build an unattached ModuleVersion (no session needed)."""
+    return ModuleVersion(
+        module_vid=vid,
+        module_id=mid,
+        start_release_id=srid,
+        end_release_id=erid,
+        code="MOD",
+        version_number=ver,
+        from_reference_date=frm,
+        to_reference_date=to,
+    )
+
+
+class TestSelectVersionInEffect:
+    """Date-window selection across both lifecycle directions."""
+
+    def test_none_ghost_date_returns_none(self):
+        sib = _mv(2, 100, None, "1.1.0", _D, None)
+        assert _select_version_in_effect([sib], None) is None
+
+    def test_forward_successor_sharing_start_date(self):
+        # FINREP9DP shape: successor starts on the ghost's date, open-ended.
+        ghost = _mv(1, 5, 100, "1.0.0", _D, _D)
+        succ = _mv(2, 100, None, "1.1.0", _D, None)
+        assert _select_version_in_effect([succ, ghost], _D) is succ
+
+    def test_backward_predecessor_window_covers_date(self):
+        # FINREP9 shape: predecessor window straddles the ghost's date.
+        d = dt.date(2024, 12, 31)
+        pred = _mv(
+            1, 1, 3, "3.1.0", dt.date(2022, 12, 31), dt.date(2026, 3, 30)
+        )
+        ghost = _mv(2, 3, 5, "3.2.0", d, d)
+        later = _mv(3, 5, None, "3.3.0", dt.date(2026, 3, 31), None)
+        assert _select_version_in_effect([later, ghost, pred], d) is pred
+
+    def test_returns_none_when_no_window_covers_date(self):
+        # Predecessor ends before the date; only sibling left is the ghost.
+        before = _mv(1, 1, 2, "1.0", dt.date(2020, 1, 1), dt.date(2021, 1, 1))
+        ghost = _mv(2, 2, None, "2.0", _D, _D)
+        assert _select_version_in_effect([before, ghost], _D) is None
+
+    def test_tiebreak_prefers_open_ended_window(self):
+        closed = _mv(1, 5, 9, "a", dt.date(2025, 1, 1), dt.date(2027, 1, 1))
+        opened = _mv(2, 5, None, "b", dt.date(2025, 1, 1), None)
+        assert _select_version_in_effect([closed, opened], _D) is opened
+
+    def test_tiebreak_prefers_latest_start_date(self):
+        early = _mv(1, 5, 9, "a", dt.date(2024, 1, 1), dt.date(2027, 1, 1))
+        late = _mv(2, 6, 9, "b", dt.date(2025, 1, 1), dt.date(2027, 1, 1))
+        assert _select_version_in_effect([early, late], _D) is late
+
+
+class TestSelectPreviousVersion:
+    """Backward release-ordered fallback (preserved behaviour)."""
+
+    def test_returns_nearest_non_ghost_predecessor(self):
+        # Provided descending by start release, as production does. A ghost
+        # predecessor (v2) is skipped in favour of the real one (v1).
+        v3 = _mv(3, 5, None, "3.0", dt.date(2026, 1, 1), None)
+        v2 = _mv(2, 3, 5, "2.0", dt.date(2024, 1, 1), dt.date(2024, 1, 1))
+        v1 = _mv(1, 1, 3, "1.0", dt.date(2020, 1, 1), dt.date(2023, 1, 1))
+        assert _select_previous_version([v3, v2, v1], 4) is v1
+
+    def test_returns_none_when_no_earlier_version(self):
+        only = _mv(1, 5, None, "1.0", dt.date(2026, 1, 1), None)
+        assert _select_previous_version([only], 5) is None


### PR DESCRIPTION
## Summary

Closes #131

A cross-instance dependency on a module that has two versions starting on the same reference date resolved to the obsolete version. That old version is a "ghost": its validity window has collapsed to a single day (`FromReferenceDate == ToReferenceDate`). The output reported the wrong version number and a one-day window instead of the current version and its open-ended window.

`_apply_fallback_for_equal_dates` already replaces ghost versions, but it only searched backward (an older start release). When the only valid replacement is a forward successor (e.g. `FINREP9DP` 1.0.0 → 1.1.0), it found nothing and left the ghost in place.

## Content

- Replace the backward-only search with a date-based one: pick the sibling version whose real validity window contains the ghost's reference date. This repairs both a forward successor and a backward predecessor, and does not rely on the opaque `ReleaseID` ordering.
- Keep the old backward-by-release search as a fallback only when no sibling window covers the date, so existing behaviour is preserved.
- Add unit tests for the selection helpers and integration tests for the fallback (forward, backward, no-replacement, and edge cases).

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`); new code at 100% branch coverage
- [ ] Documentation updated (if applicable)