### PR TITLE
Semantic analysis accepts a default: value whose type cannot be cast to the cell type

### DIFF
--- a/src/dpmcore/dpm_xl/semantic_analyzer.py
+++ b/src/dpmcore/dpm_xl/semantic_analyzer.py
@@ -253,17 +253,14 @@ class InputAnalyzer(ASTTemplate, ABC):
         cell_implicities = implicit_type_promotion_dict.get(
             type_.__class__, set()
         )
-        # Accept: D→C, C→D, or shared promotion target (excl. Boolean crossings).
-        # Mixed has no dict entry; empty cell_implicities skips the check.
-        if cell_implicities and not (
-            type_.is_included(default_implicities)
-            or default_type.is_included(cell_implicities)
-            or (
-                not isinstance(default_type, Boolean)
-                and not isinstance(type_, Boolean)
-                and default_implicities & cell_implicities
-            )
-        ):
+        # A default fills the cell, so its type must be implicitly castable
+        # *to* the cell type (spec §2.3.2) — a one-directional check. The
+        # reverse direction is meaningless: every type is implicitly castable
+        # to String, so a bidirectional check wrongly accepts e.g. a String
+        # default on a Number cell (String → Number is an Explicit cast).
+        # Null already promotes to every type; a Mixed cell has unknown type
+        # (no dict entry, empty ``cell_implicities``) and accepts any default.
+        if cell_implicities and not type_.is_included(default_implicities):
             raise errors.SemanticError(
                 "3-6", expected_type=type_, default_type=default_type
             )

--- a/tests/unit/semantic/test_default_value_type_check.py
+++ b/tests/unit/semantic/test_default_value_type_check.py
@@ -101,9 +101,7 @@ class TestCheckDefaultValue:
                 default_value, Boolean()
             )
 
-        assert "Invalid default type" in str(exc_info.value)
-        assert "String" in str(exc_info.value)
-        assert "Boolean" in str(exc_info.value)
+        assert exc_info.value.code == "3-6"
 
     def test_string_default_for_number_raises_error(self):
         """String default for Number cell should raise SemanticError 3-6.

--- a/tests/unit/semantic/test_default_value_type_check.py
+++ b/tests/unit/semantic/test_default_value_type_check.py
@@ -87,70 +87,111 @@ class TestCheckDefaultValue:
             default_value, expected_type
         )
 
-    def test_string_default_for_boolean_is_valid(self):
-        """String default for Boolean cell must be accepted.
+    def test_string_default_for_boolean_raises_error(self):
+        """String default for Boolean cell should raise SemanticError 3-6.
 
-        Boolean is string-representable (Boolean promotes to String).
+        A default fills the cell, so it must be implicitly castable *to* the
+        cell type. ``String → Boolean`` is an Explicit cast (spec §2.3.2), not
+        Implicit, so the default is rejected.
         """
         default_value = self._create_constant("String", "")
-        InputAnalyzer._InputAnalyzer__check_default_value(
-            default_value, Boolean()
-        )
 
-    def test_string_default_for_number_is_valid(self):
-        """String default for Number cell must be accepted.
+        with pytest.raises(SemanticError) as exc_info:
+            InputAnalyzer._InputAnalyzer__check_default_value(
+                default_value, Boolean()
+            )
 
-        Number is string-representable (Number promotes to String).
+        assert "Invalid default type" in str(exc_info.value)
+        assert "String" in str(exc_info.value)
+        assert "Boolean" in str(exc_info.value)
+
+    def test_string_default_for_number_raises_error(self):
+        """String default for Number cell should raise SemanticError 3-6.
+
+        ``String → Number`` is an Explicit cast (spec §2.3.2), not Implicit, so
+        a String default cannot fill a Number cell.
         """
         default_value = self._create_constant("String", "")
-        InputAnalyzer._InputAnalyzer__check_default_value(
-            default_value, Number()
-        )
 
-    def test_string_default_for_item_is_valid(self):
-        """String default for Item cell must be accepted.
+        with pytest.raises(SemanticError) as exc_info:
+            InputAnalyzer._InputAnalyzer__check_default_value(
+                default_value, Number()
+            )
 
-        Item columns are string-representable (Item promotes to String),
-        so ``default: ""`` is a valid sentinel for a missing enumeration value.
+        assert "Invalid default type" in str(exc_info.value)
+        assert "String" in str(exc_info.value)
+        assert "Number" in str(exc_info.value)
+
+    def test_string_default_for_item_raises_error(self):
+        """String default for Item cell should raise SemanticError 3-6.
+
+        ``String → Item`` is an Explicit cast (spec §2.3.2), not Implicit, so a
+        String default cannot fill an enumeration cell.
         """
         default_value = self._create_constant("String", "")
-        InputAnalyzer._InputAnalyzer__check_default_value(
-            default_value, Item()
-        )
 
-    def test_string_default_for_timeinterval_is_valid(self):
-        """String default for TimeInterval cell must be accepted.
+        with pytest.raises(SemanticError) as exc_info:
+            InputAnalyzer._InputAnalyzer__check_default_value(
+                default_value, Item()
+            )
 
-        TimeInterval is string-representable (TimeInterval promotes to String).
+        assert "Invalid default type" in str(exc_info.value)
+        assert "String" in str(exc_info.value)
+        assert "Item" in str(exc_info.value)
+
+    def test_string_default_for_timeinterval_raises_error(self):
+        """String default for TimeInterval cell should raise SemanticError 3-6.
+
+        ``String → TimeInterval`` is an Explicit cast (spec §2.3.2), not
+        Implicit, so a String default cannot fill a time-interval cell.
         """
         default_value = self._create_constant("String", "")
-        InputAnalyzer._InputAnalyzer__check_default_value(
-            default_value, TimeInterval()
-        )
 
-    def test_integer_default_for_item_is_valid(self):
-        """Integer default for Item cell must be accepted.
+        with pytest.raises(SemanticError) as exc_info:
+            InputAnalyzer._InputAnalyzer__check_default_value(
+                default_value, TimeInterval()
+            )
 
-        Both Integer and Item are string-representable, so integer 0 is a valid
-        numeric sentinel for a missing enumeration value.
-        Regression: 5 operations raised 3-6 with this pattern.
+        assert "Invalid default type" in str(exc_info.value)
+        assert "String" in str(exc_info.value)
+        assert "TimeInterval" in str(exc_info.value)
+
+    def test_integer_default_for_item_raises_error(self):
+        """Integer default for Item cell should raise SemanticError 3-6.
+
+        ``Integer → Item`` is not an Implicit cast (spec §2.3.2): integer 0 is
+        not a valid enumeration member, so it cannot fill an Item cell. The
+        known-failures oracle for ``dpm_4.2.1_20260515.db`` lists 5 operations
+        with this exact 3-6 error.
         """
         default_value = self._create_constant("Integer", 0)
-        InputAnalyzer._InputAnalyzer__check_default_value(
-            default_value, Item()
-        )
 
-    def test_integer_default_for_timeinterval_is_valid(self):
-        """Integer default for TimeInterval cell must be accepted.
+        with pytest.raises(SemanticError) as exc_info:
+            InputAnalyzer._InputAnalyzer__check_default_value(
+                default_value, Item()
+            )
 
-        Both Integer and TimeInterval are string-representable, so integer 0 is
-        a valid numeric sentinel for a missing time-interval value.
-        Regression: 1 operation raised 3-6 with this pattern.
+        assert "Invalid default type" in str(exc_info.value)
+        assert "Integer" in str(exc_info.value)
+        assert "Item" in str(exc_info.value)
+
+    def test_integer_default_for_timeinterval_raises_error(self):
+        """Integer default for TimeInterval cell should raise SemanticError 3-6.
+
+        ``Integer → TimeInterval`` is not an Implicit cast (spec §2.3.2). The
+        known-failures oracle for ``dpm_4.2.1_20260515.db`` lists 1 operation
+        with this exact 3-6 error.
         """
         default_value = self._create_constant("Integer", 0)
-        InputAnalyzer._InputAnalyzer__check_default_value(
-            default_value, TimeInterval()
-        )
+
+        with pytest.raises(SemanticError) as exc_info:
+            InputAnalyzer._InputAnalyzer__check_default_value(
+                default_value, TimeInterval()
+            )
+
+        assert "Invalid default type" in str(exc_info.value)
+        assert "Integer" in str(exc_info.value)
+        assert "TimeInterval" in str(exc_info.value)
 
     def test_item_default_for_string_is_valid(self):
         """Item default for String operand should be valid (Item can be promoted to String)."""


### PR DESCRIPTION
## Summary

Fixes #154.

The `default:` value of a `with { … default: <value> … }` clause was validated against the cell type with the implicit-cast relation applied **in both directions**. Because every type is implicitly castable **to** `String` (spec §2.3.2), the reverse leg let a `String` default through on `Number`, `Integer`, `Date`, `Boolean`, `Item` and `TimeInterval` cells (and a later "shared promotion target" leg let `Integer`/`Number` defaults through on `Item`/`TimeInterval`/`Date` cells too).

A default *fills* the cell, so it must be implicitly castable **to** the cell type — a one-directional check. This PR drops the reverse and shared-target legs in `InputAnalyzer.__check_default_value`, restoring the unidirectional rule:

```python
# A default fills the cell, so its type must be implicitly castable *to* the
# cell type (spec §2.3.2). Null already promotes to every type; a Mixed cell
# has unknown type (empty implicities) and accepts any default.
if cell_implicities and not type_.is_included(default_implicities):
    raise errors.SemanticError("3-6", expected_type=type_, default_type=default_type)
```

`default: 0` (Integer) on a `Number` cell stays valid (Integer → Number is Implicit); `default: "a"` (String) on the same cell is now correctly rejected with `SemanticError 3-6` (String → Number is Explicit).

### Root cause

The check was unidirectional and correct until two commits widened it to silence false-positive `3-6` errors:

- `ef70a4a` *"accept String default for cells whose type promotes to String"* — added the reverse leg `default_type.is_included(cell_implicities)`. This is the reported bug: it accepts a String default on **any** cell, since every type promotes to String.
- `c6b696a` *"accept Integer default for non-Boolean cells"* — added the shared-promotion-target leg `default_implicities & cell_implicities`. Since every type shares `String` as a target, this accepts essentially every non-Boolean pair.

Both legs are removed. The intent of those commits (don't reject the legitimate `default: 0`/`default: null` sentinels) is preserved by the surviving unidirectional leg: `Integer → Number` and `Null → anything` remain valid.

## Verification

Issue reproducer:

```
is_valid=True  code=None :: with {tF_04.01, c0010, default: 0,   …}
is_valid=False code=3-6  :: with {tF_04.01, c0010, default: "a", …}   ← now rejected
```

- **Unit tests** — `tests/unit/semantic/test_default_value_type_check.py` (21 tests): the 6 tests that pinned the buggy behaviour are flipped to expect `3-6` (`String → Boolean/Number/Item/TimeInterval`, `Integer → Item/TimeInterval`). `Integer → Number`, `Null → anything`, `* → String`, and `* → Mixed` stay valid.
- **Oracle replay** — replayed the 344 `3-6` rows of the known-failures set (`dpm_4.2.1_20260515_failures.csv`) through `db.services.semantic.validate(...)`: **327/344 reproduce `3-6`**. The 17 that don't are all `default: null` cases (`Null → Mixed`); `null` is the universal default and legitimately fills any cell, so VALID is correct — those rows are over-reported in the CSV and were already VALID before this change.
- **No false positives** — the change is strictly subtractive on acceptance (condition `(A)` is unchanged), so any default that genuinely casts to its cell still passes. A scan of 1,382 sampled `default`-bearing operations across the DB emitted `3-6` on 33 of them — **all genuine non-implicit-cast pairs** (`String→Item` ×26, `String→Boolean` ×4, `String→TimeInterval` ×2, `Integer→Item` ×1) and **0 false positives**.

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [ ] Documentation updated (if applicable) — n/a

## Impact / Risk

- **Behaviour change (stricter validation):** expressions with a `default:` whose type is not implicitly castable to the cell type now correctly fail `3-6` instead of silently passing. The most common real-world pattern this surfaces is `default: ""` / `default: 0` used as a sentinel on `Item`/`TimeInterval`/`Number` cells — these are spec-non-compliant defaults (`String → Item`, `Integer → Item`, etc. are Explicit casts) and are now flagged, matching the known-failures oracle.
