### PR TITLE
Skip invalid operations instead of aborting the whole module

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,10 +125,12 @@ with connect("sqlite:///dpm.db") as db:
     #                    dpm_release, dates, operations, variables, tables,
     #                    preconditions, precondition_variables,
     #                    dependency_information, dependency_modules}}
+    # script["failed_operations"] lists expressions that were skipped due to
+    # semantic errors (e.g. grey cells): {validation_code: error_message}
     namespace, ns_block = next(iter(script["enriched_ast"].items()))
-    print(ns_block["dpm_release"])      # {"release": "...", "publication_date": "..."}
-    print(ns_block["operations"])       # {validation_code: {ast, severity, ...}}
-    print(ns_block["dependency_modules"])
+    print(ns_block["dpm_release"])          # {"release": "...", "publication_date": "..."}
+    print(ns_block["operations"])           # {validation_code: {ast, severity, ...}}
+    print(script["failed_operations"])      # {validation_code: error_message} or {}
 ```
 
 `preconditions`, `severities` and `release` are all optional. Severity

--- a/specification/02-rest-api.md
+++ b/specification/02-rest-api.md
@@ -513,6 +513,7 @@ Each `preconditions` entry:
 | `success` | bool | `true` if the script was generated without errors |
 | `enriched_ast` | object \| null | Engine-ready namespaced AST (`{module_uri: {...}}`) |
 | `error` | string \| null | Error description if `success` is `false` |
+| `failed_operations` | object | Map of `{validation_code: error_message}` for expressions that failed semantic validation and were skipped. Empty when all expressions succeeded. |
 
 **Example:**
 

--- a/src/dpmcore/server/routers/scripts.py
+++ b/src/dpmcore/server/routers/scripts.py
@@ -55,6 +55,7 @@ class GenerateScriptResponse(BaseModel):
     success: bool
     enriched_ast: Optional[Any] = None
     error: Optional[str] = None
+    failed_operations: Dict[str, str] = {}
 
 
 def create_scripts_router(
@@ -99,6 +100,7 @@ def create_scripts_router(
             success=bool(result.get("success")),
             enriched_ast=result.get("enriched_ast"),
             error=result.get("error"),
+            failed_operations=result.get("failed_operations", {}),
         )
 
     return router

--- a/src/dpmcore/services/ast_generator.py
+++ b/src/dpmcore/services/ast_generator.py
@@ -165,6 +165,7 @@ class ASTGeneratorService:
             )
 
             operations: Dict[str, Dict[str, Any]] = {}
+            failed_operations: Dict[str, str] = {}
             scope_pairs: List[
                 Tuple[Tuple[str, str], "ScopeResult", Dict[str, str]]
             ] = []
@@ -180,11 +181,8 @@ class ASTGeneratorService:
                 # conflicts between two expressions in this same script.
                 result = self._semantic.validate(expr, release_id=release_id)
                 if not result.is_valid:
-                    return {
-                        "success": False,
-                        "enriched_ast": None,
-                        "error": result.error_message,
-                    }
+                    failed_operations[code] = result.error_message
+                    continue
 
                 ast = self._semantic.ast
                 ast_dict = serialize_ast(ast)
@@ -303,6 +301,7 @@ class ASTGeneratorService:
                 "success": True,
                 "enriched_ast": {namespace: ns_block},
                 "error": None,
+                "failed_operations": failed_operations,
             }
 
         except ValueError as exc:

--- a/src/dpmcore/services/ast_generator.py
+++ b/src/dpmcore/services/ast_generator.py
@@ -133,6 +133,7 @@ class ASTGeneratorService:
                 "success": False,
                 "enriched_ast": None,
                 "error": "No database session — cannot generate script.",
+                "failed_operations": {},
             }
 
         try:
@@ -158,6 +159,7 @@ class ASTGeneratorService:
                     "success": False,
                     "enriched_ast": None,
                     "error": str(exc),
+                    "failed_operations": {},
                 }
 
             from_submission_date = _format_date(
@@ -223,6 +225,7 @@ class ASTGeneratorService:
                             f"Scope calculation failed for operation "
                             f"'{code}': {sr.error_message}"
                         ),
+                        "failed_operations": failed_operations,
                     }
                 ts = self._extract_time_shifts(ast)
                 scope_pairs.append((item, sr, ts))
@@ -309,12 +312,14 @@ class ASTGeneratorService:
                 "success": False,
                 "enriched_ast": None,
                 "error": str(exc),
+                "failed_operations": {},
             }
         except Exception as exc:
             return {
                 "success": False,
                 "enriched_ast": None,
                 "error": str(exc),
+                "failed_operations": {},
             }
 
     # ------------------------------------------------------------------ #

--- a/src/dpmcore/services/ast_generator.py
+++ b/src/dpmcore/services/ast_generator.py
@@ -181,7 +181,7 @@ class ASTGeneratorService:
                 # conflicts between two expressions in this same script.
                 result = self._semantic.validate(expr, release_id=release_id)
                 if not result.is_valid:
-                    failed_operations[code] = result.error_message
+                    failed_operations[code] = result.error_message or ""
                     continue
 
                 ast = self._semantic.ast

--- a/tests/integration/api/test_scripts_endpoint.py
+++ b/tests/integration/api/test_scripts_endpoint.py
@@ -175,6 +175,35 @@ class TestPostScripts:
         assert body["success"] is False
         assert body["error"] == "boom"
 
+    def test_failed_operations_exposed_in_response(self, client):
+        """failed_operations from the service are forwarded to the caller."""
+        with patch(
+            "dpmcore.services.ast_generator.ASTGeneratorService"
+        ) as Svc:
+            Svc.return_value.script.return_value = {
+                "success": True,
+                "enriched_ast": {"ns": {}},
+                "error": None,
+                "failed_operations": {
+                    "v1": "Grey cells {F_32.03.a, r0040, c0010} were found."
+                },
+            }
+            response = client.post(
+                "/api/v1/scripts",
+                json={
+                    "expressions": [["e", "v1"]],
+                    "module_code": "FINREP_Con",
+                    "module_version": "2.0.1",
+                },
+            )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["success"] is True
+        assert body["failed_operations"] == {
+            "v1": "Grey cells {F_32.03.a, r0040, c0010} were found."
+        }
+
     def test_invalid_body_returns_422_missing_expressions(self, client):
         response = client.post(
             "/api/v1/scripts",

--- a/tests/unit/services/test_ast_generator.py
+++ b/tests/unit/services/test_ast_generator.py
@@ -906,18 +906,55 @@ class TestScript:
         assert out["success"] is False
         assert "ModuleVersion not found" in out["error"]
 
-    def test_validation_error_short_circuits(self, monkeypatch):
+    def test_validation_error_goes_to_failed_operations(self, monkeypatch):
         svc, *_ = self._build_svc()
         svc._semantic.validate.return_value = SimpleNamespace(
-            is_valid=False, error_message="bad expr"
+            is_valid=False,
+            error_message="Grey cells {F_32.03.a, r0040, c0010} were found.",
         )
         out = svc.script(
             expressions=[("x", "v1")],
             module_code="MOD",
             module_version="1.0",
         )
-        assert out["success"] is False
-        assert out["error"] == "bad expr"
+        assert out["success"] is True
+        assert out["failed_operations"] == {
+            "v1": "Grey cells {F_32.03.a, r0040, c0010} were found."
+        }
+
+    def test_grey_cell_skips_op_preserves_others(self, monkeypatch):
+        """A grey-cell failure must skip that op, not abort the module."""
+        self._stub_serialize_ast(
+            monkeypatch,
+            {"class_name": "VarID", "table": "C_01.00", "data": []},
+        )
+        svc, *_ = self._build_svc()
+
+        svc._semantic.validate.side_effect = lambda expr, release_id=None: (
+            SimpleNamespace(
+                is_valid=False,
+                error_message="Grey cells {F_32.03.a, r0040, c0010} were found.",
+            )
+            if expr == "e_bad"
+            else SimpleNamespace(
+                is_valid=True, error_message=None, parameters=()
+            )
+        )
+        svc._semantic.ast = "AST"
+
+        out = svc.script(
+            expressions=[("e_bad", "v1"), ("e2", "v2"), ("e3", "v3")],
+            module_code="MOD",
+            module_version="1.0",
+        )
+        assert out["success"] is True
+        ns = next(iter(out["enriched_ast"].values()))
+        assert "v1" not in ns["operations"]
+        assert "v2" in ns["operations"]
+        assert "v3" in ns["operations"]
+        assert out["failed_operations"] == {
+            "v1": "Grey cells {F_32.03.a, r0040, c0010} were found."
+        }
 
     def test_scope_error_fails_generation(self, monkeypatch):
         """Regression for #122: a scope-calculation error must fail the


### PR DESCRIPTION
Closes #155 

## Summary

When `ASTGeneratorService.script` encountered a semantic validation failure on any expression (grey cells, missing cells, incompatible DPM components), it aborted the entire module and returned `success: False` with no output.

The fix changes the per-expression validation check from a module-level abort into a skip: invalid operations are recorded in a new `failed_operations` dict (`{code: error_message}`) and the loop continues. The successful return now includes this dict alongside the existing `enriched_ast`, so callers can inspect which operations were dropped and why

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [x] Documentation updated (if applicable)

