### PR TITLE
fix(ast-generator): seed tables/variables from module composition

### DIFF
--- a/src/dpmcore/services/ast_generator.py
+++ b/src/dpmcore/services/ast_generator.py
@@ -232,10 +232,25 @@ class ASTGeneratorService:
             primary_tables_full = self._scope_calc._get_module_tables(
                 primary_module_vid, release_id=release_id
             )
-            tables_block: Dict[str, Any] = {
-                code: primary_tables_full[code]
-                for code in sorted(referenced_table_codes)
+            # Seed from every module-composition table that carries
+            # variables — i.e. the non-abstract tables; abstract templates
+            # have no cells, and the engine schema forbids an empty
+            # variables map — then union in anything the expressions
+            # reference. MDPM lists all such tables even when no validation
+            # touches them (#158). The union keeps this additive: a
+            # referenced table is never dropped.
+            seed_codes = {
+                code
+                for code, data in primary_tables_full.items()
+                if data.get("variables")
+            }
+            seed_codes |= {
+                code
+                for code in referenced_table_codes
                 if code in primary_tables_full
+            }
+            tables_block: Dict[str, Any] = {
+                code: primary_tables_full[code] for code in sorted(seed_codes)
             }
             variables_block: Dict[str, str] = {}
             for tbl in tables_block.values():

--- a/tests/unit/services/test_ast_generator.py
+++ b/tests/unit/services/test_ast_generator.py
@@ -1014,9 +1014,41 @@ class TestScript:
         # AST stripped
         ast_data = ns_block["operations"]["v1"]["ast"]["data"][0]
         assert "data_type" not in ast_data
-        # tables/variables filtered to referenced
+        # tables/variables seeded from the module composition
         assert "C_01.00" in ns_block["tables"]
         assert ns_block["variables"] == {"100": "m"}
+
+    def test_tables_block_includes_unreferenced_module_tables(
+        self, monkeypatch
+    ):
+        """#158: module-composition tables appear even when no expression
+        references them; abstract (empty-variable) tables stay excluded.
+        """
+        self._stub_serialize_ast(
+            monkeypatch,
+            {"class_name": "VarID", "table": "C_01.00", "data": []},
+        )
+        svc, *_ = self._build_svc()
+        svc._semantic.validate.return_value = SimpleNamespace(
+            is_valid=True, error_message=None, parameters=()
+        )
+        svc._semantic.ast = "AST"
+        svc._scope_calc._get_module_tables.return_value = {
+            "C_01.00": {"variables": {"100": "m"}, "open_keys": {}},
+            "C_99.00": {"variables": {"900": "m"}, "open_keys": {}},
+            "C_ABS.00": {"variables": {}, "open_keys": {}},
+        }
+        out = svc.script(
+            expressions=[("e1", "v1")],
+            module_code="MOD",
+            module_version="1.0",
+        )
+        assert out["success"] is True
+        ns = next(iter(out["enriched_ast"].values()))
+        # Referenced (C_01.00) AND unreferenced-with-variables (C_99.00)
+        # are present; the empty-variable (abstract) table is dropped.
+        assert set(ns["tables"]) == {"C_01.00", "C_99.00"}
+        assert ns["variables"] == {"100": "m", "900": "m"}
 
     def test_default_severity_is_warning(self, monkeypatch):
         self._stub_serialize_ast(


### PR DESCRIPTION
## Summary

Closes #158.

When `ASTGeneratorService.script()` builds the per-module `tables` block, it previously emitted **only** the tables that the script's expressions actually reference (`referenced_table_codes ∩ primary_module_tables`). MDPM instead lists every variable-bearing table in the module composition — even tables no validation touches — so the generated script's `tables`/`variables` blocks diverged from the oracle on 73 of 79 modules (the same parity gap tracked in #158).

This PR seeds the `tables` block from the module composition: every non-abstract table (one that carries variables) is included, then the expression-referenced tables are unioned in on top.

```python
seed_codes = {
    code
    for code, data in primary_tables_full.items()
    if data.get("variables")
}
seed_codes |= {
    code
    for code in referenced_table_codes
    if code in primary_tables_full
}
tables_block: Dict[str, Any] = {
    code: primary_tables_full[code] for code in sorted(seed_codes)
}
```

`variables_block` is unchanged in shape — it is still the union of every `tables_block` entry's `variables` map — so widening the table set automatically widens the variables map to match MDPM.

## Additional information

- **Abstract templates are excluded.** Abstract tables have no cells and therefore an empty `variables` map; the engine schema forbids an empty variables map, so seeding gates on `data.get("variables")` being truthy. Only tables that actually carry variables are seeded.
- **The change is additive, never subtractive.** Referenced tables are unioned in (`seed_codes |= …`) rather than replacing the seed, so a table an expression references is never dropped — including the edge case of a referenced table that happens to be abstract, which is preserved exactly as before. The only net change is the *addition* of variable-bearing tables that no expression references.
- **Deterministic output.** `tables_block` iterates `sorted(seed_codes)`, so the table ordering stays stable regardless of set iteration order.

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [ ] Documentation updated (if applicable)

