### PR TITLE
fix(scope): fall back to prior non-ghost module version for ghost-onl…

### DIFF
--- a/src/dpmcore/dpm_xl/model_queries.py
+++ b/src/dpmcore/dpm_xl/model_queries.py
@@ -13,6 +13,7 @@ import warnings
 from typing import (
     TYPE_CHECKING,
     Any,
+    Callable,
     Hashable,
     Sequence,
 )
@@ -45,6 +46,11 @@ from dpmcore.orm.packaging import (
     ModuleVersionComposition,
 )
 from dpmcore.orm.query_utils import chunked_in
+from dpmcore.orm.release_sort_order import (
+    load_release_sort_orders,
+    release_ids_for_sort_order,
+    resolve_sort_order,
+)
 from dpmcore.orm.rendering import (
     Cell,
     HeaderVersion,
@@ -720,6 +726,225 @@ def _exclude_collapsed_reference_window(query: Any) -> Any:
     )
 
 
+# ------------------------------------------------------------------ #
+# Ghost-module-version fallback (issue #182)
+# ------------------------------------------------------------------ #
+#
+# Some module versions carry a *collapsed* reference-date window
+# (``FromReferenceDate == ToReferenceDate``) even though their release
+# window genuinely spans several releases -- a known, un-fixable source
+# data error. These "ghost" versions are never usable for scope, so when
+# the only version whose release window covers a target release is a
+# ghost the release would otherwise resolve to an empty scope. Instead we
+# fall back to the most recent *prior* non-collapsed version of the same
+# module. The search is strictly backward, so it never selects a version
+# whose release window begins after the target release (#151 safety).
+
+_MODULE_VID_COL = "ModuleVID"
+_FROM_REF_COL = "FromReferenceDate"
+_TO_REF_COL = "ToReferenceDate"
+
+
+def _collapsed_mask(df: pd.DataFrame) -> "pd.Series[bool]":
+    """Boolean mask of rows whose reference-date window is collapsed.
+
+    DataFrame-level mirror of :func:`_exclude_collapsed_reference_window`:
+    a row is collapsed only when both reference dates are present and
+    equal. Open-ended windows (``None``/``NaT`` on either bound) are
+    genuine ranges, not collapsed.
+
+    Args:
+        df: A module-version DataFrame with ``FromReferenceDate`` and
+            ``ToReferenceDate`` columns.
+
+    Returns:
+        Boolean Series aligned with ``df``; ``True`` marks a ghost row.
+    """
+    frm = df[_FROM_REF_COL]
+    to = df[_TO_REF_COL]
+    return frm.notna() & to.notna() & (frm == to)
+
+
+def _drop_collapsed_rows(df: pd.DataFrame) -> pd.DataFrame:
+    """Return ``df`` without its collapsed (ghost) reference-date rows."""
+    if df.empty:
+        return df
+    return df[~_collapsed_mask(df)]
+
+
+def _module_ids_for_vids(
+    session: "Session", vids: Sequence[int]
+) -> dict[int, int]:
+    """Map module-version VIDs to their owning module id.
+
+    Args:
+        session: SQLAlchemy session.
+        vids: Module-version ids to resolve.
+
+    Returns:
+        Mapping ``{module_vid: module_id}`` for VIDs that exist and carry
+        a module id.
+    """
+    if not vids:
+        return {}
+    rows = (
+        session.query(ModuleVersion.module_vid, ModuleVersion.module_id)
+        .filter(ModuleVersion.module_vid.in_(list(set(vids))))
+        .all()
+    )
+    return {vid: mid for vid, mid in rows if mid is not None}
+
+
+def _latest_prior_non_collapsed_vids(
+    session: "Session",
+    module_ids: set[int],
+    release_id: int,
+) -> dict[int, int]:
+    """Latest prior non-ghost version per module for a target release.
+
+    For each module id, return the ``ModuleVID`` of the most recent
+    module version that (a) has a genuine (non-collapsed) reference-date
+    window and (b) whose release-window start is on or before the target
+    release on the semver sort order. The search is strictly backward: a
+    version whose release window begins *after* the target is never
+    chosen, preserving the #151 release-axis safety constraint. Modules
+    with no such version are omitted, so the caller keeps the clean
+    "no module versions" outcome for them.
+
+    Args:
+        session: SQLAlchemy session.
+        module_ids: Modules whose sole release-covering version is a
+            ghost.
+        release_id: Target release id.
+
+    Returns:
+        Mapping ``{module_id: fallback_module_vid}``.
+    """
+    if not module_ids:
+        return {}
+    target = resolve_sort_order(session, release_id)
+    sort_orders = load_release_sort_orders(session)
+    prior_start_ids = release_ids_for_sort_order(sort_orders, le=target)
+    if not prior_start_ids:
+        return {}
+    query = session.query(
+        ModuleVersion.module_id,
+        ModuleVersion.module_vid,
+        ModuleVersion.start_release_id,
+    ).filter(
+        ModuleVersion.module_id.in_(module_ids),
+        ModuleVersion.start_release_id.in_(prior_start_ids),
+    )
+    query = _exclude_collapsed_reference_window(query)
+    best: dict[int, tuple[int, int]] = {}
+    for module_id, vid, start_id in query.all():
+        order = sort_orders.get(start_id)
+        if order is None:
+            continue
+        current = best.get(module_id)
+        if current is None or (order, vid) > current:
+            best[module_id] = (order, vid)
+    return {module_id: vid for module_id, (_, vid) in best.items()}
+
+
+def _release_filter(release_id: int | None) -> Callable[[Any], Any]:
+    """Return a module filter narrowing to the target release window."""
+
+    def apply(query: Any) -> Any:
+        return filter_by_release(
+            query,
+            start_col=ModuleVersion.start_release_id,
+            end_col=ModuleVersion.end_release_id,
+            release_id=release_id,
+        )
+
+    return apply
+
+
+def _vids_filter(vids: Sequence[int]) -> Callable[[Any], Any]:
+    """Return a module filter narrowing to an explicit set of VIDs."""
+
+    def apply(query: Any) -> Any:
+        return query.filter(ModuleVersion.module_vid.in_(list(vids)))
+
+    return apply
+
+
+def _resolve_with_ghost_fallback(
+    session: "Session",
+    build_query: Callable[[Callable[[Any], Any]], Any],
+    materialize: Callable[[Any], list[Any]],
+    cols: list[str],
+    release_id: int | None,
+) -> pd.DataFrame:
+    """Resolve module versions for a release, applying ghost fallback.
+
+    Runs the caller's release-filtered lookup, then for any module whose
+    sole release-covering version is a ghost substitutes the latest prior
+    non-collapsed version of that module (see
+    :func:`_latest_prior_non_collapsed_vids`). Modules with no prior
+    non-ghost version are left out, so the caller still reports the clean
+    "no module versions" outcome for them. Re-fetching the fallback
+    version's operand rows (rather than rewriting the ghost row) means a
+    fallback row appears only if that version genuinely contains the
+    requested table / precondition.
+
+    Args:
+        session: SQLAlchemy session.
+        build_query: Builds the lookup's joined query given a
+            ``module_filter`` callable that narrows ``ModuleVersion`` to
+            either the target release or an explicit set of VIDs.
+        materialize: Executes a built query and returns its rows (e.g.
+            ``chunked_in`` over the operand column, or ``query.all()``).
+        cols: Output DataFrame column names.
+        release_id: Target release id, or ``None`` for no release filter.
+
+    Returns:
+        DataFrame of resolved module versions, ghosts replaced by their
+        prior non-collapsed fallback where one exists.
+    """
+    covering = pd.DataFrame(
+        materialize(build_query(_release_filter(release_id))),
+        columns=cols,
+    )
+    # Without a target release there is no "prior" to fall back to;
+    # keep the historical behaviour of simply dropping ghosts.
+    if release_id is None or covering.empty:
+        return _drop_collapsed_rows(covering)
+
+    ghost = _collapsed_mask(covering)
+    non_ghost = covering[~ghost]
+    vid_to_module = _module_ids_for_vids(
+        session, covering[_MODULE_VID_COL].tolist()
+    )
+    ghost_modules = {
+        vid_to_module[v]
+        for v in covering.loc[ghost, _MODULE_VID_COL]
+        if v in vid_to_module
+    }
+    kept_modules = {
+        vid_to_module[v]
+        for v in non_ghost[_MODULE_VID_COL]
+        if v in vid_to_module
+    }
+    need = ghost_modules - kept_modules
+    fallback = _latest_prior_non_collapsed_vids(session, need, release_id)
+    if not fallback:
+        return non_ghost
+
+    fallback_rows = _drop_collapsed_rows(
+        pd.DataFrame(
+            materialize(build_query(_vids_filter(list(fallback.values())))),
+            columns=cols,
+        )
+    )
+    # The fallback version may not actually host the requested operand (its
+    # composition can differ from the ghost's), leaving nothing to add.
+    if fallback_rows.empty:
+        return non_ghost
+    return pd.concat([non_ghost, fallback_rows], ignore_index=True)
+
+
 class ModuleVersionQuery:
     """Query helpers around ModuleVersion."""
 
@@ -769,30 +994,31 @@ class ModuleVersionQuery:
         if not tables_vids:
             return pd.DataFrame(columns=cols)
 
-        query = session.query(
-            ModuleVersion.module_vid.label("ModuleVID"),
-            ModuleVersionComposition.table_vid.label("variable_vid"),
-            ModuleVersion.code.label("ModuleCode"),
-            ModuleVersion.version_number.label("VersionNumber"),
-            ModuleVersion.from_reference_date.label("FromReferenceDate"),
-            ModuleVersion.to_reference_date.label("ToReferenceDate"),
-            ModuleVersion.start_release_id.label("StartReleaseID"),
-            ModuleVersion.end_release_id.label("EndReleaseID"),
-        ).join(
-            ModuleVersionComposition,
-            ModuleVersion.module_vid == ModuleVersionComposition.module_vid,
+        def build_query(module_filter: Callable[[Any], Any]) -> Any:
+            query = session.query(
+                ModuleVersion.module_vid.label("ModuleVID"),
+                ModuleVersionComposition.table_vid.label("variable_vid"),
+                ModuleVersion.code.label("ModuleCode"),
+                ModuleVersion.version_number.label("VersionNumber"),
+                ModuleVersion.from_reference_date.label("FromReferenceDate"),
+                ModuleVersion.to_reference_date.label("ToReferenceDate"),
+                ModuleVersion.start_release_id.label("StartReleaseID"),
+                ModuleVersion.end_release_id.label("EndReleaseID"),
+            ).join(
+                ModuleVersionComposition,
+                ModuleVersion.module_vid
+                == ModuleVersionComposition.module_vid,
+            )
+            return module_filter(query)
+
+        def materialize(query: Any) -> list[Any]:
+            return chunked_in(
+                query, ModuleVersionComposition.table_vid, tables_vids
+            )
+
+        return _resolve_with_ghost_fallback(
+            session, build_query, materialize, cols, release_id
         )
-        query = filter_by_release(
-            query,
-            start_col=ModuleVersion.start_release_id,
-            end_col=ModuleVersion.end_release_id,
-            release_id=release_id,
-        )
-        query = _exclude_collapsed_reference_window(query)
-        results = chunked_in(
-            query, ModuleVersionComposition.table_vid, tables_vids
-        )
-        return pd.DataFrame(results, columns=cols)
 
     @staticmethod
     def get_from_table_codes(
@@ -824,37 +1050,40 @@ class ModuleVersionQuery:
         if not table_codes:
             return pd.DataFrame(columns=cols)
 
-        query = (
-            session.query(
-                ModuleVersion.module_vid.label("ModuleVID"),
-                ModuleVersionComposition.table_vid.label("variable_vid"),
-                ModuleVersion.code.label("ModuleCode"),
-                ModuleVersion.version_number.label("VersionNumber"),
-                ModuleVersion.from_reference_date.label("FromReferenceDate"),
-                ModuleVersion.to_reference_date.label("ToReferenceDate"),
-                ModuleVersion.start_release_id.label("StartReleaseID"),
-                ModuleVersion.end_release_id.label("EndReleaseID"),
-                TableVersion.code.label("TableCode"),
+        def build_query(module_filter: Callable[[Any], Any]) -> Any:
+            query = (
+                session.query(
+                    ModuleVersion.module_vid.label("ModuleVID"),
+                    ModuleVersionComposition.table_vid.label("variable_vid"),
+                    ModuleVersion.code.label("ModuleCode"),
+                    ModuleVersion.version_number.label("VersionNumber"),
+                    ModuleVersion.from_reference_date.label(
+                        "FromReferenceDate"
+                    ),
+                    ModuleVersion.to_reference_date.label("ToReferenceDate"),
+                    ModuleVersion.start_release_id.label("StartReleaseID"),
+                    ModuleVersion.end_release_id.label("EndReleaseID"),
+                    TableVersion.code.label("TableCode"),
+                )
+                .join(
+                    ModuleVersionComposition,
+                    ModuleVersion.module_vid
+                    == ModuleVersionComposition.module_vid,
+                )
+                .join(
+                    TableVersion,
+                    ModuleVersionComposition.table_vid
+                    == TableVersion.table_vid,
+                )
             )
-            .join(
-                ModuleVersionComposition,
-                ModuleVersion.module_vid
-                == ModuleVersionComposition.module_vid,
-            )
-            .join(
-                TableVersion,
-                ModuleVersionComposition.table_vid == TableVersion.table_vid,
-            )
+            return module_filter(query)
+
+        def materialize(query: Any) -> list[Any]:
+            return chunked_in(query, TableVersion.code, table_codes)
+
+        return _resolve_with_ghost_fallback(
+            session, build_query, materialize, cols, release_id
         )
-        query = filter_by_release(
-            query,
-            start_col=ModuleVersion.start_release_id,
-            end_col=ModuleVersion.end_release_id,
-            release_id=release_id,
-        )
-        query = _exclude_collapsed_reference_window(query)
-        results = chunked_in(query, TableVersion.code, table_codes)
-        return pd.DataFrame(results, columns=cols)
 
     @staticmethod
     def get_precondition_module_versions(
@@ -886,42 +1115,45 @@ class ModuleVersionQuery:
         if not precondition_items:
             return pd.DataFrame(columns=cols)
 
-        query = (
-            session.query(
-                ModuleVersion.module_vid.label("ModuleVID"),
-                VariableVersion.variable_vid.label("variable_vid"),
-                ModuleVersion.code.label("ModuleCode"),
-                ModuleVersion.version_number.label("VersionNumber"),
-                ModuleVersion.from_reference_date.label("FromReferenceDate"),
-                ModuleVersion.to_reference_date.label("ToReferenceDate"),
-                ModuleVersion.start_release_id.label("StartReleaseID"),
-                ModuleVersion.end_release_id.label("EndReleaseID"),
-                VariableVersion.code.label("Code"),
+        def build_query(module_filter: Callable[[Any], Any]) -> Any:
+            query = (
+                session.query(
+                    ModuleVersion.module_vid.label("ModuleVID"),
+                    VariableVersion.variable_vid.label("variable_vid"),
+                    ModuleVersion.code.label("ModuleCode"),
+                    ModuleVersion.version_number.label("VersionNumber"),
+                    ModuleVersion.from_reference_date.label(
+                        "FromReferenceDate"
+                    ),
+                    ModuleVersion.to_reference_date.label("ToReferenceDate"),
+                    ModuleVersion.start_release_id.label("StartReleaseID"),
+                    ModuleVersion.end_release_id.label("EndReleaseID"),
+                    VariableVersion.code.label("Code"),
+                )
+                .join(
+                    ModuleParameters,
+                    ModuleVersion.module_vid == ModuleParameters.module_vid,
+                )
+                .join(
+                    VariableVersion,
+                    ModuleParameters.variable_vid
+                    == VariableVersion.variable_vid,
+                )
+                .join(
+                    Variable,
+                    VariableVersion.variable_id == Variable.variable_id,
+                )
+                .filter(VariableVersion.code.in_(precondition_items))
+                .filter(_is_filing_indicator())
             )
-            .join(
-                ModuleParameters,
-                ModuleVersion.module_vid == ModuleParameters.module_vid,
-            )
-            .join(
-                VariableVersion,
-                ModuleParameters.variable_vid == VariableVersion.variable_vid,
-            )
-            .join(
-                Variable,
-                VariableVersion.variable_id == Variable.variable_id,
-            )
-            .filter(VariableVersion.code.in_(precondition_items))
-            .filter(_is_filing_indicator())
+            return module_filter(query)
+
+        def materialize(query: Any) -> list[Any]:
+            return query.all()
+
+        return _resolve_with_ghost_fallback(
+            session, build_query, materialize, cols, release_id
         )
-        query = filter_by_release(
-            query,
-            start_col=ModuleVersion.start_release_id,
-            end_col=ModuleVersion.end_release_id,
-            release_id=release_id,
-        )
-        query = _exclude_collapsed_reference_window(query)
-        results = query.all()
-        return pd.DataFrame(results, columns=cols)
 
     @staticmethod
     def get_module_version_by_vid(

--- a/src/dpmcore/dpm_xl/utils/scopes_calculator.py
+++ b/src/dpmcore/dpm_xl/utils/scopes_calculator.py
@@ -380,8 +380,10 @@ class OperationScopeService:
                 # The "1-13" template is keyed on ``table_version_ids``; pass
                 # the table codes under that name (codes ARE table-version
                 # identifiers) so the message formats instead of raising a
-                # KeyError. Reached now that single-day module versions are
-                # excluded from scope and a release may host none.
+                # KeyError.
+                # a release hosts none only when its sole covering version
+                # is a single-day (ghost) module version AND no prior
+                # non-collapsed version exists to fall back to.
                 raise errors.SemanticError(
                     "1-13", table_version_ids=list(table_codes)
                 )

--- a/tests/integration/services/test_ghost_date_resolution.py
+++ b/tests/integration/services/test_ghost_date_resolution.py
@@ -1,0 +1,89 @@
+"""Pin the date-mode side of issue #182.
+
+The #182 code fix lives on the *release* axis (scope calculation). On the
+*reference-date* axis the desired behaviour -- resolve to the module version
+that would actually be executed, i.e. the prior non-ghost when the covering
+version is a ghost -- already holds without a code change, because a collapsed
+window (``from == to``) matches no date under ``from <= date < to`` and the
+prior non-ghost's genuine (wide) window already covers the ghost's era.
+
+These tests pin that so a future change to ``filter_by_date`` / the date
+branches of ``_apply_module_filter`` cannot silently regress it. Concretely,
+FINREP9's ghost ``3.2.0`` claims the instant ``2024-12-31``; the prior
+non-ghost ``3.1.0`` (window ``2022-12-31 -> 2026-03-30``) covers it, so a
+reference-date lookup for F_01.02 there must resolve to ``3.1.0``'s structure,
+never the ghost's and never empty.
+"""
+
+from __future__ import annotations
+
+from dpmcore.orm.packaging import ModuleVersion, ModuleVersionComposition
+from dpmcore.services.data_dictionary import DataDictionaryService
+from dpmcore.services.hierarchy import HierarchyService
+
+# A reporting reference date inside FINREP9's ghost era (3.2.0's collapsed
+# instant); the prior non-ghost 3.1.0 covers it.
+_GHOST_ERA_DATE = "2024-12-31"
+
+
+def _module_vid(session, code, version):
+    """Return the ``ModuleVID`` for a ``(code, version_number)`` pair."""
+    mv = (
+        session.query(ModuleVersion)
+        .filter(
+            ModuleVersion.code == code,
+            ModuleVersion.version_number == version,
+        )
+        .one()
+    )
+    return mv.module_vid
+
+
+def _hosts_table_vid(session, module_vid, table_vid):
+    """Whether ``module_vid``'s composition contains ``table_vid``."""
+    return (
+        session.query(ModuleVersionComposition)
+        .filter(
+            ModuleVersionComposition.module_vid == module_vid,
+            ModuleVersionComposition.table_vid == table_vid,
+        )
+        .first()
+        is not None
+    )
+
+
+def test_date_lookup_resolves_to_prior_non_ghost(fixture_session):
+    """A ghost-era reference-date lookup lands on the prior non-ghost.
+
+    ``get_table_details('F_01.02', date=<ghost era>)`` must resolve, and the
+    table version it returns must belong to the prior non-ghost FINREP9 3.1.0
+    -- never the ghost 3.2.0.
+    """
+    session = fixture_session
+    prior = _module_vid(session, "FINREP9", "3.1.0")
+    ghost = _module_vid(session, "FINREP9", "3.2.0")
+
+    details = HierarchyService(session).get_table_details(
+        "F_01.02", date=_GHOST_ERA_DATE
+    )
+    assert details is not None, "ghost-era date must resolve, not go empty"
+
+    table_vid = details["table_vid"]
+    assert _hosts_table_vid(session, prior, table_vid), (
+        "date lookup should resolve to the prior non-ghost's table version"
+    )
+    assert not _hosts_table_vid(session, ghost, table_vid), (
+        "date lookup must not resolve to the ghost's table version"
+    )
+
+
+def test_get_tables_by_date_includes_ghost_era_table(fixture_session):
+    """A table hosted only via a ghost era is still listed by date.
+
+    F_01.02 must appear in ``get_tables(date=<ghost era>)`` because the prior
+    non-ghost FINREP9 3.1.0 covers that reference date.
+    """
+    tables = DataDictionaryService(fixture_session).get_tables(
+        date=_GHOST_ERA_DATE
+    )
+    assert "F_01.02" in tables

--- a/tests/integration/services/test_scope_release_axis.py
+++ b/tests/integration/services/test_scope_release_axis.py
@@ -1,6 +1,6 @@
-"""Regression tests for issue #151: release-axis scope selection + single-day exclusion.
+"""Regression tests for issue #151 (release axis) + #182 (ghost fallback).
 
-Two rules are pinned here, both verified against EBA's own pre-calculated
+Rules pinned here, verified against EBA's own pre-calculated
 ``OperationScope`` / ``OperationScopeComposition`` shipped in the dictionary
 (an oracle straight from the data, not hand-built fixtures):
 
@@ -10,15 +10,23 @@ Two rules are pinned here, both verified against EBA's own pre-calculated
    could substitute a version absent from R -- e.g. ``FINREP9DP 1.1.0`` (a 4.2.1
    version) leaking into release 4.2 -- producing an invalid scope and the
    downstream ``Release X predates module version ...`` error a consumer hit.
+   The #182 fallback is still bound by this: it only ever reaches *backward*
+   (a version whose release window starts on or before R), never forward.
 
-2. **Single-day module versions are excluded (EBA business rule).** A module
-   version whose reference-date window is collapsed (``FromReferenceDate ==
-   ToReferenceDate``) describes one reporting date and is never in scope, even
-   when it is the only version valid in a release -- that release then has no
-   scope and reports a clean "no module versions found" error.
+2. **Ghost (single-day) versions are never scoped as-is.** A module version
+   whose reference-date window is collapsed (``FromReferenceDate ==
+   ToReferenceDate``) describes one reporting date and is never placed in scope.
 
-So the release-R oracle is the operation's persisted module versions, filtered
-to R by the release axis, minus any collapsed-window version.
+3. **#182 ghost fallback.** When the only version whose release window covers R
+   is a ghost, the scope falls back to the most recent *prior* non-collapsed
+   version of the same module (e.g. release 4.0/4.1 for F_01.02 fall back to
+   ``FINREP9 3.1.0``). When no such prior version exists -- the ghost is the
+   earliest usable version of its module (e.g. ``FINREP9DP 1.0.0`` at 4.2) --
+   the release keeps the clean "no module versions found" error (rule 2 wins).
+
+So the release-R oracle is: the operation's persisted versions valid in R by
+the release axis and not collapsed, plus -- for a module whose only R-covering
+version is a ghost -- that module's latest prior non-collapsed version.
 """
 
 from __future__ import annotations
@@ -107,6 +115,39 @@ def _is_collapsed(mv):
     )
 
 
+def _starts_on_or_before(mv, target_sort, sort_by_id):
+    """Whether ``mv``'s release window starts on or before ``target_sort``.
+
+    The #182 fallback may return a version whose window ended before R (it
+    reaches backward), but it must *never* return one that begins after R --
+    that is the #151 guarantee. This is the weakened form of
+    :func:`_valid_in_release` used by the invariant sweep.
+    """
+    if mv.start_release_id is None:
+        return False
+    start = sort_by_id.get(mv.start_release_id)
+    return start is not None and start <= target_sort
+
+
+def _latest_prior_non_collapsed(module_versions, target_sort, sort_by_id):
+    """Oracle mirror of ``_latest_prior_non_collapsed_vids`` for one module.
+
+    Returns the ``ModuleVID`` of the newest non-collapsed version whose
+    release-window start sort order is ``<= target_sort`` (strictly backward),
+    or ``None`` when the module has no such version.
+    """
+    best = None  # (start_sort, module_vid)
+    for mv in module_versions:
+        if _is_collapsed(mv) or mv.start_release_id is None:
+            continue
+        order = sort_by_id.get(mv.start_release_id)
+        if order is None or order > target_sort:
+            continue
+        if best is None or (order, mv.module_vid) > best:
+            best = (order, mv.module_vid)
+    return None if best is None else best[1]
+
+
 def _latest_expression(session, op_code):
     """Return the open (current) operation version's expression text."""
     expr = session.execute(
@@ -156,13 +197,13 @@ def _f0102_operation_codes(session, limit):
 
 
 def test_scope_matches_eba_persisted_scope_per_release(fixture_session):
-    """Computed scope == persisted scope per release, minus single-day versions.
+    """Computed scope == persisted scope per release, with #182 ghost fallback.
 
-    The exact #151 scenario plus the business rule: release 4.2 yields
-    ``FINREP9 3.3.0`` only -- never the 4.2.1 version ``1.1.0`` (release axis)
-    and never the single-day ``FINREP9DP 1.0.0`` (exclusion rule). Releases
-    4.0/4.1, whose only FINREP9 version (``3.2.0``) is single-day, end up with
-    no scope at all.
+    The #151 scenario plus the #182 rule: release 4.2 yields ``FINREP9 3.3.0``
+    only -- never the 4.2.1 version ``1.1.0`` (release axis), and the ghost
+    ``FINREP9DP 1.0.0`` is dropped with no prior to fall back to. Releases
+    4.0/4.1, whose only FINREP9 version (``3.2.0``) is a ghost, now fall back
+    to the prior non-collapsed ``FINREP9 3.1.0`` instead of ending up empty.
     """
     session = fixture_session
     expression = _latest_expression(session, _ISSUE_OPERATION)
@@ -179,17 +220,50 @@ def test_scope_matches_eba_persisted_scope_per_release(fixture_session):
     collapsed = {vid for vid, mv in versions.items() if _is_collapsed(mv)}
     assert collapsed, "oracle should include collapsed versions to exercise"
 
+    # Every module version of every module hosting this operation, so the
+    # oracle can reproduce the fallback's backward search across versions EBA
+    # never persisted for the operation.
+    module_ids = {mv.module_id for mv in versions.values()}
+    all_by_module: dict[int, list] = {}
+    for mv in (
+        session.query(ModuleVersion)
+        .filter(ModuleVersion.module_id.in_(module_ids))
+        .all()
+    ):
+        all_by_module.setdefault(mv.module_id, []).append(mv)
+
     svc = ScopeCalculatorService(session)
 
-    saw_empty_release = False
+    saw_fallback = False
     for rel in _ordered_releases(session):
         target_sort = compute_sort_order(rel.code)
-        oracle = {
+        base = {
             vid
             for vid, mv in versions.items()
             if _valid_in_release(mv, target_sort, sort_by_id)
             and not _is_collapsed(mv)
         }
+        base_modules = {versions[v].module_id for v in base}
+        # Modules whose only R-covering version is a ghost -> need a fallback.
+        ghost_only_modules = {
+            mv.module_id
+            for mv in versions.values()
+            if _valid_in_release(mv, target_sort, sort_by_id)
+            and _is_collapsed(mv)
+        } - base_modules
+
+        oracle = set(base)
+        for module_id in ghost_only_modules:
+            cand = _latest_prior_non_collapsed(
+                all_by_module.get(module_id, []), target_sort, sort_by_id
+            )
+            # The resolver re-fetches the fallback version's tables and keeps
+            # it only if it still hosts the operation; persisted membership is
+            # that guarantee for this single-table operation.
+            if cand is not None and cand in persisted:
+                oracle.add(cand)
+                saw_fallback = True
+
         result = svc.calculate_from_expression(
             expression=expression, release_code=rel.code
         )
@@ -198,27 +272,29 @@ def test_scope_matches_eba_persisted_scope_per_release(fixture_session):
             f"{sorted(result.module_versions)} != oracle {sorted(oracle)} "
             f"(has_error={result.has_error}, msg={result.error_message})"
         )
-        # A single-day version must never be selected, in any release.
+        # A ghost (single-day) version must never be selected, in any release.
         assert not (set(result.module_versions) & collapsed)
         if not oracle:
-            # No eligible module version -> clean "no module versions" error.
-            saw_empty_release = True
+            # No eligible version and no prior -> clean "no modules" error.
             assert result.has_error
             assert "No module versions found" in (result.error_message or "")
 
-    assert saw_empty_release, (
-        "expected a release whose only module version is single-day "
-        "(4.0/4.1 for F_01.02) to end up with no scope"
+    assert saw_fallback, (
+        "expected a release (4.0/4.1 for F_01.02) whose only covering version "
+        "is a ghost to fall back to a prior non-collapsed version"
     )
 
 
-def test_scoped_versions_are_release_valid_and_not_single_day(fixture_session):
-    """No computed scope returns a release-invalid or single-day version.
+def test_scoped_versions_are_backward_only_and_not_single_day(fixture_session):
+    """No computed scope returns a forward or single-day version.
 
     The two invariants, swept across a sample of real F_01.02 operations:
-    every module version in a computed scope must (a) satisfy
-    ``start <= release < end`` on the semver sort order and (b) have a
-    non-collapsed reference-date window.
+    every module version in a computed scope must (a) start on or before the
+    target release on the semver sort order (never forward -- the #151
+    guarantee, which the #182 fallback must not break; the fallback may reach
+    backward past the release window, so full ``start <= release < end``
+    validity is not required) and (b) have a non-collapsed reference-date
+    window (the #182 fallback always resolves to a genuine version).
     """
     session = fixture_session
     sort_by_id = _release_sort_by_id(session)
@@ -242,10 +318,10 @@ def test_scoped_versions_are_release_valid_and_not_single_day(fixture_session):
             for vid in result.module_versions:
                 checks += 1
                 mv = versions[vid]
-                assert _valid_in_release(mv, target_sort, sort_by_id), (
+                assert _starts_on_or_before(mv, target_sort, sort_by_id), (
                     f"{code} @ {rel.code}: module version {vid} "
-                    f"({mv.code} {mv.version_number}) is not valid in "
-                    f"release {rel.code}"
+                    f"({mv.code} {mv.version_number}) begins after "
+                    f"release {rel.code} (forward selection, #151)"
                 )
                 assert not _is_collapsed(mv), (
                     f"{code} @ {rel.code}: single-day module version {vid} "
@@ -253,6 +329,41 @@ def test_scoped_versions_are_release_valid_and_not_single_day(fixture_session):
                 )
 
     assert checks, "invariant swept zero module versions"
+
+
+def test_ghost_only_release_falls_back_to_prior_version(fixture_session):
+    """#182 reproduction: F_01.02 @ 4.1 falls back to FINREP9 3.1.0.
+
+    Release 4.1's only covering FINREP9 version is the ghost ``3.2.0`` (VID
+    404). Before the fix this errored ``No module versions found``; now it
+    resolves to the prior non-collapsed ``3.1.0`` (VID 356) and never the
+    ghost.
+    """
+    svc = ScopeCalculatorService(fixture_session)
+    result = svc.calculate_from_expression(
+        expression="{tF_01.02, r0010, c0010} >= 0", release_code="4.1"
+    )
+    assert not result.has_error, result.error_message
+    assert 356 in result.module_versions, result.module_versions
+    assert 404 not in result.module_versions, "ghost 3.2.0 must not be scoped"
+
+
+def test_no_prior_non_ghost_keeps_clean_no_scope_error(fixture_session):
+    """#182 no-prior case: a ghost with no prior non-collapsed version errors.
+
+    ``SEPA_IPR 1.0.0`` is the earliest version of its module, is a ghost, and
+    covers release 4.1; its only sibling ``1.1.0`` starts later (4.2), so there
+    is nothing to fall back to. ``S_01.01`` is hosted only by SEPA_IPR, so the
+    release keeps the clean "no module versions found" error rather than
+    scoping the ghost.
+    """
+    svc = ScopeCalculatorService(fixture_session)
+    result = svc.calculate_from_expression(
+        expression="{tS_01.01, r0010, c0010} >= 0", release_code="4.1"
+    )
+    assert result.has_error
+    assert "No module versions found" in (result.error_message or "")
+    assert not result.module_versions
 
 
 class TestResolveExplicitRelease:


### PR DESCRIPTION
## Summary

Fixes #182.

Some module versions have a bad reference-date window: `FromReferenceDate` equals `ToReferenceDate` (one single day). This is a known error in the source data and it will not be fixed upstream. We call these ghost versions.

A ghost version is still marked as valid for several releases. But the scope code dropped it, because a single-day window is treated as "does not apply".

The scope of an expression is built one module at a time: for each module the expression touches, the scope takes the version that covers the target release. The fix works at that level. For each module, if the version covering the release is a ghost, the scope uses the latest previous valid (non-ghost) version of that module. This runs for every affected module on its own. It does not depend on whether the whole validation would still run: a module gets its fallback even when the other modules in the same expression are fine.

Only the reference dates are wrong in this data, not the release windows, so each module has exactly one version covering a given release. If a module's covering version is a ghost and there is no previous valid version, that module adds nothing. If that leaves the whole scope empty, the release returns "No module versions found", same as before.

Example. For FINREP9, releases 4.0 and 4.1 are covered only by the ghost `3.2.0`, so before the fix they had no scope. Now they use `3.1.0` (the previous valid version) and the validations run. For FINREP9DP, version `1.0.0` at release 4.2 is a ghost and has no earlier version, so 4.2 still returns no scope.

## Decisions

- Use the previous version, not the ghost. For each module, the scope takes the structure of the latest previous valid version. This is decided per module, not per validation: a module gets the fallback whenever its covering version is a ghost, even if other modules in the same expression are fine.
- Only look backwards. The fallback never picks a version that starts after the target release. This keeps the rule from #151 (a newer version must not show up in an older release, which used to cause the "Release X predates module version" error).
- No previous version means no scope. If the ghost is the first version of its module, there is nothing to fall back to, so the release returns the same "No module versions found" error as before.
- Date lookups did not need a code change. A single-day window matches no date, and the previous non-ghost version's window already covers those dates. So a lookup by date already returns the previous version. New tests check this stays true.
- One place for the fix. The fallback is in the shared module-version queries used by expression scope, table scope, and preconditions.

## Files changed

- `src/dpmcore/dpm_xl/model_queries.py`: the fallback. For each module, if its covering version for the release is a ghost, use the latest previous non-ghost version of that module.
- `src/dpmcore/dpm_xl/utils/scopes_calculator.py`: comment only.
- `tests/integration/services/test_scope_release_axis.py`: the #151 tests, updated to the new behaviour.
- `tests/integration/services/test_ghost_date_resolution.py`: new, checks the date lookups.

## Checklist

- [x] `ruff format`, `ruff check`, `mypy`: clean on the changed files.
- [x] Tests pass
- [ ] Documentation updated (if applicable).

## Impact / Risk

- Same inputs, same return type. What changes is the scope content: for any module whose covering version is a ghost, the scope now uses the previous valid version. A release returns an error only when this leaves no module version at all.
- This changes part of #151. #151 left these releases empty on purpose. The #151 tests were updated, not removed.
- No database or migration changes.
- Changelog: ghost-only releases now use the previous module version instead of failing.

## Notes

- A ghost version is never used directly. It only triggers the fallback.
- The fallback re-reads the tables of the previous version. It is used only if that version really contains the requested table or item, because a module's tables can change between versions.
