### PR TITLE
Support custom code and version_id in preconditions API

### DIFF
--- a/specification/02-rest-api.md
+++ b/specification/02-rest-api.md
@@ -505,6 +505,8 @@ Each `preconditions` entry:
 |-------|------|-------------|
 | `expression` | string | Precondition DPM-XL expression |
 | `validation_codes` | `[string]` | Validation codes this precondition guards |
+| `code` | string \| null | (Optional) Custom precondition key (e.g., `"P_571"`). If omitted, generated as `p_<variable_vid>` |
+| `version_id` | integer \| null | (Optional) Custom precondition version_id. If omitted, defaults to `variable_vid` |
 
 **Response body:**
 
@@ -514,7 +516,7 @@ Each `preconditions` entry:
 | `enriched_ast` | object \| null | Engine-ready namespaced AST (`{module_uri: {...}}`) |
 | `error` | string \| null | Error description if `success` is `false` |
 
-**Example:**
+**Example without custom precondition code:**
 
 ```bash
 POST /api/v1/scripts
@@ -527,6 +529,29 @@ Content-Type: application/json
   ],
   "module_code": "C_01.00",
   "module_version": "3.4"
+}
+```
+
+**Example with custom precondition code and version_id:**
+
+```bash
+POST /api/v1/scripts
+Content-Type: application/json
+
+{
+  "expressions": [
+    ["{tC_01.00, r0010, c0010} = 0", "V001"]
+  ],
+  "module_code": "C_01.00",
+  "module_version": "3.4",
+  "preconditions": [
+    {
+      "expression": "{v_C_01.00}",
+      "validation_codes": ["V001"],
+      "code": "P_571",
+      "version_id": 8341
+    }
+  ]
 }
 ```
 

--- a/src/dpmcore/cli/main.py
+++ b/src/dpmcore/cli/main.py
@@ -13,6 +13,7 @@ Usage::
 from __future__ import annotations
 
 import sys
+from typing import Any
 
 import click
 
@@ -419,6 +420,30 @@ def serve(database: str, host: str, port: int) -> None:
     type=click.Path(dir_okay=False),
     help="Path to write the generated script JSON.",
 )
+def _process_preconditions_from_json(
+    preconditions_raw: list[Any],
+) -> list[tuple[str, list[str]] | dict[str, Any]] | None:
+    """Convert raw precondition entries to script() format."""
+    if not preconditions_raw:
+        return None
+
+    preconditions: list[tuple[str, list[str]] | dict[str, Any]] = []
+    for entry in preconditions_raw:
+        has_custom = "code" in entry or "version_id" in entry
+        if isinstance(entry, dict) and has_custom:
+            preconditions.append(entry)
+        elif isinstance(entry, (list, tuple)) and len(entry) >= 2:
+            preconditions.append((entry[0], list(entry[1])))
+        elif isinstance(entry, dict) and "expression" in entry:
+            preconditions.append(
+                (
+                    entry["expression"],
+                    list(entry.get("affected_operations", [])),
+                )
+            )
+    return preconditions or None
+
+
 def generate_script(
     expressions_path: str,
     module_code: str,
@@ -472,7 +497,7 @@ def generate_script(
 
     items = [tuple(pair) for pair in raw["expressions"]]
     preconditions_raw = raw.get("preconditions") or []
-    preconditions = [(pair[0], list(pair[1])) for pair in preconditions_raw]
+    preconditions = _process_preconditions_from_json(preconditions_raw)
 
     severities_raw = raw.get("severities")
     severities: dict[str, str] | None = None

--- a/src/dpmcore/cli/main.py
+++ b/src/dpmcore/cli/main.py
@@ -367,6 +367,30 @@ def serve(database: str, host: str, port: int) -> None:
     uvicorn.run(app, host=host, port=port)
 
 
+def _process_preconditions_from_json(
+    preconditions_raw: list[Any],
+) -> list[tuple[str, list[str]] | dict[str, Any]] | None:
+    """Convert raw precondition entries to script() format."""
+    if not preconditions_raw:
+        return None
+
+    preconditions: list[tuple[str, list[str]] | dict[str, Any]] = []
+    for entry in preconditions_raw:
+        has_custom = "code" in entry or "version_id" in entry
+        if isinstance(entry, dict) and has_custom:
+            preconditions.append(entry)
+        elif isinstance(entry, (list, tuple)) and len(entry) >= 2:
+            preconditions.append((entry[0], list(entry[1])))
+        elif isinstance(entry, dict) and "expression" in entry:
+            preconditions.append(
+                (
+                    entry["expression"],
+                    list(entry.get("affected_operations", [])),
+                )
+            )
+    return preconditions or None
+
+
 @main.command("generate-script")
 @click.option(
     "--expressions",
@@ -420,30 +444,6 @@ def serve(database: str, host: str, port: int) -> None:
     type=click.Path(dir_okay=False),
     help="Path to write the generated script JSON.",
 )
-def _process_preconditions_from_json(
-    preconditions_raw: list[Any],
-) -> list[tuple[str, list[str]] | dict[str, Any]] | None:
-    """Convert raw precondition entries to script() format."""
-    if not preconditions_raw:
-        return None
-
-    preconditions: list[tuple[str, list[str]] | dict[str, Any]] = []
-    for entry in preconditions_raw:
-        has_custom = "code" in entry or "version_id" in entry
-        if isinstance(entry, dict) and has_custom:
-            preconditions.append(entry)
-        elif isinstance(entry, (list, tuple)) and len(entry) >= 2:
-            preconditions.append((entry[0], list(entry[1])))
-        elif isinstance(entry, dict) and "expression" in entry:
-            preconditions.append(
-                (
-                    entry["expression"],
-                    list(entry.get("affected_operations", [])),
-                )
-            )
-    return preconditions or None
-
-
 def generate_script(
     expressions_path: str,
     module_code: str,

--- a/src/dpmcore/server/routers/scripts.py
+++ b/src/dpmcore/server/routers/scripts.py
@@ -11,10 +11,15 @@ from sqlalchemy.orm import Session
 
 
 class PreconditionEntry(BaseModel):
-    """A precondition expression and the validation codes it guards."""
+    """A precondition expression and the validation codes it guards.
+
+    Supports custom code and version_id.
+    """
 
     expression: str
     validation_codes: List[str]
+    code: Optional[str] = None
+    version_id: Optional[int] = None
 
 
 class GenerateScriptRequest(BaseModel):
@@ -78,14 +83,28 @@ def create_scripts_router(
         items: List[tuple[str, str]] = [
             (item[0], item[1]) for item in body.expressions
         ]
-        preconditions = (
-            [
-                (p.expression, list(p.validation_codes))
-                for p in body.preconditions
-            ]
-            if body.preconditions
-            else None
-        )
+        preconditions: Optional[
+            List[tuple[str, List[str]] | Dict[str, Any]]
+        ] = None
+        if body.preconditions:
+            preconditions = []
+            for p in body.preconditions:
+                if p.code is not None or p.version_id is not None:
+                    # Dict format with optional code/version_id
+                    entry: Dict[str, Any] = {
+                        "expression": p.expression,
+                        "affected_operations": list(p.validation_codes),
+                    }
+                    if p.code is not None:
+                        entry["code"] = p.code
+                    if p.version_id is not None:
+                        entry["version_id"] = p.version_id
+                    preconditions.append(entry)
+                else:
+                    # Tuple format (backward compat)
+                    preconditions.append(
+                        (p.expression, list(p.validation_codes))
+                    )
         result = ASTGeneratorService(session).script(
             expressions=items,
             module_code=body.module_code,

--- a/src/dpmcore/services/ast_generator.py
+++ b/src/dpmcore/services/ast_generator.py
@@ -793,8 +793,12 @@ class ASTGeneratorService:
         if len(var_infos) == 1:
             vi = var_infos[0]
             default_key = f"p_{vi['variable_vid']}"
-            code = provided_code or default_key
-            version_id = provided_version_id or vi["variable_vid"]
+            code = provided_code if provided_code is not None else default_key
+            version_id = (
+                provided_version_id
+                if provided_version_id is not None
+                else vi["variable_vid"]
+            )
             return code, {
                 "ast": {
                     "class_name": "PreconditionItem",
@@ -808,8 +812,12 @@ class ASTGeneratorService:
 
         sorted_vids = sorted(vi["variable_vid"] for vi in var_infos)
         default_key = "p_" + "_".join(str(v) for v in sorted_vids)
-        code = provided_code or default_key
-        version_id = provided_version_id or sorted_vids[0]
+        code = provided_code if provided_code is not None else default_key
+        version_id = (
+            provided_version_id
+            if provided_version_id is not None
+            else sorted_vids[0]
+        )
         ast_node: Dict[str, Any] = {
             "class_name": "PreconditionItem",
             "variable_id": var_infos[0]["variable_id"],

--- a/src/dpmcore/services/ast_generator.py
+++ b/src/dpmcore/services/ast_generator.py
@@ -14,6 +14,7 @@ from typing import (
     List,
     Optional,
     Tuple,
+    Union,
 )
 
 from dpmcore.dpm_xl.utils.tokens import (
@@ -88,7 +89,9 @@ class ASTGeneratorService:
         expressions: List[Tuple[str, str]],
         module_code: str,
         module_version: str,
-        preconditions: Optional[List[Tuple[str, List[str]]]] = None,
+        preconditions: Optional[
+            List[Union[Tuple[str, List[str]], Dict[str, Any]]]
+        ] = None,
         severity: Optional[str] = None,
         severities: Optional[Dict[str, str]] = None,
         release: Optional[str] = None,
@@ -100,8 +103,11 @@ class ASTGeneratorService:
             module_code: Code of the primary module (e.g. ``"COREP_Con"``).
             module_version: Version of the primary module
                 (e.g. ``"2.0.1"``).
-            preconditions: Optional list of
-                ``(precondition_expression, [validation_codes])`` tuples.
+            preconditions: Optional list of precondition specs:
+                - Tuples: ``(precondition_expression, [validation_codes])``
+                - Dicts: ``{"expression": "...",
+                  "affected_operations": [...], "code": "P_571",
+                  "version_id": 8341}`` (code and version_id optional)
                 A precondition can guard many validation codes; a
                 validation may have no precondition.
             severity: Optional global default severity tag
@@ -654,7 +660,7 @@ class ASTGeneratorService:
 
     def _build_preconditions_block(
         self,
-        preconditions: List[Tuple[str, List[str]]],
+        preconditions: List[Union[Tuple[str, List[str]], Dict[str, Any]]],
         release_id: Optional[int],
     ) -> Tuple[Dict[str, Any], Dict[str, str]]:
         """Build the ``preconditions`` and ``precondition_variables`` blocks.
@@ -674,8 +680,15 @@ class ASTGeneratorService:
             return preconditions_dict, precondition_variables
 
         all_codes: List[str] = []
-        for precondition_expr, _ in preconditions:
-            for raw in _VAR_REF_PATTERN.findall(precondition_expr):
+        for precond_spec in preconditions:
+            precond_expr = (
+                precond_spec.get("expression")
+                if isinstance(precond_spec, dict)
+                else precond_spec[0]
+            )
+            if not precond_expr:
+                continue
+            for raw in _VAR_REF_PATTERN.findall(precond_expr):
                 normalized = _normalize_variable_code(raw)
                 if normalized not in all_codes:
                     all_codes.append(normalized)
@@ -686,14 +699,24 @@ class ASTGeneratorService:
             self.session, all_codes, release_id=release_id
         )
 
-        for precondition_expr, validation_codes in preconditions:
+        for precond_spec in preconditions:
+            if isinstance(precond_spec, dict):
+                precond_expr = precond_spec["expression"]
+                validation_codes = precond_spec["affected_operations"]
+                provided_code = precond_spec.get("code")
+                provided_version_id = precond_spec.get("version_id")
+            else:
+                precond_expr, validation_codes = precond_spec
+                provided_code = None
+                provided_version_id = None
+
             var_infos = self._collect_precondition_var_infos(
-                precondition_expr, resolved, precondition_variables
+                precond_expr, resolved, precondition_variables
             )
             if not var_infos:
                 continue
             key, entry = self._build_precondition_entry(
-                var_infos, validation_codes
+                var_infos, validation_codes, provided_code, provided_version_id
             )
             self._merge_precondition_entry(preconditions_dict, key, entry)
 
@@ -755,29 +778,38 @@ class ASTGeneratorService:
     def _build_precondition_entry(
         var_infos: List[Dict[str, Any]],
         validation_codes: List[str],
+        provided_code: Optional[str] = None,
+        provided_version_id: Optional[int] = None,
     ) -> Tuple[str, Dict[str, Any]]:
         """Assemble a single ``preconditions[key]`` entry.
 
         Single-variable case → ``p_<vid>`` with a ``PreconditionItem``
         AST. Compound case → ``p_<sorted_vids>`` with a left-folded
         chain of ``BinOp(op="and")`` nodes.
+
+        When provided_code or provided_version_id are supplied, they override
+        the auto-generated values.
         """
         if len(var_infos) == 1:
             vi = var_infos[0]
-            key = f"p_{vi['variable_vid']}"
-            return key, {
+            default_key = f"p_{vi['variable_vid']}"
+            code = provided_code or default_key
+            version_id = provided_version_id or vi["variable_vid"]
+            return code, {
                 "ast": {
                     "class_name": "PreconditionItem",
                     "variable_id": vi["variable_id"],
                     "variable_code": vi["variable_code"],
                 },
                 "affected_operations": list(validation_codes),
-                "version_id": vi["variable_vid"],
-                "code": key,
+                "version_id": version_id,
+                "code": code,
             }
 
         sorted_vids = sorted(vi["variable_vid"] for vi in var_infos)
-        key = "p_" + "_".join(str(v) for v in sorted_vids)
+        default_key = "p_" + "_".join(str(v) for v in sorted_vids)
+        code = provided_code or default_key
+        version_id = provided_version_id or sorted_vids[0]
         ast_node: Dict[str, Any] = {
             "class_name": "PreconditionItem",
             "variable_id": var_infos[0]["variable_id"],
@@ -794,11 +826,11 @@ class ASTGeneratorService:
                     "variable_code": vi["variable_code"],
                 },
             }
-        return key, {
+        return code, {
             "ast": ast_node,
             "affected_operations": list(validation_codes),
-            "version_id": sorted_vids[0],
-            "code": key,
+            "version_id": version_id,
+            "code": code,
         }
 
     # ------------------------------------------------------------------ #
@@ -891,22 +923,28 @@ class ASTGeneratorService:
 
     def _build_precondition_index(
         self,
-        preconditions: List[Tuple[str, List[str]]],
+        preconditions: List[Union[Tuple[str, List[str]], Dict[str, Any]]],
     ) -> Dict[str, List[str]]:
         """Map each validation code → unioned precondition variable codes.
 
         Parses each precondition expression once and extracts variable
         codes that act as precondition items. Raises ``ValueError`` if
         a precondition expression cannot be parsed.
+        Supports both tuple and dict formats.
         """
         index: Dict[str, List[str]] = {}
-        for precondition_expr, validation_codes in preconditions:
+        for precond_spec in preconditions:
+            if isinstance(precond_spec, dict):
+                precond_expr = precond_spec["expression"]
+                validation_codes = precond_spec["affected_operations"]
+            else:
+                precond_expr, validation_codes = precond_spec
+
             try:
-                ast = self._syntax.parse(precondition_expr)
+                ast = self._syntax.parse(precond_expr)
             except Exception as exc:
                 raise ValueError(
-                    f"Invalid precondition expression "
-                    f"{precondition_expr!r}: {exc}"
+                    f"Invalid precondition expression {precond_expr!r}: {exc}"
                 ) from exc
             codes = self._extract_precondition_codes(ast)
             for vc in validation_codes:

--- a/tests/unit/services/test_ast_generator.py
+++ b/tests/unit/services/test_ast_generator.py
@@ -408,6 +408,64 @@ class TestBuildPreconditionsBlock:
             "v3",
         ]
 
+    def test_dict_format_with_custom_code_and_version_id(self, monkeypatch):
+        """Dict format allows overriding code and version_id"""
+        svc, _, _ = _bare_svc()
+        svc.session = MagicMock()
+
+        fake_query = MagicMock()
+        fake_query.get_variable_vids_by_codes.return_value = {
+            "C_01.00": {"variable_id": 11, "variable_vid": 110}
+        }
+        monkeypatch.setitem(
+            sys.modules,
+            "dpmcore.dpm_xl.model_queries",
+            SimpleNamespace(VariableVersionQuery=fake_query),
+        )
+
+        preconds, vars_ = svc._build_preconditions_block(
+            [
+                {
+                    "expression": "{v_C_01.00}",
+                    "affected_operations": ["v1", "v2"],
+                    "code": "P_571",  # Override default p_110
+                    "version_id": 8341,  # Override default 110
+                }
+            ],
+            release_id=5,
+        )
+        assert "P_571" in preconds
+        entry = preconds["P_571"]
+        assert entry["code"] == "P_571"
+        assert entry["version_id"] == 8341
+        assert entry["affected_operations"] == ["v1", "v2"]
+        assert vars_ == {"110": "b"}
+
+    def test_backward_compat_tuple_format_still_works(self, monkeypatch):
+        """Tuple format (old) still works for backward compatibility."""
+        svc, _, _ = _bare_svc()
+        svc.session = MagicMock()
+
+        fake_query = MagicMock()
+        fake_query.get_variable_vids_by_codes.return_value = {
+            "C_01.00": {"variable_id": 11, "variable_vid": 110}
+        }
+        monkeypatch.setitem(
+            sys.modules,
+            "dpmcore.dpm_xl.model_queries",
+            SimpleNamespace(VariableVersionQuery=fake_query),
+        )
+
+        # Old tuple format should still work
+        preconds, vars_ = svc._build_preconditions_block(
+            [("{v_C_01.00}", ["v1", "v2"])],
+            release_id=5,
+        )
+        assert "p_110" in preconds
+        entry = preconds["p_110"]
+        assert entry["code"] == "p_110"
+        assert entry["version_id"] == 110
+
 
 # ------------------------------------------------------------------ #
 # _resolve_root_operator_id
@@ -817,6 +875,29 @@ class TestBuildPreconditionIndex:
         svc._syntax.parse.side_effect = RuntimeError("syntax error")
         with pytest.raises(ValueError, match="Invalid precondition"):
             svc._build_precondition_index([("bad", ["v"])])
+
+    def test_dict_format_builds_index_correctly(self):
+        """Dict format in _build_precondition_index works like tuple format."""
+        svc, _, _ = _bare_svc()
+        svc._syntax = MagicMock()
+        svc._syntax.parse.side_effect = lambda expr: f"AST_{expr}"
+        svc._extract_precondition_codes = lambda ast: (
+            ["P1"] if ast == "AST_expr1" else ["P2"]
+        )
+        idx = svc._build_precondition_index(
+            [
+                {
+                    "expression": "expr1",
+                    "affected_operations": ["v1", "v2"],
+                    "code": "P_571",  # Custom fields ignored by index builder
+                    "version_id": 8341,
+                },
+                ("expr2", ["v2", "v3"]),  # Tuple format still works
+            ]
+        )
+        assert idx["v1"] == ["P1"]
+        assert idx["v2"] == ["P1", "P2"]
+        assert idx["v3"] == ["P2"]
 
 
 # ------------------------------------------------------------------ #


### PR DESCRIPTION
Closes #160 

## Summary

The preconditions API generates keys based on `variable_vid` (e.g., `P_395473`), while MDPM uses the precondition's own `operation_id` (e.g., `P_571`). This naming divergence affects 73 of 79 modules. There was no way for callers to specify the correct code and version_id.

So the fix is to allow callers to optionally provide `code` and `version_id` in precondition specifications. The implementation accepts both tuple format (old, backward-compatible) and dict format (new, with custom fields). Updated REST API, service layer, and CLI to handle both formats. When custom values are provided, they override auto-generated defaults.

## Checklist

- [X] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [X] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [X] Documentation updated (if applicable)
