### PR TITLE
fix: script generation — if-then, eba_q namespace, false intra

### DIFF
--- a/src/dpmcore/dpm_xl/utils/serialization.py
+++ b/src/dpmcore/dpm_xl/utils/serialization.py
@@ -670,19 +670,19 @@ class ASTToJSONVisitor(NodeVisitor):
         return result
 
     def visit_Scalar(self, node: Any) -> NodeDict:
-        """Visit Scalar nodes with item name normalization."""
+        """Visit Scalar nodes, emitting the item code verbatim.
+
+        The item code is the namespaced member signature as authored
+        (e.g. ``eba_qEC:qx01``) and must be serialized unchanged. An
+        earlier "version compatibility" pass rewrote ``eba_q*`` to
+        ``eba_*``, which corrupted the namespace the engine consumes
+        (it dropped the ``q`` so ``eba_qEC`` became ``eba_EC``); the
+        engine requires the original code, so no rewriting is applied.
+        """
         result: NodeDict = {"class_name": "Scalar"}
 
-        # Apply item name normalization for version compatibility
         if hasattr(node, "item") and node.item:
-            item_name = node.item
-            # Handle version differences in scalar naming
-            # e.g., eba_qEC -> eba_EC, eba_qLR -> eba_LR
-            if isinstance(item_name, str) and item_name.startswith("eba_q"):
-                normalized_item = item_name.replace("eba_q", "eba_")
-                result["item"] = normalized_item
-            else:
-                result["item"] = item_name
+            result["item"] = node.item
 
         # Include scalar_type field (REQUIRED by ADAM Engine)
         if hasattr(node, "scalar_type") and node.scalar_type:

--- a/src/dpmcore/dpm_xl/utils/serialization.py
+++ b/src/dpmcore/dpm_xl/utils/serialization.py
@@ -321,10 +321,8 @@ class ASTToJSONVisitor(NodeVisitor):
                                     )
                                 transformed_record["z"] = z_index
 
-                        # Note: column and row are at VarID level, not in data entries
-
-                        # Add additional fields required by ADAM engine
-                        # CRITICAL: data_type determines how the engine processes values
+                        # Column and row live at VarID level, not in data entries.
+                        # data_type determines how values are processed downstream.
                         if (
                             "data_type" in record
                             and record["data_type"] is not None
@@ -393,10 +391,8 @@ class ASTToJSONVisitor(NodeVisitor):
                     }
                     coord_to_field = {"x": "row", "y": "column", "z": "sheet"}
 
-                    # Add dimension codes to each data entry
-                    # IMPORTANT: adam-engine requires BOTH row AND column in every data item
-                    # We add all dimension codes (row, column, sheet) when they exist in the original record
-                    # We need to match each transformed record back to its original record
+                    # Every data item carries both row and column (plus sheet
+                    # when present); match each transformed record to its origin.
                     record_index = 0
                     for x_index, row_code in enumerate(rows, 1):
                         for original_record in entries_by_row[row_code]:
@@ -405,8 +401,7 @@ class ASTToJSONVisitor(NodeVisitor):
                                     record_index
                                 ]
 
-                                # Add ALL dimension codes (row, column, sheet) to every data item
-                                # This is required by adam-engine even when the coordinate is common
+                                # Emit every coordinate, even when it is common.
                                 for coord in ["x", "y", "z"]:
                                     dimension_field = coord_to_dimension[coord]
                                     output_field = coord_to_field[coord]
@@ -553,11 +548,10 @@ class ASTToJSONVisitor(NodeVisitor):
         """Serialize SubOp as left-deep chained ``SubClauseOp`` nodes.
 
         Multi-sub ``X[sub a=1, b=2]`` is semantically equivalent to chained
-        single-subs ``X[sub a=1][sub b=2]``. The adam-engine consumer
-        defines ``SubClauseOp`` with a single ``condition`` field
-        (additionalProperties: false), so chaining is the only valid wire
-        shape -- the original recordset sits at the deepest level and each
-        substitution wraps the previous result.
+        single-subs ``X[sub a=1][sub b=2]``. ``SubClauseOp`` takes a single
+        ``condition`` field, so chaining is the only valid wire shape -- the
+        original recordset sits at the deepest level and each substitution
+        wraps the previous result.
         """
         result: NodeValue = self.visit(node.operand)
         for sub in node.substitutions:
@@ -670,21 +664,12 @@ class ASTToJSONVisitor(NodeVisitor):
         return result
 
     def visit_Scalar(self, node: Any) -> NodeDict:
-        """Visit Scalar nodes, emitting the item code verbatim.
-
-        The item code is the namespaced member signature as authored
-        (e.g. ``eba_qEC:qx01``) and must be serialized unchanged. An
-        earlier "version compatibility" pass rewrote ``eba_q*`` to
-        ``eba_*``, which corrupted the namespace the engine consumes
-        (it dropped the ``q`` so ``eba_qEC`` became ``eba_EC``); the
-        engine requires the original code, so no rewriting is applied.
-        """
+        """Visit Scalar nodes, emitting the item code unchanged."""
         result: NodeDict = {"class_name": "Scalar"}
 
         if hasattr(node, "item") and node.item:
             result["item"] = node.item
 
-        # Include scalar_type field (REQUIRED by ADAM Engine)
         if hasattr(node, "scalar_type") and node.scalar_type:
             result["scalar_type"] = node.scalar_type
 
@@ -924,7 +909,7 @@ def serialize_ast(ast_obj: Any) -> NodeValue:
     # ``toJSON`` for everything except ``GetOp``/``SubOp`` emitted
     # raw node attributes (``rows``/``cols``/``sheets``,
     # ``is_table_group``, ``default`` as a Constant dict) which the
-    # ADAM engine schema rejects.
+    # consumer schema rejects.
     if isinstance(expanded_obj, ASTObjects.AST):
         visitor = ASTToJSONVisitor()
         return visitor.visit(expanded_obj)

--- a/src/dpmcore/services/ast_generator.py
+++ b/src/dpmcore/services/ast_generator.py
@@ -555,6 +555,12 @@ class ASTGeneratorService:
             break
 
         op_symbol = getattr(node, "op", None)
+        if not op_symbol and type(node).__name__ == "CondExpr":
+            # An ``if-then`` / ``if-then-else`` validation has a ``CondExpr``
+            # root that carries no ``op`` on this stateless serialize path
+            # (only ``MLGeneration.visit_CondExpr`` sets it). Resolve its
+            # operator symbol explicitly, matching ``ml_generation.py``.
+            op_symbol = "if-then-else"
         if not op_symbol:
             raise RuntimeError(
                 f"Cannot resolve root operator: AST root "

--- a/src/dpmcore/services/ast_generator.py
+++ b/src/dpmcore/services/ast_generator.py
@@ -556,10 +556,7 @@ class ASTGeneratorService:
 
         op_symbol = getattr(node, "op", None)
         if not op_symbol and type(node).__name__ == "CondExpr":
-            # An ``if-then`` / ``if-then-else`` validation has a ``CondExpr``
-            # root that carries no ``op`` on this stateless serialize path
-            # (only ``MLGeneration.visit_CondExpr`` sets it). Resolve its
-            # operator symbol explicitly, matching ``ml_generation.py``.
+            # CondExpr carries no ``op`` attribute; its operator is fixed.
             op_symbol = "if-then-else"
         if not op_symbol:
             raise RuntimeError(

--- a/src/dpmcore/services/scope_calculator.py
+++ b/src/dpmcore/services/scope_calculator.py
@@ -310,8 +310,9 @@ class ScopeCalculatorService:
             scope_result, primary_module_vid
         )
         if not valid_vids:
-            # The primary module appears in no scope, so it hosts none of
-            # the referenced tables and is not the intra-instance owner.
+            # Scopes exist, but the primary module hosts none of the
+            # referenced tables and so participates in none of them: it is
+            # neither the intra-instance owner nor a cross-instance partner.
             return {**empty_result}
 
         # Build cross_instance_dependencies and dependency_modules

--- a/src/dpmcore/services/scope_calculator.py
+++ b/src/dpmcore/services/scope_calculator.py
@@ -310,16 +310,8 @@ class ScopeCalculatorService:
             scope_result, primary_module_vid
         )
         if not valid_vids:
-            # Reaching here, the operation is cross-module yet the primary
-            # module is neither a single-module scope on its own (see
-            # ``primary_has_intra`` above) nor a partner in any multi-module
-            # scope (``filter_valid_dependency_modules`` returned nothing).
-            # That means the primary participates in *no* scope at all and so
-            # hosts none of the referenced tables — it cannot be the
-            # intra-instance owner. Classifying it intra here would emit a
-            # script with an empty ``tables`` block falsely marked
-            # intra-instance (e.g. generating an IF_CLASS2/IF_CLASS3
-            # validation for COREP_OF). Emit no classification instead.
+            # The primary module appears in no scope, so it hosts none of
+            # the referenced tables and is not the intra-instance owner.
             return {**empty_result}
 
         # Build cross_instance_dependencies and dependency_modules

--- a/src/dpmcore/services/scope_calculator.py
+++ b/src/dpmcore/services/scope_calculator.py
@@ -310,12 +310,17 @@ class ScopeCalculatorService:
             scope_result, primary_module_vid
         )
         if not valid_vids:
-            return {
-                **empty_result,
-                "intra_instance_validations": (
-                    [operation_code] if operation_code else []
-                ),
-            }
+            # Reaching here, the operation is cross-module yet the primary
+            # module is neither a single-module scope on its own (see
+            # ``primary_has_intra`` above) nor a partner in any multi-module
+            # scope (``filter_valid_dependency_modules`` returned nothing).
+            # That means the primary participates in *no* scope at all and so
+            # hosts none of the referenced tables — it cannot be the
+            # intra-instance owner. Classifying it intra here would emit a
+            # script with an empty ``tables`` block falsely marked
+            # intra-instance (e.g. generating an IF_CLASS2/IF_CLASS3
+            # validation for COREP_OF). Emit no classification instead.
+            return {**empty_result}
 
         # Build cross_instance_dependencies and dependency_modules
         cross_deps: List[Dict[str, Any]] = []

--- a/tests/integration/services/test_ast_generator_condexpr.py
+++ b/tests/integration/services/test_ast_generator_condexpr.py
@@ -1,14 +1,8 @@
-"""Integration regression for if-then(-else) script generation.
+"""Integration regression: if-then(-else) script generation.
 
-``ASTGeneratorService.script`` previously failed for every ``if-then`` /
-``if-then-else`` validation with::
-
-    Cannot resolve root operator: AST root 'CondExpr' has no 'op' attribute.
-
-because ``CondExpr`` carries no ``op`` on the stateless serialize path (only
-``MLGeneration.visit_CondExpr`` sets it). The downstream engine consumes the
-``script`` output, so this blocked a broad slice of the dictionary (DORA,
-REM_DBM, ...). These tests pin the fix against the real 4.2.1 dictionary.
+``ASTGeneratorService.script`` failed for every ``if-then`` / ``if-then-else``
+validation because a ``CondExpr`` root carries no ``op`` attribute. These
+tests confirm such validations now generate and resolve their root operator.
 """
 
 from __future__ import annotations

--- a/tests/integration/services/test_ast_generator_condexpr.py
+++ b/tests/integration/services/test_ast_generator_condexpr.py
@@ -6,7 +6,7 @@
     Cannot resolve root operator: AST root 'CondExpr' has no 'op' attribute.
 
 because ``CondExpr`` carries no ``op`` on the stateless serialize path (only
-``MLGeneration.visit_CondExpr`` sets it). The ADAM engine consumes the
+``MLGeneration.visit_CondExpr`` sets it). The downstream engine consumes the
 ``script`` output, so this blocked a broad slice of the dictionary (DORA,
 REM_DBM, ...). These tests pin the fix against the real 4.2.1 dictionary.
 """

--- a/tests/integration/services/test_ast_generator_condexpr.py
+++ b/tests/integration/services/test_ast_generator_condexpr.py
@@ -22,13 +22,15 @@ def _latest_expression(session, code: str) -> str:
         {"c": code},
     ).scalar()
     assert operation_id is not None, f"{code} not in fixture DB"
-    return session.execute(
+    expression = session.execute(
         text(
             "SELECT Expression FROM OperationVersion "
             "WHERE OperationID = :o ORDER BY OperationVID DESC LIMIT 1"
         ),
         {"o": operation_id},
     ).scalar()
+    assert expression is not None, f"{code} has no expression in fixture DB"
+    return expression
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/services/test_ast_generator_condexpr.py
+++ b/tests/integration/services/test_ast_generator_condexpr.py
@@ -1,0 +1,64 @@
+"""Integration regression for if-then(-else) script generation.
+
+``ASTGeneratorService.script`` previously failed for every ``if-then`` /
+``if-then-else`` validation with::
+
+    Cannot resolve root operator: AST root 'CondExpr' has no 'op' attribute.
+
+because ``CondExpr`` carries no ``op`` on the stateless serialize path (only
+``MLGeneration.visit_CondExpr`` sets it). The ADAM engine consumes the
+``script`` output, so this blocked a broad slice of the dictionary (DORA,
+REM_DBM, ...). These tests pin the fix against the real 4.2.1 dictionary.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import text
+
+from dpmcore.services.ast_generator import ASTGeneratorService
+
+_IF_THEN_OPERATOR_ID = 30  # Operator.Symbol == "if-then-else"
+
+
+def _latest_expression(session, code: str) -> str:
+    """Return the latest-version expression text for an operation code."""
+    operation_id = session.execute(
+        text("SELECT OperationID FROM Operation WHERE Code = :c"),
+        {"c": code},
+    ).scalar()
+    assert operation_id is not None, f"{code} not in fixture DB"
+    return session.execute(
+        text(
+            "SELECT Expression FROM OperationVersion "
+            "WHERE OperationID = :o ORDER BY OperationVID DESC LIMIT 1"
+        ),
+        {"o": operation_id},
+    ).scalar()
+
+
+@pytest.mark.parametrize(
+    ("code", "module_code", "module_version"),
+    [
+        ("v22581_m", "REM_DBM", "2.3.0"),
+        ("v8804_m", "DORA", "1.2.0"),
+    ],
+)
+def test_if_then_validation_generates(
+    fixture_session, code, module_code, module_version
+):
+    """A real if-then validation now generates a CondExpr-rooted script."""
+    expression = _latest_expression(fixture_session, code)
+    service = ASTGeneratorService(fixture_session)
+
+    result = service.script(
+        expressions=[(expression, code)],
+        module_code=module_code,
+        module_version=module_version,
+    )
+
+    assert result["success"], result["error"]
+    namespace = next(iter(result["enriched_ast"]))
+    operation = result["enriched_ast"][namespace]["operations"][code]
+    assert operation["root_operator_id"] == _IF_THEN_OPERATOR_ID
+    assert operation["ast"]["class_name"] == "CondExpr"

--- a/tests/integration/services/test_cross_module_classification.py
+++ b/tests/integration/services/test_cross_module_classification.py
@@ -1,8 +1,8 @@
-"""Integration regression for intra/cross-module classification (#623 P1).
+"""Integration regression for intra/cross-module classification.
 
 These pin, against the real 4.2.1 dictionary, the dependency-information
 classification that ``ASTGeneratorService.script`` emits for the validations
-the ADAM engine flagged. The agreed rule: a validation is intra-instance for
+the downstream engine flagged. The agreed rule: a validation is intra-instance for
 module M when every table it references belongs to M; otherwise, for a module
 that hosts only some of the tables it is a cross-instance dependency; and for
 a module that hosts *none* of its tables it is neither (empty classification).

--- a/tests/integration/services/test_cross_module_classification.py
+++ b/tests/integration/services/test_cross_module_classification.py
@@ -1,0 +1,95 @@
+"""Integration regression for intra/cross-module classification (#623 P1).
+
+These pin, against the real 4.2.1 dictionary, the dependency-information
+classification that ``ASTGeneratorService.script`` emits for the validations
+the ADAM engine flagged. The agreed rule: a validation is intra-instance for
+module M when every table it references belongs to M; otherwise, for a module
+that hosts only some of the tables it is a cross-instance dependency; and for
+a module that hosts *none* of its tables it is neither (empty classification).
+
+Synthetic-fixture greens are what let the rc2 misclassifications slip, so
+these run end-to-end on the shipped dictionary.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import text
+
+from dpmcore.services.ast_generator import ASTGeneratorService
+
+
+def _latest_expression(session, code: str) -> str:
+    operation_id = session.execute(
+        text("SELECT OperationID FROM Operation WHERE Code = :c"),
+        {"c": code},
+    ).scalar()
+    assert operation_id is not None, f"{code} not in fixture DB"
+    return session.execute(
+        text(
+            "SELECT Expression FROM OperationVersion "
+            "WHERE OperationID = :o ORDER BY OperationVID DESC LIMIT 1"
+        ),
+        {"o": operation_id},
+    ).scalar()
+
+
+def _classify(session, code, module_code, module_version):
+    expression = _latest_expression(session, code)
+    result = ASTGeneratorService(session).script(
+        expressions=[(expression, code)],
+        module_code=module_code,
+        module_version=module_version,
+    )
+    assert result["success"], result["error"]
+    namespace = next(iter(result["enriched_ast"]))
+    module = result["enriched_ast"][namespace]
+    info = module["dependency_information"]
+    return {
+        "intra": info["intra_instance_validations"],
+        "cross": len(info["cross_instance_dependencies"]),
+        "tables": sorted(module["tables"].keys()),
+    }
+
+
+@pytest.mark.parametrize(
+    ("code", "module_code", "module_version", "expect_intra", "expect_cross"),
+    [
+        # Both referenced tables belong to the module -> intra in both.
+        ("v09808_m", "COREP_OF", "4.1.0", True, False),
+        ("v09808_m", "IF_CLASS2", "1.4.0", True, False),
+        # All tables in the primary, secondary requires the primary -> the
+        # legit MIXED case: intra for COREP_OF, cross for IF_CLASS2.
+        ("v22973_m", "COREP_OF", "4.1.0", True, False),
+        ("v22973_m", "IF_CLASS2", "1.4.0", False, True),
+        # v11120_m references I_04.00 (IF_CLASS2-only) and I_05.00 (both
+        # IF_CLASS2 and IF_CLASS3): intra in IF_CLASS2, cross in IF_CLASS3.
+        ("v11120_m", "IF_CLASS2", "1.4.0", True, False),
+        ("v11120_m", "IF_CLASS3", "1.4.0", False, True),
+    ],
+)
+def test_named_classification(
+    fixture_session,
+    code,
+    module_code,
+    module_version,
+    expect_intra,
+    expect_cross,
+):
+    """Each named validation classifies as agreed against real data."""
+    result = _classify(fixture_session, code, module_code, module_version)
+    assert (result["intra"] == [code]) is expect_intra
+    assert (result["cross"] > 0) is expect_cross
+
+
+def test_primary_hosting_no_tables_is_not_intra(fixture_session):
+    """v11120_m for COREP_OF (hosts neither I_04.00 nor I_05.00).
+
+    Regression for the misclassification where a validation generated for a
+    module that hosts none of its tables was emitted as intra-instance with
+    an empty ``tables`` block. It must be neither intra nor cross.
+    """
+    result = _classify(fixture_session, "v11120_m", "COREP_OF", "4.1.0")
+    assert result["intra"] == []
+    assert result["cross"] == 0
+    assert result["tables"] == []

--- a/tests/integration/services/test_cross_module_classification.py
+++ b/tests/integration/services/test_cross_module_classification.py
@@ -1,14 +1,9 @@
-"""Integration regression for intra/cross-module classification.
+"""Integration regression: intra/cross-module classification.
 
-These pin, against the real 4.2.1 dictionary, the dependency-information
-classification that ``ASTGeneratorService.script`` emits for the validations
-the downstream engine flagged. The agreed rule: a validation is intra-instance for
-module M when every table it references belongs to M; otherwise, for a module
-that hosts only some of the tables it is a cross-instance dependency; and for
-a module that hosts *none* of its tables it is neither (empty classification).
-
-Synthetic-fixture greens are what let the rc2 misclassifications slip, so
-these run end-to-end on the shipped dictionary.
+A validation is intra-instance for a module when every table it references
+belongs to that module; cross-instance when the module hosts only some of
+them; and neither when the module hosts none. These tests pin that behaviour
+for the affected validations.
 """
 
 from __future__ import annotations
@@ -76,19 +71,14 @@ def test_named_classification(
     expect_intra,
     expect_cross,
 ):
-    """Each named validation classifies as agreed against real data."""
+    """Each named validation classifies as expected."""
     result = _classify(fixture_session, code, module_code, module_version)
     assert (result["intra"] == [code]) is expect_intra
     assert (result["cross"] > 0) is expect_cross
 
 
 def test_primary_hosting_no_tables_is_not_intra(fixture_session):
-    """v11120_m for COREP_OF (hosts neither I_04.00 nor I_05.00).
-
-    Regression for the misclassification where a validation generated for a
-    module that hosts none of its tables was emitted as intra-instance with
-    an empty ``tables`` block. It must be neither intra nor cross.
-    """
+    """A module hosting none of a validation's tables is neither intra nor cross."""
     result = _classify(fixture_session, "v11120_m", "COREP_OF", "4.1.0")
     assert result["intra"] == []
     assert result["cross"] == 0

--- a/tests/integration/services/test_cross_module_classification.py
+++ b/tests/integration/services/test_cross_module_classification.py
@@ -20,13 +20,15 @@ def _latest_expression(session, code: str) -> str:
         {"c": code},
     ).scalar()
     assert operation_id is not None, f"{code} not in fixture DB"
-    return session.execute(
+    expression = session.execute(
         text(
             "SELECT Expression FROM OperationVersion "
             "WHERE OperationID = :o ORDER BY OperationVID DESC LIMIT 1"
         ),
         {"o": operation_id},
     ).scalar()
+    assert expression is not None, f"{code} has no expression in fixture DB"
+    return expression
 
 
 def _classify(session, code, module_code, module_version):

--- a/tests/unit/ast/test_sub.py
+++ b/tests/unit/ast/test_sub.py
@@ -6,7 +6,7 @@ The sub clause accepts one or more comma-separated substitutions:
 
 import pytest
 
-from dpmcore.dpm_xl.ast.nodes import SubAssignment, SubOp
+from dpmcore.dpm_xl.ast.nodes import Scalar, SubAssignment, SubOp
 from dpmcore.dpm_xl.utils.serialization import ASTToJSONVisitor
 from dpmcore.services.syntax import SyntaxService
 
@@ -118,6 +118,48 @@ def test_multi_sub_serializes_as_chained_subclause_ops():
 
     # Original recordset sits at the deepest level.
     assert inner["operand"]["class_name"] != "SubClauseOp"
+
+
+@pytest.mark.parametrize(
+    "item_code",
+    [
+        "eba_qEC:qx01",
+        "eba_qAE:qx2023",
+        "eba_qLR:qx10",
+        "eba_EC:qx01",
+        "ns:code",
+    ],
+)
+def test_scalar_item_serialized_verbatim(item_code):
+    """A Scalar item code is serialized unchanged.
+
+    Regression: an earlier pass rewrote ``eba_q*`` to ``eba_*`` (dropping
+    the ``q``), corrupting the namespaced member signature the engine
+    consumes (``eba_qEC:qx01`` became ``eba_EC:qx01``). The code must be
+    emitted exactly as authored.
+    """
+    serialized = ASTToJSONVisitor().visit(
+        Scalar(item=item_code, scalar_type="Item")
+    )
+
+    assert serialized["class_name"] == "Scalar"
+    assert serialized["item"] == item_code
+    assert serialized["scalar_type"] == "Item"
+
+
+def test_sub_clause_preserves_eba_q_item_namespace():
+    """``[sub key = [eba_qEC:qx01]]`` keeps the ``q`` in the item code.
+
+    End-to-end through the parser and serializer: the substitution value
+    is a namespaced item whose ``q`` must survive into the wire format.
+    """
+    ast = SyntaxService().parse("{tT, r010}[sub c0010 = [eba_qEC:qx01]]")
+    sub_op = ast.children[0]
+    serialized = ASTToJSONVisitor().visit(sub_op)
+
+    right = serialized["condition"]["right"]
+    assert right["class_name"] == "Scalar"
+    assert right["item"] == "eba_qEC:qx01"
 
 
 def test_three_subs_serialize_as_three_chained_subclause_ops():

--- a/tests/unit/ast/test_sub.py
+++ b/tests/unit/ast/test_sub.py
@@ -78,8 +78,8 @@ def test_multiple_sub_produces_multiple_substitutions():
 def test_single_sub_serializes_as_one_subclause_op():
     """Single-sub JSON is one SubClauseOp wrapping the recordset directly.
 
-    Backwards-compatibility check: adam-engine's existing scripts use this
-    shape, so the wire format must be unchanged for the single-sub case.
+    Backwards-compatibility check: the wire format must be unchanged for
+    the single-sub case.
     """
     ast = SyntaxService().parse('{tT, r010}[sub c0010 = "ES"]')
     sub_op = ast.children[0]
@@ -97,9 +97,8 @@ def test_single_sub_serializes_as_one_subclause_op():
 def test_multi_sub_serializes_as_chained_subclause_ops():
     """Multi-sub JSON nests one SubClauseOp per substitution (left-deep).
 
-    Locks the wire-format contract with adam-engine, whose ``SubClauseOp``
-    schema accepts a single ``condition`` per node. The outermost node
-    wraps the LAST substitution; the original recordset sits at the
+    ``SubClauseOp`` accepts a single ``condition`` per node. The outermost
+    node wraps the LAST substitution; the original recordset sits at the
     deepest level. Order matches the left-to-right reading of the
     source: ``c0010`` is applied first, ``c0020`` second.
     """
@@ -131,13 +130,7 @@ def test_multi_sub_serializes_as_chained_subclause_ops():
     ],
 )
 def test_scalar_item_serialized_verbatim(item_code):
-    """A Scalar item code is serialized unchanged.
-
-    Regression: an earlier pass rewrote ``eba_q*`` to ``eba_*`` (dropping
-    the ``q``), corrupting the namespaced member signature the engine
-    consumes (``eba_qEC:qx01`` became ``eba_EC:qx01``). The code must be
-    emitted exactly as authored.
-    """
+    """A Scalar item code is serialized exactly as authored."""
     serialized = ASTToJSONVisitor().visit(
         Scalar(item=item_code, scalar_type="Item")
     )
@@ -148,11 +141,7 @@ def test_scalar_item_serialized_verbatim(item_code):
 
 
 def test_sub_clause_preserves_eba_q_item_namespace():
-    """``[sub key = [eba_qEC:qx01]]`` keeps the ``q`` in the item code.
-
-    End-to-end through the parser and serializer: the substitution value
-    is a namespaced item whose ``q`` must survive into the wire format.
-    """
+    """``[sub key = [eba_qEC:qx01]]`` keeps the ``q`` in the item code."""
     ast = SyntaxService().parse("{tT, r010}[sub c0010 = [eba_qEC:qx01]]")
     sub_op = ast.children[0]
     serialized = ASTToJSONVisitor().visit(sub_op)

--- a/tests/unit/services/test_ast_generator.py
+++ b/tests/unit/services/test_ast_generator.py
@@ -489,13 +489,12 @@ class TestResolveRootOperatorId:
         assert Cls._resolve_root_operator_id(pa, MagicMock()) == 33
 
     def test_condexpr_root_resolves_to_if_then_else(self, monkeypatch):
-        # An if-then / if-then-else validation has a CondExpr root that
-        # carries no 'op' on the stateless serialize path. It must resolve
-        # to the 'if-then-else' operator rather than raising.
+        # A CondExpr root has no 'op'; it resolves to the if-then-else
+        # operator instead of raising.
         _, Cls, _ = _bare_svc()
         CondExpr = type("CondExpr", (), {})
         node = CondExpr()
-        node.op = None  # mirrors the AST base default
+        node.op = None
 
         WithExpression = type("WithExpression", (), {})
         with_expr = WithExpression()

--- a/tests/unit/services/test_ast_generator.py
+++ b/tests/unit/services/test_ast_generator.py
@@ -488,6 +488,35 @@ class TestResolveRootOperatorId:
         )
         assert Cls._resolve_root_operator_id(pa, MagicMock()) == 33
 
+    def test_condexpr_root_resolves_to_if_then_else(self, monkeypatch):
+        # An if-then / if-then-else validation has a CondExpr root that
+        # carries no 'op' on the stateless serialize path. It must resolve
+        # to the 'if-then-else' operator rather than raising.
+        _, Cls, _ = _bare_svc()
+        CondExpr = type("CondExpr", (), {})
+        node = CondExpr()
+        node.op = None  # mirrors the AST base default
+
+        WithExpression = type("WithExpression", (), {})
+        with_expr = WithExpression()
+        with_expr.expression = node
+
+        class FakeOperatorQuery:
+            @staticmethod
+            def get_operators(session):  # noqa: ARG004
+                import pandas as pd
+
+                return pd.DataFrame(
+                    [{"Symbol": "if-then-else", "OperatorID": 30}]
+                )
+
+        monkeypatch.setitem(
+            sys.modules,
+            "dpmcore.dpm_xl.model_queries",
+            SimpleNamespace(OperatorQuery=FakeOperatorQuery),
+        )
+        assert Cls._resolve_root_operator_id(with_expr, MagicMock()) == 30
+
     def test_unresolvable_root_raises(self, monkeypatch):
         _, Cls, _ = _bare_svc()
         # No 'op' attribute anywhere.

--- a/tests/unit/services/test_scope_calculator.py
+++ b/tests/unit/services/test_scope_calculator.py
@@ -397,11 +397,8 @@ class TestDetectCrossModuleDependencies:
         assert dep["affected_operations"] == ["v1234"]
 
     def test_primary_in_no_scope_is_not_intra(self):
-        # The primary module (10) appears in no scope: the cross-module
-        # scope is between 20 and 30. The primary hosts none of the
-        # referenced tables, so it must NOT be classified intra-instance
-        # (it would otherwise emit a script with an empty tables block
-        # falsely marked intra).
+        # Primary module 10 is in no scope (the cross-module scope is
+        # 20+30), so it must not be classified intra-instance.
         svc, SR = self._make_svc()
         sr = SR(
             scopes=[_scope([20, 30])],

--- a/tests/unit/services/test_scope_calculator.py
+++ b/tests/unit/services/test_scope_calculator.py
@@ -396,7 +396,12 @@ class TestDetectCrossModuleDependencies:
         assert dep["modules"][0]["URI"] == ("http://uri/mod_20")
         assert dep["affected_operations"] == ["v1234"]
 
-    def test_no_valid_deps_returns_intra(self):
+    def test_primary_in_no_scope_is_not_intra(self):
+        # The primary module (10) appears in no scope: the cross-module
+        # scope is between 20 and 30. The primary hosts none of the
+        # referenced tables, so it must NOT be classified intra-instance
+        # (it would otherwise emit a script with an empty tables block
+        # falsely marked intra).
         svc, SR = self._make_svc()
         sr = SR(
             scopes=[_scope([20, 30])],
@@ -407,7 +412,7 @@ class TestDetectCrossModuleDependencies:
             primary_module_vid=10,
             operation_code="v1234",
         )
-        assert info["intra_instance_validations"] == ["v1234"]
+        assert info["intra_instance_validations"] == []
         assert info["cross_instance_dependencies"] == []
 
     def test_alternative_deps_included(self):


### PR DESCRIPTION
## Summary

Closes #139 
Closes #140 
Closes #141 

After upgrading to `0.1.1rc2`, the ADAM engine team still saw broken validation **scripts**. We reproduced every report against the and found that rc2's scope work had already fixed the cross-module *classification* complaints, but **three real bugs remained in script generation**. This PR fixes all three.

1. **`if-then` validations could not be generated at all.** Any validation written as `if (…) then (…) endif` made `ast_generator.script(...)` fail. This is broad (DORA, REM_DBM, and every conditional validation) and is the most likely cause of the "scripts are still broken" feedback.
2. **Item codes were corrupted** : `eba_qEC:qx01` came out as `eba_EC:qx01` (the `q` was dropped) in every generated script.
3. **Wrong "intra" label** : a validation generated for a module that contains *none* of its tables was reported as `intra` with an empty tables block.

**Evidence:**

| Bug | Before (0.1.1rc2) | After (this PR) |
|---|---|---|
| 1 : `v22581_m`, `v8804_m` | `success=False`, `"Cannot resolve root operator: AST root 'CondExpr' has no 'op' attribute."` | `success=True`, root operator = `if-then-else` (id 30) |
| 2 : `EGDQ_0951` `[sub … = [eba_qEC:qx01]]` | item = `eba_EC:qx01` | item = `eba_qEC:qx01` |
| 3 : `v11120_m` for `COREP_OF` | `intra=['v11120_m']`, `tables=[]` | `intra=[]`, `tables=[]` |

**Root causes:**

- Bug 1 : `ASTGeneratorService._resolve_root_operator_id` read `node.op`, but a `CondExpr` root never has it set on the serialize path. Fix: map `CondExpr` → `if-then-else`.
- Bug 2 : `ASTToJSONVisitor.visit_Scalar` had a wrong "normalization" (`replace("eba_q", "eba_")`). Fix: emit the item code verbatim.
- Bug 3 : `ScopeCalculatorService.detect_cross_module_dependencies` fell back to `intra` even when the primary module is in no scope. Fix: emit no classification in that case.

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [ ] Documentation updated (if applicable)