### PR TITLE
fix: align time_shift serialization with engine format

### DIFF
--- a/src/dpmcore/dpm_xl/ast/nodes.py
+++ b/src/dpmcore/dpm_xl/ast/nodes.py
@@ -790,9 +790,13 @@ class TimeShiftOp(AST):
         return {
             "class_name": self.__class__.__name__,
             "operand": self.operand,
-            "period_indicator": self.period_indicator,
-            "component": self.component,
+            "period_indicator": {
+                "class_name": "Constant",
+                "type_": "String",
+                "value": self.period_indicator,
+            },
             "shift_number": self.shift_number.toJSON(),
+            "reference_period": self.component,
         }
 
 

--- a/src/dpmcore/dpm_xl/utils/serialization.py
+++ b/src/dpmcore/dpm_xl/utils/serialization.py
@@ -596,13 +596,22 @@ class ASTToJSONVisitor(NodeVisitor):
         }
 
     def visit_TimeShiftOp(self, node: Any) -> NodeDict:
-        """Visit TimeShiftOp nodes."""
+        """Visit TimeShiftOp nodes.
+
+        ``period_indicator`` is wrapped in a ``Constant`` node so it matches
+        how every other scalar literal is serialized, and the reference-period
+        selector is emitted under ``reference_period``.
+        """
         return {
             "class_name": "TimeShiftOp",
             "operand": self.visit(node.operand),
-            "component": node.component,
-            "period_indicator": node.period_indicator,
+            "period_indicator": {
+                "class_name": "Constant",
+                "type_": "String",
+                "value": node.period_indicator,
+            },
             "shift_number": self.visit(node.shift_number),
+            "reference_period": node.component,
         }
 
     def visit_AnnualiseOp(self, node: Any) -> NodeDict:

--- a/tests/unit/ast/test_time_shift_expression.py
+++ b/tests/unit/ast/test_time_shift_expression.py
@@ -126,3 +126,33 @@ def test_tojson_period_indicator_is_constant_node():
     }
     assert out["reference_period"] == "refPeriod"
     assert "component" not in out
+
+
+def test_serializer_scalar_form_reference_period_is_null():
+    # The 3-argument form has no reference-period selector; the key is
+    # still emitted, as null, and period_indicator stays a Constant node.
+    from dpmcore.dpm_xl.utils.serialization import serialize_ast
+
+    node = SyntaxService().parse("time_shift({tT1}, A, 1)").children[0]
+    out = serialize_ast(node)
+
+    assert out["period_indicator"] == {
+        "class_name": "Constant",
+        "type_": "String",
+        "value": "A",
+    }
+    assert out["reference_period"] is None
+    assert "component" not in out
+
+
+def test_tojson_scalar_form_reference_period_is_null():
+    node = SyntaxService().parse("time_shift({tT1}, A, 1)").children[0]
+    out = node.toJSON()
+
+    assert out["period_indicator"] == {
+        "class_name": "Constant",
+        "type_": "String",
+        "value": "A",
+    }
+    assert out["reference_period"] is None
+    assert "component" not in out

--- a/tests/unit/ast/test_time_shift_expression.py
+++ b/tests/unit/ast/test_time_shift_expression.py
@@ -94,3 +94,35 @@ def test_string_shift_has_string_type_constant():
     assert isinstance(node, TimeShiftOp)
     assert isinstance(node.shift_number, Constant)
     assert node.shift_number.type == "String"
+
+
+def test_serializer_period_indicator_is_constant_node():
+    from dpmcore.dpm_xl.utils.serialization import serialize_ast
+
+    node = (
+        SyntaxService().parse("time_shift({tT1}, A, 1, refPeriod)").children[0]
+    )
+    out = serialize_ast(node)
+
+    assert out["period_indicator"] == {
+        "class_name": "Constant",
+        "type_": "String",
+        "value": "A",
+    }
+    assert out["reference_period"] == "refPeriod"
+    assert "component" not in out
+
+
+def test_tojson_period_indicator_is_constant_node():
+    node = (
+        SyntaxService().parse("time_shift({tT1}, A, 1, refPeriod)").children[0]
+    )
+    out = node.toJSON()
+
+    assert out["period_indicator"] == {
+        "class_name": "Constant",
+        "type_": "String",
+        "value": "A",
+    }
+    assert out["reference_period"] == "refPeriod"
+    assert "component" not in out


### PR DESCRIPTION
Closes #169 

## Summary

Aligns `time_shift` JSON serialization with the engine-ready format.

`TimeShiftOp` now serializes `period_indicator` as a nested `Constant` node (carrying the actual indicator value) instead of a bare string, and emits the reference-period selector under `reference_period` instead of `component`. Both the visitor-based serializer (`serialize_ast`) and the node's own `toJSON()` are updated so the two paths stay consistent.

Before:

```json
{ "class_name": "TimeShiftOp", "component": "refPeriod", "period_indicator": "A", ... }
```

After:

```json
{ "class_name": "TimeShiftOp", "reference_period": "refPeriod", "period_indicator": { "class_name": "Constant", "type_": "String", "value": "A" }, ... }
```

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`) — added coverage for both serializers in `tests/unit/ast/test_time_shift_expression.py`
- [ ] Documentation updated (if applicable)

## Notes

- `period_indicator` is serialized from the actual value parsed from the expression, not a fixed placeholder.
- `reference_period` carries the reference-period selector (`refPeriod` or a property code); it is `null` for the scalar form of `time_shift`, where no selector is allowed.
