### PR TITLE
Switch release ordering logic from semver to date based

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ curl -X POST http://localhost:8000/api/v1/scripts \
 **Data dictionary queries:**
 
 Release-aware methods accept `release_id` (integer ID) or
-`release_code` (semver string like `"4.2.1"`). At most one may be
+`release_code` (a code string like `"4.2.1"`). At most one may be
 supplied; passing both raises `ValueError`.
 
 ```python
@@ -238,9 +238,8 @@ with connect("sqlite:///dpm.db") as db:
     # Deep tree: framework -> module_versions -> table_versions
     tree       = hierarchy.get_all_frameworks(deep=True)
 
-    # Filter by release code — preferred over numeric release_id since
-    # IDs became opaque from DPM 4.2.1 onwards (e.g. release "4.2.1"
-    # has ReleaseID=1010000003, not 6).
+    # Filter by release code — preferred over numeric release_id,
+    # which is opaque from DPM 4.2.1 onwards.
     by_code    = hierarchy.get_all_frameworks(
         deep=True, release_code="4.2.1"
     )
@@ -272,20 +271,9 @@ fall back to the currently-active (`end_release_id IS NULL`) module
 versions, so results stay deterministic when a module has been
 republished across releases.
 
-> **How range comparisons work.** From DPM **4.2.1** onwards EBA
-> assigns opaque `ReleaseID` values (`4.2.1` is `1010000003`, while
-> older releases are still 1..5), so release-range comparisons cannot
-> rely on numeric ID ordering. dpmcore instead parses `Release.code`
-> as a semver tuple and packs it into a single sortable integer **in
-> Python at query time**
-> (`dpmcore.orm.release_sort_order.compute_sort_order`) — there is no
-> persisted `sort_order` column, ORM listener, or migration backfill.
-> This means both forms work correctly: `release_id=1010000003` and
-> `release_code="4.2.1"` resolve identically, and a hypothetical
-> backport like `4.0.1` shipped after `4.2.1` is correctly placed
-> inside the `4.0` lineage. Prefer `release_code` for human input
-> because the codes are readable; `release_id` is for cases where
-> you already have the resolved integer in hand.
+> **Tip.** Prefer `release_code` for human input — the numeric
+> `ReleaseID` is opaque from DPM 4.2.1 onwards. Both resolve to the
+> same release, and any release code format is accepted.
 
 **Migration — import from Access:**
 

--- a/docs/api/hierarchy.rst
+++ b/docs/api/hierarchy.rst
@@ -43,7 +43,9 @@ returned. Passing more than one raises :class:`ValueError`.
 
 Releases are ordered chronologically by publication date, so a release
 filter returns the entities whose release-validity window contains the
-target release.
+target release. An unpublished working release has no publication date
+and is treated as the latest, so filtering at it returns the current
+(non-ended) entities.
 
 HierarchyService
 ----------------

--- a/docs/api/hierarchy.rst
+++ b/docs/api/hierarchy.rst
@@ -28,11 +28,10 @@ The supported filter set varies by method:
     Restrict to entities valid at the given DPM release.
 
 ``release_code`` (``str``)
-    Restrict by release code (e.g. ``"3.4"``, ``"4.2.1"``). Resolved
-    against :class:`Release.code` to its numeric ``ReleaseID``.
-    Raises :class:`ValueError` if the code does not match any release.
-    Preferred for user-facing input — ``"4.2.1"`` is more readable
-    than the opaque ``ReleaseID = 1010000003`` EBA assigns.
+    Restrict by release code (e.g. ``"3.4"``, ``"4.2.1"``). Raises
+    :class:`ValueError` if the code does not match any release.
+    Preferred for user-facing input, since ``ReleaseID`` values are
+    opaque from DPM 4.2.1 onwards. Any release code format is accepted.
 
 ``date`` (``str``, ``YYYY-MM-DD``)
     Restrict via ``ModuleVersion.from_reference_date`` /
@@ -42,38 +41,9 @@ The supported filter set varies by method:
 When none is supplied, the active (non-ended) module versions are
 returned. Passing more than one raises :class:`ValueError`.
 
-How range comparison works
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-DPM ``ReleaseID`` values are no longer monotonic — from 4.2.1 onwards
-EBA assigns opaque IDs like ``1010000003`` while older releases are
-still ``1..5``, so release-range comparisons cannot rely on numeric ID
-ordering. Instead dpmcore parses ``Release.code`` as a semver tuple
-(``"4.2.1" → (4, 2, 1)``) and packs it into a single sortable integer
-**in Python at query time**
-(:func:`dpmcore.orm.release_sort_order.compute_sort_order`). There is
-**no** persisted ``sort_order`` column, ORM event listener, or
-migration backfill — the packed value is recomputed on demand from
-the release code and held as a plain ``int``.
-
-All range comparisons (``filter_by_release``, ``filter_item_version``,
-the inline ``Release.release_id >= …`` patterns in
-:class:`ASTGeneratorService` and the ECB-validations importer) compare
-these packed values, not the raw ``ReleaseID``. Two consequences worth
-being aware of:
-
-* Both filter forms resolve identically: ``release_id=1010000003`` and
-  ``release_code="4.2.1"`` select the same release. A backport
-  published chronologically after a higher-numbered release — e.g. a
-  future ``4.0.1`` shipped after ``4.2.1`` — is still correctly placed
-  inside the ``4.0`` lineage, so a module version declared "valid from
-  4.0 to 4.2" includes the ``4.0.1`` backport.
-* If a ``Release.code`` cannot be parsed as ``MAJOR.MINOR[.PATCH]``,
-  :func:`~dpmcore.orm.release_sort_order.compute_sort_order` returns
-  ``None`` and any range filter passing that release as the target
-  raises a clear :class:`ValueError` rather than silently returning
-  wrong rows. Releases with unparseable codes simply do not
-  participate in range filters.
+Releases are ordered chronologically by publication date, so a release
+filter returns the entities whose release-validity window contains the
+target release.
 
 HierarchyService
 ----------------

--- a/src/dpmcore/dpm_xl/model_queries.py
+++ b/src/dpmcore/dpm_xl/model_queries.py
@@ -952,30 +952,29 @@ class ModuleVersionQuery:
     def get_last_release(
         session: "Session",
     ) -> int | None:
-        """Return the ID of the most recent release, ordered by date.
+        """Return the ID of the latest release by the date sort order.
 
-        Releases are ordered by ``Release.date`` (descending), not the
-        opaque ``release_id`` FK, which is non-monotonic from DPM 4.2.1
-        onwards (e.g. ``4.2.1`` is ``ReleaseID 1010000003``), so the
-        highest id is not necessarily the latest release. Releases with
-        no date are unrankable and excluded.
+        Releases are ranked by :func:`compute_sort_order` (from
+        ``Release.date``), not the opaque ``release_id`` FK, which is
+        non-monotonic from DPM 4.2.1 onwards (e.g. ``4.2.1`` is
+        ``ReleaseID 1010000003``), so the highest id is not necessarily
+        the latest release. An undated (unpublished) release sorts as the
+        latest; ties are broken by ``release_id`` for determinism.
 
         Args:
             session: SQLAlchemy session.
 
         Returns:
-            Integer release ID of the latest dated release, or ``None``
-            when there is no dated release.
+            Integer release ID of the latest release, or ``None`` when
+            there are no releases.
         """
-        result = (
-            session.query(Release.release_id)
-            .filter(Release.date.isnot(None))
-            .order_by(Release.date.desc())
-            .first()
-        )
-        if result is None:
+        sort_orders = load_release_sort_orders(session)
+        ranked = [
+            (so, rid) for rid, so in sort_orders.items() if so is not None
+        ]
+        if not ranked:
             return None
-        return int(result[0])
+        return max(ranked)[1]
 
     @staticmethod
     def get_from_tables_vids(

--- a/src/dpmcore/dpm_xl/model_queries.py
+++ b/src/dpmcore/dpm_xl/model_queries.py
@@ -805,7 +805,7 @@ def _latest_prior_non_collapsed_vids(
     For each module id, return the ``ModuleVID`` of the most recent
     module version that (a) has a genuine (non-collapsed) reference-date
     window and (b) whose release-window start is on or before the target
-    release on the semver sort order. The search is strictly backward: a
+    release on the date-based sort order. The search is strictly backward: a
     version whose release window begins *after* the target is never
     chosen, preserving the #151 release-axis safety constraint. Modules
     with no such version are omitted, so the caller keeps the clean

--- a/src/dpmcore/dpm_xl/model_queries.py
+++ b/src/dpmcore/dpm_xl/model_queries.py
@@ -952,18 +952,30 @@ class ModuleVersionQuery:
     def get_last_release(
         session: "Session",
     ) -> int | None:
-        """Return the highest release ID.
+        """Return the ID of the most recent release, ordered by date.
+
+        Releases are ordered by ``Release.date`` (descending), not the
+        opaque ``release_id`` FK, which is non-monotonic from DPM 4.2.1
+        onwards (e.g. ``4.2.1`` is ``ReleaseID 1010000003``), so the
+        highest id is not necessarily the latest release. Releases with
+        no date are unrankable and excluded.
 
         Args:
             session: SQLAlchemy session.
 
         Returns:
-            Integer release ID, or None.
+            Integer release ID of the latest dated release, or ``None``
+            when there is no dated release.
         """
-        result = session.query(func.max(Release.release_id)).scalar()
+        result = (
+            session.query(Release.release_id)
+            .filter(Release.date.isnot(None))
+            .order_by(Release.date.desc())
+            .first()
+        )
         if result is None:
             return None
-        return int(result)
+        return int(result[0])
 
     @staticmethod
     def get_from_tables_vids(

--- a/src/dpmcore/dpm_xl/model_queries.py
+++ b/src/dpmcore/dpm_xl/model_queries.py
@@ -969,12 +969,9 @@ class ModuleVersionQuery:
             there are no releases.
         """
         sort_orders = load_release_sort_orders(session)
-        ranked = [
-            (so, rid) for rid, so in sort_orders.items() if so is not None
-        ]
-        if not ranked:
+        if not sort_orders:
             return None
-        return max(ranked)[1]
+        return max((so, rid) for rid, so in sort_orders.items())[1]
 
     @staticmethod
     def get_from_tables_vids(

--- a/src/dpmcore/dpm_xl/utils/filters.py
+++ b/src/dpmcore/dpm_xl/utils/filters.py
@@ -3,13 +3,13 @@
 Provides composable SQLAlchemy filter conditions for
 release-based versioning and date-range queries.
 
-Release-range comparisons compare against the semver-parsed sort order
-of ``Release.code`` (computed in Python via
-:func:`dpmcore.orm.release_sort_order.compute_sort_order`) rather than
-against the raw ``Release.release_id`` FK, because EBA's post-4.2.1 ID
-scheme is no longer monotonic (4.2.1 has ``ReleaseID = 1010000003``).
-A hypothetical backport ``4.0.1`` is correctly placed inside the
-``4.0`` lineage even when published chronologically after ``4.2.1``.
+Release-range comparisons order releases by ``Release.date`` (via
+:func:`dpmcore.orm.release_sort_order.resolve_sort_order`) rather than
+by the raw ``Release.release_id`` FK, because EBA's post-4.2.1 ID scheme
+is no longer monotonic (4.2.1 has ``ReleaseID = 1010000003``). Dates are
+unique and follow the version lineage, so ordering by date works for
+every ``code`` format — including EBA's four-segment codes and
+non-versioned working releases — without parsing the code.
 """
 
 from datetime import datetime
@@ -130,10 +130,14 @@ def filter_by_release(
 ) -> Any:
     """Filter a query by DPM release versioning logic.
 
-    Logic (semver-aware):
+    Logic (date-ordered):
         If release_id provided:
-            sort_order(start) <= sort_order(target) AND
-            (end IS NULL OR sort_order(end) > sort_order(target))
+            ``sort_order(start) <= sort_order(target)`` AND
+            ``(end IS NULL OR sort_order(end) > sort_order(target))``,
+            where ``sort_order`` is the release's ``Release.date``. This
+            works for every ``code`` format — a ``"Playground"``/working
+            release orders by its (latest) date like any other, so a
+            request for it naturally resolves to the current rows.
         If release_id is None:
             * ``active_only_fallback=True`` → ``end_col IS NULL`` only
               (currently-active rows). Useful for callers that want a
@@ -159,8 +163,7 @@ def filter_by_release(
         TypeError: If ``query`` is not a session-bound SQLAlchemy
             ``Query`` (e.g. a Core ``Select`` was passed).
         ValueError: If ``release_id`` does not correspond to a known
-            ``Release`` row, or that release's code is not parseable
-            as ``MAJOR.MINOR[.PATCH]``.
+            ``Release`` row, or that release has no ``date``.
     """
     if release_id is None:
         if active_only_fallback:
@@ -176,6 +179,9 @@ def filter_by_release(
             "Select statements are not supported.",
         )
 
+    # Order releases by date. A "Playground"/working release orders by
+    # its date like any other, so no code parsing and no special-casing
+    # is needed; an unknown release_id (or one with no date) raises.
     target_sort_order = resolve_sort_order(session, release_id)
     sort_orders = load_release_sort_orders(session)
     start_ids = release_ids_for_sort_order(sort_orders, le=target_sort_order)
@@ -209,7 +215,7 @@ def filter_item_version(
 ) -> Any:
     """Build a version-range join condition.
 
-    Pattern (semver-aware):
+    Pattern (date-ordered):
 
         sort_order(item_start) <= ref_sort_order
         AND (item_end IS NULL OR ref_sort_order < sort_order(item_end))
@@ -218,8 +224,8 @@ def filter_item_version(
         sort_orders: Pre-loaded mapping from
             :func:`load_release_sort_orders`.
         ref_sort_order: Reference release's pre-resolved sort order.
-            ``None`` (unparseable code) collapses to a condition that
-            never matches.
+            ``None`` (no date / unknown release) collapses to a condition
+            that never matches.
         item_start_col: Item's start-release ID column.
         item_end_col: Item's end-release ID column.
 

--- a/src/dpmcore/dpm_xl/utils/filters.py
+++ b/src/dpmcore/dpm_xl/utils/filters.py
@@ -210,7 +210,7 @@ def filter_active_only(query: Any, end_col: Any) -> Any:
 
 
 def filter_item_version(
-    sort_orders: Dict[int, Optional[int]],
+    sort_orders: Dict[int, int],
     ref_sort_order: Optional[int],
     item_start_col: Any,
     item_end_col: Any,

--- a/src/dpmcore/dpm_xl/utils/filters.py
+++ b/src/dpmcore/dpm_xl/utils/filters.py
@@ -136,8 +136,9 @@ def filter_by_release(
             ``(end IS NULL OR sort_order(end) > sort_order(target))``,
             where ``sort_order`` is the release's ``Release.date``. This
             works for every ``code`` format — a ``"Playground"``/working
-            release orders by its (latest) date like any other, so a
-            request for it naturally resolves to the current rows.
+            release orders by its date like any other, and an undated
+            working release ranks as the latest, so a request for it
+            naturally resolves to the current rows.
         If release_id is None:
             * ``active_only_fallback=True`` → ``end_col IS NULL`` only
               (currently-active rows). Useful for callers that want a
@@ -163,7 +164,7 @@ def filter_by_release(
         TypeError: If ``query`` is not a session-bound SQLAlchemy
             ``Query`` (e.g. a Core ``Select`` was passed).
         ValueError: If ``release_id`` does not correspond to a known
-            ``Release`` row, or that release has no ``date``.
+            ``Release`` row.
     """
     if release_id is None:
         if active_only_fallback:
@@ -180,8 +181,9 @@ def filter_by_release(
         )
 
     # Order releases by date. A "Playground"/working release orders by
-    # its date like any other, so no code parsing and no special-casing
-    # is needed; an unknown release_id (or one with no date) raises.
+    # its date like any other (an undated one ranks as the latest), so no
+    # code parsing and no special-casing is needed; an unknown release_id
+    # raises.
     target_sort_order = resolve_sort_order(session, release_id)
     sort_orders = load_release_sort_orders(session)
     start_ids = release_ids_for_sort_order(sort_orders, le=target_sort_order)
@@ -224,8 +226,9 @@ def filter_item_version(
         sort_orders: Pre-loaded mapping from
             :func:`load_release_sort_orders`.
         ref_sort_order: Reference release's pre-resolved sort order.
-            ``None`` (no date / unknown release) collapses to a condition
-            that never matches.
+            ``None`` (an unknown/absent release) collapses to a condition
+            that never matches; an undated release is not ``None`` (it
+            ranks as the latest).
         item_start_col: Item's start-release ID column.
         item_end_col: Item's end-release ID column.
 

--- a/src/dpmcore/loaders/migration.py
+++ b/src/dpmcore/loaders/migration.py
@@ -27,7 +27,7 @@ from io import StringIO
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from sqlalchemy import inspect, select, text
+from sqlalchemy import case, inspect, select, text
 from sqlalchemy.engine import Engine
 
 from dpmcore.orm.base import Base
@@ -368,18 +368,25 @@ class MigrationService:
         """Return a filename-safe code for the current release."""
         from sqlalchemy.orm import Session
 
+        # Latest first: an undated (unpublished) working release ranks as
+        # the latest. The NULL-first CASE keeps this uniform across
+        # backends (SQLite/SQL Server otherwise sort NULLs last in DESC).
+        latest_first = (
+            case((Release.date.is_(None), 1), else_=0).desc(),
+            Release.date.desc(),
+        )
         with Session(self._engine) as session:
             stmt = (
                 select(Release.code)
                 .where(Release.is_current.is_(True))
-                .order_by(Release.date.desc())
+                .order_by(*latest_first)
             )
             code = session.scalars(stmt).first()
             if code is None:
                 code = session.scalars(
                     select(Release.code)
                     .where(Release.code.is_not(None))
-                    .order_by(Release.date.desc())
+                    .order_by(*latest_first)
                 ).first()
 
         if not code:

--- a/src/dpmcore/orm/release_sort_order.py
+++ b/src/dpmcore/orm/release_sort_order.py
@@ -1,95 +1,68 @@
-"""Compute release sort order from ``Release.code`` at query time.
+"""Compute release sort order from ``Release.date`` at query time.
 
 DPM ``ReleaseID`` values are no longer monotonic (4.2.1 has
 ``ReleaseID = 1010000003`` while older releases are still 1..5), so
-release-range comparisons cannot rely on numeric ID ordering. Instead
-we parse ``Release.code`` as a semver-style version tuple and pack it
-into a single sortable integer. Backports — e.g. a hypothetical
-``4.0.1`` published after ``4.2.1`` — still slot correctly into the
-``4.0`` lineage because comparison runs against the parsed semver, not
-the FK ID.
+release-range comparisons cannot rely on numeric ID ordering. They order
+by ``Release.date`` instead: EBA publishes releases chronologically in
+lineage order, and the date is present regardless of the ``code`` format,
+so date ordering handles every code — the classic ``MAJOR.MINOR[.PATCH]``
+form, EBA's four-segment codes (e.g. ``4.2.1.3``) and non-versioned
+working releases like ``"Playground"`` — uniformly, without parsing the
+code. Release dates are unique, so no tiebreak is needed.
+
+The order key is the date's proleptic-Gregorian ordinal, computed in
+Python at query time and held as a plain ``int`` — there is no persisted
+SQL column; only its ordering is ever used.
 """
 
 from __future__ import annotations
 
+from datetime import date
 from typing import TYPE_CHECKING, Dict, List, Optional
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
-# Three 6-digit slots per version segment → can hold 999999.999999.999999.
-# The packed value is computed in Python at query time and held as a
-# plain ``int`` — there is no persisted SQL column. Python ints are
-# arbitrary-precision so the >32-bit packed value needs no special
-# column type; if this ever moves to a stored column it must be BIGINT.
-_SEGMENT_BITS = 1_000_000
 
+def compute_sort_order(release_date: Optional[date]) -> Optional[int]:
+    """Return a sortable integer for a release's publication date.
 
-def parse_version(code: Optional[str]) -> Optional[tuple[int, int, int]]:
-    """Parse a release code into a ``(major, minor, patch)`` tuple.
+    Ordering is purely chronological: an earlier ``Release.date`` sorts
+    before a later one. Dates are unique per release, so the ordinal is a
+    total order and needs no tiebreak.
 
     Args:
-        code: Release code such as ``"4.2"`` or ``"4.2.1"``. ``None``
-            and unparseable codes return ``None`` so the caller can
-            decide whether to exclude or fall back.
+        release_date: The release's ``Release.date``. ``None`` returns
+            ``None`` so callers can skip an unorderable row; in practice
+            every release carries a date.
 
     Returns:
-        A 3-tuple of integers, or ``None`` when ``code`` is missing or
-        cannot be parsed as ``MAJOR.MINOR[.PATCH]``.
+        The date's ordinal (days since 0001-01-01), or ``None`` when
+        ``release_date`` is missing.
     """
-    if not code:
+    if release_date is None:
         return None
-    parts = code.split(".")
-    if not (1 <= len(parts) <= 3):
-        return None
-    try:
-        ints = [int(p) for p in parts]
-    except ValueError:
-        return None
-    while len(ints) < 3:
-        ints.append(0)
-    if any(p < 0 or p >= _SEGMENT_BITS for p in ints):
-        return None
-    return (ints[0], ints[1], ints[2])
-
-
-def compute_sort_order(code: Optional[str]) -> Optional[int]:
-    """Pack a release code into a single sortable integer.
-
-    ``"4.2.1"`` packs to ``4_000002_000001``. The packing is monotone:
-    if ``parse_version(a) < parse_version(b)`` then
-    ``compute_sort_order(a) < compute_sort_order(b)``.
-
-    Returns ``None`` when the code is missing or unparseable so callers
-    can decide whether to skip or fail for that release.
-    """
-    parsed = parse_version(code)
-    if parsed is None:
-        return None
-    major, minor, patch = parsed
-    return (
-        major * _SEGMENT_BITS * _SEGMENT_BITS + minor * _SEGMENT_BITS + patch
-    )
+    return release_date.toordinal()
 
 
 def load_release_sort_orders(
     session: "Session",
 ) -> Dict[int, Optional[int]]:
-    """Return ``{release_id: sort_order}`` parsed from ``Release.code``.
+    """Return ``{release_id: sort_order}`` derived from ``Release.date``.
 
-    Rows whose code is unparseable map to ``None`` so callers can fail
-    loudly when one of them is named as a bound.
+    Rows with no date map to ``None`` so callers can skip them; every
+    release is expected to carry a date in practice.
     """
     from dpmcore.orm.infrastructure import Release
 
-    rows = session.query(Release.release_id, Release.code).all()
-    return {rid: compute_sort_order(code) for rid, code in rows}
+    rows = session.query(Release.release_id, Release.date).all()
+    return {rid: compute_sort_order(d) for rid, d in rows}
 
 
 def resolve_sort_order(
     session: "Session", release_id: int, *, role: str = "release"
 ) -> int:
-    """Return the parsed sort order for ``release_id`` or raise.
+    """Return the date-based sort order for ``release_id`` or raise.
 
     Args:
         session: Open SQLAlchemy session.
@@ -101,13 +74,13 @@ def resolve_sort_order(
             customise wording.
 
     Raises:
-        ValueError: If no Release row matches ``release_id`` or its
-            code cannot be parsed as ``MAJOR.MINOR[.PATCH]``.
+        ValueError: If no Release row matches ``release_id`` or that
+            release has no ``date``.
     """
     from dpmcore.orm.infrastructure import Release
 
     row = (
-        session.query(Release.code)
+        session.query(Release.date)
         .filter(Release.release_id == release_id)
         .first()
     )
@@ -119,8 +92,7 @@ def resolve_sort_order(
     sort_order = compute_sort_order(row[0])
     if sort_order is None:
         raise ValueError(
-            f"{role} {release_id} has no sort_order — its "
-            "code could not be parsed as MAJOR.MINOR[.PATCH]."
+            f"{role} {release_id} has no sort_order — the release has no date."
         )
     return sort_order
 
@@ -135,8 +107,9 @@ def release_ids_for_sort_order(
 ) -> List[int]:
     """Filter ``{release_id: sort_order}`` by inequality predicates.
 
-    Releases whose ``sort_order`` is ``None`` (unparseable code) are
-    always excluded — they cannot satisfy a comparison either way.
+    Releases whose ``sort_order`` is ``None`` (no date, or an orphan FK
+    absent from the mapping) are always excluded — they cannot satisfy a
+    comparison either way.
 
     Args:
         sort_orders: Mapping from :func:`load_release_sort_orders`.

--- a/src/dpmcore/orm/release_sort_order.py
+++ b/src/dpmcore/orm/release_sort_order.py
@@ -57,13 +57,14 @@ def compute_sort_order(release_date: Optional[date]) -> int:
 
 def load_release_sort_orders(
     session: "Session",
-) -> Dict[int, Optional[int]]:
+) -> Dict[int, int]:
     """Return ``{release_id: sort_order}`` derived from ``Release.date``.
 
     Every release maps to an ``int``: dated releases to their date's
     ordinal, and an undated (unpublished) release to the "latest"
-    sentinel. Only a ``.get()`` miss on a release_id absent from the
-    mapping (an orphan FK) yields ``None`` for a caller.
+    sentinel. The mapping never holds ``None`` values; only a ``.get()``
+    miss on a release_id absent from the mapping (an orphan FK) yields
+    ``None`` for a caller.
     """
     from dpmcore.orm.infrastructure import Release
 
@@ -107,7 +108,7 @@ def resolve_sort_order(
 
 
 def release_ids_for_sort_order(
-    sort_orders: Dict[int, Optional[int]],
+    sort_orders: Dict[int, int],
     *,
     le: Optional[int] = None,
     lt: Optional[int] = None,
@@ -116,10 +117,9 @@ def release_ids_for_sort_order(
 ) -> List[int]:
     """Filter ``{release_id: sort_order}`` by inequality predicates.
 
-    Releases whose ``sort_order`` is ``None`` (an orphan FK absent from
-    the mapping) are always excluded — they cannot satisfy a comparison
-    either way. Undated releases are *not* ``None``: they carry the
-    "latest" sentinel and rank above every dated release.
+    Every mapped release carries an ``int`` sort order, so all releases
+    are candidates. Undated releases carry the "latest" sentinel and rank
+    above every dated release.
 
     Args:
         sort_orders: Mapping from :func:`load_release_sort_orders`.
@@ -135,8 +135,6 @@ def release_ids_for_sort_order(
     """
     matches: List[tuple[int, int]] = []
     for rid, so in sort_orders.items():
-        if so is None:
-            continue
         if le is not None and not so <= le:
             continue
         if lt is not None and not so < lt:

--- a/src/dpmcore/orm/release_sort_order.py
+++ b/src/dpmcore/orm/release_sort_order.py
@@ -10,6 +10,11 @@ form, EBA's four-segment codes (e.g. ``4.2.1.3``) and non-versioned
 working releases like ``"Playground"`` — uniformly, without parsing the
 code. Release dates are unique, so no tiebreak is needed.
 
+A release with **no publication date** is an unpublished working release,
+which represents the current in-progress state; it therefore sorts *after*
+every dated release — i.e. it is the latest. This is expressed by mapping a
+missing date to a sentinel ordinal greater than any real date's.
+
 The order key is the date's proleptic-Gregorian ordinal, computed in
 Python at query time and held as a plain ``int`` — there is no persisted
 SQL column; only its ordering is ever used.
@@ -23,8 +28,13 @@ from typing import TYPE_CHECKING, Dict, List, Optional
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
+# Sentinel sort order for a release with no publication date: it sorts
+# after every real date (which cannot exceed ``date.max``), so an
+# unpublished working release ranks as the latest.
+_UNDATED_SORT_ORDER = date.max.toordinal() + 1
 
-def compute_sort_order(release_date: Optional[date]) -> Optional[int]:
+
+def compute_sort_order(release_date: Optional[date]) -> int:
     """Return a sortable integer for a release's publication date.
 
     Ordering is purely chronological: an earlier ``Release.date`` sorts
@@ -32,16 +42,16 @@ def compute_sort_order(release_date: Optional[date]) -> Optional[int]:
     total order and needs no tiebreak.
 
     Args:
-        release_date: The release's ``Release.date``. ``None`` returns
-            ``None`` so callers can skip an unorderable row; in practice
-            every release carries a date.
+        release_date: The release's ``Release.date``. ``None`` (an
+            unpublished working release) sorts as the latest release.
 
     Returns:
-        The date's ordinal (days since 0001-01-01), or ``None`` when
-        ``release_date`` is missing.
+        The date's ordinal (days since 0001-01-01), or the "latest"
+        sentinel (:data:`_UNDATED_SORT_ORDER`) when ``release_date`` is
+        missing.
     """
     if release_date is None:
-        return None
+        return _UNDATED_SORT_ORDER
     return release_date.toordinal()
 
 
@@ -50,8 +60,10 @@ def load_release_sort_orders(
 ) -> Dict[int, Optional[int]]:
     """Return ``{release_id: sort_order}`` derived from ``Release.date``.
 
-    Rows with no date map to ``None`` so callers can skip them; every
-    release is expected to carry a date in practice.
+    Every release maps to an ``int``: dated releases to their date's
+    ordinal, and an undated (unpublished) release to the "latest"
+    sentinel. Only a ``.get()`` miss on a release_id absent from the
+    mapping (an orphan FK) yields ``None`` for a caller.
     """
     from dpmcore.orm.infrastructure import Release
 
@@ -73,9 +85,11 @@ def resolve_sort_order(
             don't have to wrap the call in their own try/except just to
             customise wording.
 
+    An undated (unpublished) release is *not* an error — it resolves to
+    the "latest" sentinel like any other release.
+
     Raises:
-        ValueError: If no Release row matches ``release_id`` or that
-            release has no ``date``.
+        ValueError: If no Release row matches ``release_id``.
     """
     from dpmcore.orm.infrastructure import Release
 
@@ -89,12 +103,7 @@ def resolve_sort_order(
             f"{role} {release_id} has no sort_order — "
             "no Release row matches that ID."
         )
-    sort_order = compute_sort_order(row[0])
-    if sort_order is None:
-        raise ValueError(
-            f"{role} {release_id} has no sort_order — the release has no date."
-        )
-    return sort_order
+    return compute_sort_order(row[0])
 
 
 def release_ids_for_sort_order(
@@ -107,9 +116,10 @@ def release_ids_for_sort_order(
 ) -> List[int]:
     """Filter ``{release_id: sort_order}`` by inequality predicates.
 
-    Releases whose ``sort_order`` is ``None`` (no date, or an orphan FK
-    absent from the mapping) are always excluded — they cannot satisfy a
-    comparison either way.
+    Releases whose ``sort_order`` is ``None`` (an orphan FK absent from
+    the mapping) are always excluded — they cannot satisfy a comparison
+    either way. Undated releases are *not* ``None``: they carry the
+    "latest" sentinel and rank above every dated release.
 
     Args:
         sort_orders: Mapping from :func:`load_release_sort_orders`.

--- a/src/dpmcore/services/ast_generator.py
+++ b/src/dpmcore/services/ast_generator.py
@@ -416,8 +416,8 @@ class ASTGeneratorService:
 
         Looks up ``Release.code == release`` and validates that the
         release sits inside ``mv``'s window. Comparison runs against the
-        semver-parsed sort order of each release ``code`` (the DPM
-        ``ReleaseID`` FK is no longer monotonic — see
+        date-based sort order of each release (the DPM ``ReleaseID`` FK
+        is no longer monotonic — see
         :mod:`dpmcore.orm.release_sort_order`), not the raw id. Raises
         ``ValueError`` if the release is unknown, predates
         ``start_release_id``, or is past ``end_release_id``.
@@ -458,11 +458,10 @@ class ASTGeneratorService:
     def _latest_release_in_window(self, mv: Any) -> Any:
         """Pick the latest ``released`` Release covering *mv*'s window.
 
-        Comparison runs against the semver-parsed sort order of each
-        candidate's ``code`` so a hypothetical backport like ``4.0.1``
-        published after ``4.2.1`` is correctly placed inside the
-        ``4.0`` lineage. Falls back to the latest of any status if no
-        released row matches.
+        Comparison runs against the date-based sort order of each
+        candidate (``Release.date``), not the opaque ``ReleaseID`` FK.
+        Falls back to the latest of any status if no released row
+        matches.
         """
         from dpmcore.orm.infrastructure import Release
         from dpmcore.orm.release_sort_order import (
@@ -491,7 +490,7 @@ class ASTGeneratorService:
         rows = self.session.query(Release).all()
         candidates: List[tuple[int, Any]] = []
         for r in rows:
-            so = compute_sort_order(r.code)
+            so = compute_sort_order(r.date)
             if so is None:
                 continue
             if start_sort is not None and so < start_sort:

--- a/src/dpmcore/services/ast_generator.py
+++ b/src/dpmcore/services/ast_generator.py
@@ -459,7 +459,8 @@ class ASTGeneratorService:
         """Pick the latest ``released`` Release covering *mv*'s window.
 
         Comparison runs against the date-based sort order of each
-        candidate (``Release.date``), not the opaque ``ReleaseID`` FK.
+        candidate (``Release.date``), not the opaque ``ReleaseID`` FK; an
+        undated (unpublished) release ranks as the latest candidate.
         Falls back to the latest of any status if no released row
         matches.
         """
@@ -491,8 +492,6 @@ class ASTGeneratorService:
         candidates: List[tuple[int, Any]] = []
         for r in rows:
             so = compute_sort_order(r.date)
-            if so is None:
-                continue
             if start_sort is not None and so < start_sort:
                 continue
             if end_sort is not None and so >= end_sort:

--- a/src/dpmcore/services/data_dictionary.py
+++ b/src/dpmcore/services/data_dictionary.py
@@ -18,6 +18,7 @@ from dpmcore.orm.packaging import (
     ModuleVersion,
     ModuleVersionComposition,
 )
+from dpmcore.orm.release_sort_order import compute_sort_order
 from dpmcore.orm.rendering import TableVersion
 
 if TYPE_CHECKING:
@@ -40,8 +41,18 @@ class DataDictionaryService:
     # ------------------------------------------------------------------ #
 
     def get_releases(self) -> List[Dict[str, Any]]:
-        """Return all releases ordered by date descending."""
-        rows = self.session.query(Release).order_by(Release.date.desc()).all()
+        """Return all releases, latest first.
+
+        Ordered by the date-based sort order (see
+        :func:`compute_sort_order`), so an undated (unpublished) working
+        release ranks as the latest and comes first; ties break by
+        ``release_id`` for determinism.
+        """
+        rows = self.session.query(Release).all()
+        rows.sort(
+            key=lambda r: (compute_sort_order(r.date), r.release_id),
+            reverse=True,
+        )
         return [r.to_dict() for r in rows]
 
     def get_release_by_id(self, release_id: int) -> Optional[Dict[str, Any]]:
@@ -65,9 +76,18 @@ class DataDictionaryService:
         return row.to_dict() if row else None
 
     def get_latest_release(self) -> Optional[Dict[str, Any]]:
-        """Return the most recent release."""
-        row = self.session.query(Release).order_by(Release.date.desc()).first()
-        return row.to_dict() if row else None
+        """Return the latest release by the date-based sort order.
+
+        An undated (unpublished) working release ranks as the latest;
+        ties break by ``release_id`` for determinism.
+        """
+        rows = self.session.query(Release).all()
+        if not rows:
+            return None
+        row = max(
+            rows, key=lambda r: (compute_sort_order(r.date), r.release_id)
+        )
+        return row.to_dict()
 
     # ------------------------------------------------------------------ #
     # Tables

--- a/src/dpmcore/services/ecb_validations_import.py
+++ b/src/dpmcore/services/ecb_validations_import.py
@@ -217,7 +217,7 @@ class EcbValidationsImportService:
         if start_sort is None:
             raise EcbValidationsImportError(
                 f"Release {start_release_id} has no sort_order — "
-                "it has no date or does not exist."
+                "no Release row matches that ID."
             )
         if end_release_id is None:
             return release_ids_for_sort_order(sort_orders, ge=start_sort)
@@ -225,7 +225,7 @@ class EcbValidationsImportService:
         if end_sort is None:
             raise EcbValidationsImportError(
                 f"Release {end_release_id} has no sort_order — "
-                "it has no date or does not exist."
+                "no Release row matches that ID."
             )
         return release_ids_for_sort_order(
             sort_orders, ge=start_sort, lt=end_sort

--- a/src/dpmcore/services/ecb_validations_import.py
+++ b/src/dpmcore/services/ecb_validations_import.py
@@ -200,11 +200,12 @@ class EcbValidationsImportService:
         start_release_id: int,
         end_release_id: Optional[int],
     ) -> List[int]:
-        """Release IDs in [start, end) ordered by semver sort order.
+        """Release IDs in [start, end) ordered by ``Release.date``.
 
-        Comparison runs against the semver-parsed sort order of each
-        release's ``code`` so backports (e.g. a hypothetical ``4.0.1``
-        post-``4.2.1``) place correctly within their version lineage.
+        Comparison runs against the date-based sort order of each release
+        (``Release.date``), not the opaque ``ReleaseID`` FK, so releases
+        place correctly within their version lineage regardless of the
+        ``code`` format.
         """
         from dpmcore.orm.release_sort_order import (
             load_release_sort_orders,
@@ -215,8 +216,8 @@ class EcbValidationsImportService:
         start_sort = sort_orders.get(start_release_id)
         if start_sort is None:
             raise EcbValidationsImportError(
-                f"Release {start_release_id} has no sort_order — its "
-                "code could not be parsed as MAJOR.MINOR[.PATCH]."
+                f"Release {start_release_id} has no sort_order — "
+                "it has no date or does not exist."
             )
         if end_release_id is None:
             return release_ids_for_sort_order(sort_orders, ge=start_sort)
@@ -224,8 +225,7 @@ class EcbValidationsImportService:
         if end_sort is None:
             raise EcbValidationsImportError(
                 f"Release {end_release_id} has no sort_order — "
-                "its code could not be parsed as "
-                "MAJOR.MINOR[.PATCH]."
+                "it has no date or does not exist."
             )
         return release_ids_for_sort_order(
             sort_orders, ge=start_sort, lt=end_sort

--- a/src/dpmcore/services/hierarchy.py
+++ b/src/dpmcore/services/hierarchy.py
@@ -46,8 +46,9 @@ def _most_recent_by_release(
 ) -> Optional[Any]:
     """Pick the row whose start-release sorts last by date order.
 
-    Rows whose release has no parseable sort order lose to any
-    parseable row, mirroring ``NULLS LAST`` ordering.
+    Rows whose start-release is absent from the release set (an orphan
+    FK) lose to any ranked row, mirroring ``NULLS LAST`` ordering. An
+    undated (unpublished) release is ranked as the latest, so it wins.
     """
     if not rows:
         return None

--- a/src/dpmcore/services/hierarchy.py
+++ b/src/dpmcore/services/hierarchy.py
@@ -44,7 +44,7 @@ def _most_recent_by_release(
     rows: List[Any],
     release_key: Any,
 ) -> Optional[Any]:
-    """Pick the row whose start-release sorts last by semver order.
+    """Pick the row whose start-release sorts last by date order.
 
     Rows whose release has no parseable sort order lose to any
     parseable row, mirroring ``NULLS LAST`` ordering.
@@ -645,7 +645,7 @@ class HierarchyService:
         Joins through ModuleVersionComposition + ModuleVersion so that
         the date filter (which is tracked on ModuleVersion) applies
         consistently. Falls back to the most recent module-version
-        match (by semver-parsed sort order of ``start_release_id``)
+        match (by date-based sort order of ``start_release_id``)
         when several rows survive the filter.
         """
         q = (

--- a/src/dpmcore/services/semantic.py
+++ b/src/dpmcore/services/semantic.py
@@ -205,7 +205,7 @@ class SemanticService:
             expression: The DPM-XL expression to validate.
             release_id: Optional release ID filter. When neither this nor
                 ``release_code`` is given, defaults to the latest release.
-            release_code: Optional release semver code (mutually exclusive
+            release_code: Optional release code (mutually exclusive
                 with ``release_id``).
         """
         try:

--- a/src/dpmcore/services/structure.py
+++ b/src/dpmcore/services/structure.py
@@ -14,7 +14,7 @@ from typing import (
     cast,
 )
 
-from sqlalchemy import func, or_
+from sqlalchemy import case, func, or_
 from sqlalchemy.orm import joinedload
 
 from dpmcore.orm.glossary import (
@@ -288,8 +288,14 @@ class StructureService:
         # Count before pagination/limiting
         total = q.count()
 
-        # Latest → order by date desc, take first
-        q = q.order_by(Release.date.desc())
+        # Latest first: an undated (unpublished) working release ranks as
+        # the latest, then dated releases descending. The explicit
+        # NULL-first CASE keeps this uniform across backends (SQLite and
+        # SQL Server otherwise sort NULLs last in DESC).
+        q = q.order_by(
+            case((Release.date.is_(None), 1), else_=0).desc(),
+            Release.date.desc(),
+        )
 
         if latest or latest_stable:
             q = q.limit(1)

--- a/src/dpmcore/services/structure.py
+++ b/src/dpmcore/services/structure.py
@@ -171,26 +171,25 @@ class StructureService:
     # ------------------------------------------------------------------ #
 
     def _get_all_releases(self) -> List[Release]:
-        """Return all releases ordered by semver-parsed sort order.
+        """Return all releases ordered by ``Release.date``.
 
-        Releases are ordered ascending by ``compute_sort_order(code)``
+        Releases are ordered ascending by ``compute_sort_order(date)``
         (NOT the opaque ``release_id`` FK, which is non-monotonic from
-        DPM 4.2.1 onwards — e.g. ``4.2.1`` is ``ReleaseID 1010000003`` —
-        nor by ``date``). This keeps the version walks in
-        ``_compute_*_versions`` / ``_version_at_release`` monotonic and
-        places a chronological backport (e.g. ``4.0.1`` published after
-        ``4.2.1``) inside its own lineage.
+        DPM 4.2.1 onwards — e.g. ``4.2.1`` is ``ReleaseID 1010000003``).
+        Dates are unique and follow the version lineage, so this keeps
+        the version walks in ``_compute_*_versions`` /
+        ``_version_at_release`` monotonic for every ``code`` format
+        without parsing the code.
 
-        Releases whose ``code`` is unparseable (``sort_order`` is
-        ``None`` — e.g. a ``3.5-draft`` pre-release) cannot be placed in
-        semver space, so they sort *first* and are skipped by the
-        version walks. ``sort_order`` is computed from the same query
-        that loads the releases, so this adds no extra round-trip.
+        Releases with no ``date`` (``sort_order`` is ``None``) cannot be
+        ordered, so they sort *first* and are skipped by the version
+        walks. ``sort_order`` is computed from the same query that loads
+        the releases, so this adds no extra round-trip.
         """
         if self._releases_cache is None:
             releases = self.session.query(Release).all()
             self._sort_orders_cache = {
-                r.release_id: compute_sort_order(r.code) for r in releases
+                r.release_id: compute_sort_order(r.date) for r in releases
             }
             sort_orders = self._sort_orders_cache
             releases.sort(
@@ -203,12 +202,12 @@ class StructureService:
         return self._releases_cache
 
     def _release_sort_orders(self) -> Dict[int, Optional[int]]:
-        """Cached ``{release_id: sort_order}`` map (semver-parsed)."""
+        """Cached ``{release_id: sort_order}`` map (date-based)."""
         self._get_all_releases()  # populates _sort_orders_cache
         return self._sort_orders_cache or {}
 
     def _sort_order(self, release_id: int) -> Optional[int]:
-        """Semver sort order of a release_id, or ``None`` if unrankable."""
+        """Date-based sort order of a release_id, or ``None`` if unrankable."""
         return self._release_sort_orders().get(release_id)
 
     def _window_alive(
@@ -219,12 +218,12 @@ class StructureService:
     ) -> bool:
         """Whether a ``[start, end]`` release window covers the target.
 
-        Comparisons use the semver-parsed sort order rather than the
+        Comparisons use the date-based sort order rather than the
         opaque ``release_id`` FK. The end bound is **inclusive** — the
         convention the category/context virtual-versioning walks have
         always used (this intentionally differs from
         ``filter_by_release``'s exclusive end). Returns ``False`` for
-        any release whose code is unrankable.
+        any release with no date (unrankable).
         """
         target_so = self._sort_order(target_release_id)
         start_so = self._sort_order(start_release_id)
@@ -500,7 +499,7 @@ class StructureService:
     ) -> Optional[Dict[str, Any]]:
         """Find the version active at *target_release*.
 
-        Returns the last version whose semver sort order does not
+        Returns the last version whose date-based sort order does not
         exceed the target's. ``versions`` is produced in ascending
         sort order, so the walk stops at the first version that
         overshoots.

--- a/src/dpmcore/services/structure.py
+++ b/src/dpmcore/services/structure.py
@@ -181,10 +181,10 @@ class StructureService:
         ``_version_at_release`` monotonic for every ``code`` format
         without parsing the code.
 
-        Releases with no ``date`` (``sort_order`` is ``None``) cannot be
-        ordered, so they sort *first* and are skipped by the version
-        walks. ``sort_order`` is computed from the same query that loads
-        the releases, so this adds no extra round-trip.
+        A release with no ``date`` is an unpublished working release; it
+        sorts *last* (as the latest) and participates in the version
+        walks like any other. ``sort_order`` is computed from the same
+        query that loads the releases, so this adds no extra round-trip.
         """
         if self._releases_cache is None:
             releases = self.session.query(Release).all()
@@ -222,8 +222,9 @@ class StructureService:
         opaque ``release_id`` FK. The end bound is **inclusive** — the
         convention the category/context virtual-versioning walks have
         always used (this intentionally differs from
-        ``filter_by_release``'s exclusive end). Returns ``False`` for
-        any release with no date (unrankable).
+        ``filter_by_release``'s exclusive end). Returns ``False`` only
+        for a release_id absent from the release set (orphan FK); an
+        undated release ranks as the latest.
         """
         target_so = self._sort_order(target_release_id)
         start_so = self._sort_order(start_release_id)

--- a/tests/integration/api/test_explorer.py
+++ b/tests/integration/api/test_explorer.py
@@ -21,11 +21,11 @@ from dpmcore.services.explorer import ExplorerService
 
 
 def _seed_two_releases(session) -> None:
-    """Create release_id 1 and 2 with parseable semver codes.
+    """Create release_id 1 and 2 with dates.
 
     The release-range filter resolves the target release's
-    ``sort_order`` (parsed from ``code``), so any ``release_id`` used
-    in a filter must correspond to a real ``Release`` row.
+    ``sort_order`` from ``Release.date``, so any ``release_id`` used
+    in a filter must correspond to a real, dated ``Release`` row.
     """
     session.add(Release(release_id=1, code="1.0", date=date(2024, 1, 1)))
     session.add(Release(release_id=2, code="2.0", date=date(2025, 1, 1)))

--- a/tests/integration/queries/test_get_table_details.py
+++ b/tests/integration/queries/test_get_table_details.py
@@ -114,9 +114,9 @@ def test_get_table_details_filtering_by_release_id(memory_session):
     """
     session = memory_session
 
-    # Release-range filter resolves the target's sort_order (parsed
-    # from semver code), so each release_id must correspond to a real
-    # Release row with a parseable code.
+    # Release-range filter resolves the target's sort_order from
+    # Release.date, so each release_id must correspond to a real, dated
+    # Release row.
     session.add(Release(release_id=1, code="1.0", date=date(2024, 1, 1)))
     session.add(Release(release_id=2, code="2.0", date=date(2025, 1, 1)))
 

--- a/tests/integration/queries/test_precondition_filing_indicator.py
+++ b/tests/integration/queries/test_precondition_filing_indicator.py
@@ -32,8 +32,8 @@ def _seed(session):
     """
     session.add_all(
         [
-            # Release-axis filtering resolves sort order from Release.code,
-            # so the target release must exist as a real row.
+            # Release-axis filtering resolves sort order from Release.date,
+            # so the target release must exist as a real, dated row.
             Release(release_id=1, code="3.4", date=datetime.date(2022, 12, 1)),
             Variable(variable_id=1, type="filingindicator"),
             Variable(variable_id=2, type="Filing Indicator"),

--- a/tests/integration/queries/test_query_refactor.py
+++ b/tests/integration/queries/test_query_refactor.py
@@ -21,9 +21,9 @@ from dpmcore.services.data_dictionary import DataDictionaryService
 def service_with_data(memory_session):
     """Insert three TableVersions spanning three releases."""
     session = memory_session
-    # Release-range filter resolves the target's sort_order (parsed
-    # from semver code), so each release_id used in a filter must
-    # correspond to a real Release row with a parseable code.
+    # Release-range filter resolves the target's sort_order from
+    # Release.date, so each release_id used in a filter must correspond
+    # to a real, dated Release row.
     session.add_all(
         [
             Release(release_id=1, code="1.0", date=date(2024, 1, 1)),

--- a/tests/integration/releases/test_data_dictionary_releases.py
+++ b/tests/integration/releases/test_data_dictionary_releases.py
@@ -98,3 +98,35 @@ def test_get_release_by_id_returns_correct_release(service_with_data):
 
 def test_get_release_by_id_returns_none_if_not_found(service_with_data):
     assert service_with_data.get_release_by_id(999) is None
+
+
+def test_get_latest_release_returns_most_recent(service_with_data):
+    latest = service_with_data.get_latest_release()
+    assert latest is not None
+    assert latest["code"] == "R3"
+
+
+def test_get_latest_release_empty_db(memory_session):
+    assert DataDictionaryService(memory_session).get_latest_release() is None
+
+
+def test_undated_release_is_latest(memory_session):
+    """An undated working release ranks as the latest, ahead of dated ones."""
+    session = memory_session
+    session.add_all(
+        [
+            Release(release_id=1, code="4.2", date=date(2025, 10, 31)),
+            Release(release_id=2, code="4.2.1", date=date(2026, 2, 15)),
+            Release(release_id=9999, code="Playground", date=None),
+        ]
+    )
+    session.commit()
+    service = DataDictionaryService(session)
+
+    assert service.get_latest_release()["code"] == "Playground"
+    # Latest first: undated Playground, then 4.2.1, then 4.2.
+    assert [r["code"] for r in service.get_releases()] == [
+        "Playground",
+        "4.2.1",
+        "4.2",
+    ]

--- a/tests/integration/releases/test_get_tables_date_filter.py
+++ b/tests/integration/releases/test_get_tables_date_filter.py
@@ -30,8 +30,8 @@ def service_with_dates(memory_session):
     """
     session = memory_session
 
-    # release_id=1 must correspond to a real Release row with a
-    # parseable code so the new sort_order-based filter can resolve it.
+    # release_id=1 must correspond to a real Release row with a date so
+    # the date-based sort_order filter can resolve it.
     session.add(Release(release_id=1, code="1.0", date=date(2023, 1, 1)))
 
     session.add_all([Table(table_id=1), Table(table_id=2), Table(table_id=3)])

--- a/tests/integration/releases/test_release_sort_order.py
+++ b/tests/integration/releases/test_release_sort_order.py
@@ -1,16 +1,16 @@
-"""Tests for semver-based release range comparison.
+"""Tests for date-based release range comparison.
 
 DPM ``ReleaseID`` values are no longer monotonic (4.2.1 has
 ``ReleaseID = 1010000003`` while older releases are still 1..5), so
-range filters must compare against a semver-parsed sort order rather
-than against the raw integer ID.
+range filters must compare against a ``Release.date``-based sort order
+rather than against the raw integer ID.
 
-The headline scenario is a *backport*: a hypothetical ``4.0.1``
-published chronologically after ``4.2.1`` but semantically belonging
-to the ``4.0`` lineage.
-
-Pre-fix this looked broken in two distinct ways depending on which
-ID the backport got, and both are exercised here.
+The headline scenario is a *backport*: a ``4.0.1`` release that carries
+a high ``ReleaseID`` (assigned after ``4.2.1``) but a date that follows
+its ``4.0`` lineage. Ordering by date places it correctly; ordering by
+id would not. Ordering never parses ``Release.code``, so non-versioned
+codes (``"Playground"``) and four-segment codes (``4.2.1.3``) order the
+same way — the regression that motivated issue #185.
 """
 
 from datetime import date
@@ -31,65 +31,57 @@ from dpmcore.orm.packaging import (
 )
 from dpmcore.orm.release_sort_order import (
     compute_sort_order,
-    parse_version,
+    resolve_sort_order,
 )
 from dpmcore.orm.rendering import Table, TableVersion
 from dpmcore.services.data_dictionary import DataDictionaryService
 from dpmcore.services.hierarchy import HierarchyService
 
 # --------------------------------------------------------------------- #
-# parse_version / compute_sort_order
+# compute_sort_order / resolve_sort_order
 # --------------------------------------------------------------------- #
 
 
-def test_parse_version_padding() -> None:
-    assert parse_version("4.2") == (4, 2, 0)
-    assert parse_version("4.2.1") == (4, 2, 1)
-    assert parse_version("3") == (3, 0, 0)
+def test_compute_sort_order_from_date() -> None:
+    assert compute_sort_order(None) is None
+    assert compute_sort_order(date(2025, 3, 4)) == date(2025, 3, 4).toordinal()
+    # Earlier date sorts before a later one.
+    assert compute_sort_order(date(2024, 1, 1)) < compute_sort_order(
+        date(2024, 6, 1)
+    )
 
 
-def test_parse_version_unparseable_returns_none() -> None:
-    assert parse_version(None) is None
-    assert parse_version("") is None
-    assert parse_version("draft") is None
-    assert parse_version("4.2-rc1") is None
-
-
-def test_compute_sort_order_requires_bigint() -> None:
-    # Values like 4.2.1 produce sort_order=4_000_002_000_001, which exceeds
-    # PostgreSQL/SQL Server INTEGER (max 2_147_483_647). The ORM column must
-    # use BigInteger; this test fails if _SEGMENT_BITS is ever shrunk enough
-    # to sneak under the 32-bit cap.
-    _INT32_MAX = 2_147_483_647
-    assert compute_sort_order("4.2.1") > _INT32_MAX
-
-
-def test_compute_sort_order_is_monotone() -> None:
-    """If parse_version(a) < parse_version(b) then sort_order(a) < sort_order(b)."""
-    samples = [
-        "1.0",
-        "3.4",
-        "3.5",
-        "4.0",
-        "4.0.1",  # backport
-        "4.1",
-        "4.2",
-        "4.2.1",
-        "4.2.10",  # multi-digit segment — lexical comparison would break
+def test_compute_sort_order_is_monotone_in_date() -> None:
+    """Chronological dates map to strictly increasing sort orders."""
+    dates = [
+        date(2024, 2, 6),
+        date(2024, 7, 11),
+        date(2024, 12, 19),
+        date(2025, 2, 1),  # a backport, published within the 4.0 lineage
+        date(2025, 4, 28),
+        date(2025, 10, 31),
+        date(2026, 2, 15),
     ]
-    parsed = [parse_version(s) for s in samples]
-    sorts = [compute_sort_order(s) for s in samples]
-    pairs = list(zip(parsed, sorts, strict=True))
-    assert sorted(pairs) == pairs
-    # And specifically: 4.2.10 sorts after 4.2.1 (lexical would say opposite).
-    assert compute_sort_order("4.2.10") > compute_sort_order("4.2.1")
-    # Backport sits between 4.0 and 4.1.
-    assert compute_sort_order("4.0") < compute_sort_order("4.0.1")
-    assert compute_sort_order("4.0.1") < compute_sort_order("4.1")
+    orders = [compute_sort_order(d) for d in dates]
+    assert orders == sorted(orders)
+    # Distinct dates → distinct keys, so no tiebreak is ever needed.
+    assert len(set(orders)) == len(orders)
 
 
-def test_load_release_sort_orders_from_code() -> None:
-    """``load_release_sort_orders`` parses ``Release.code`` per row."""
+def test_resolve_sort_order_raises_for_undated_and_unknown(memory_session):
+    """resolve_sort_order raises on a missing date or an unknown id."""
+    session = memory_session
+    session.add(Release(release_id=1, code="4.2", date=None))
+    session.commit()
+
+    with pytest.raises(ValueError, match="has no date"):
+        resolve_sort_order(session, 1)
+    with pytest.raises(ValueError, match="no Release row matches"):
+        resolve_sort_order(session, 999)
+
+
+def test_load_release_sort_orders_from_date() -> None:
+    """``load_release_sort_orders`` derives order from ``Release.date``."""
     from sqlalchemy import create_engine
     from sqlalchemy.orm import Session
 
@@ -109,24 +101,24 @@ def test_load_release_sort_orders_from_code() -> None:
         )
         session.commit()
         rows = load_release_sort_orders(session)
-    # 4.2 → (4, 2, 0); 4.2.1 → (4, 2, 1) — the latter must compare greater.
+    # 4.2 (Oct 2025) must sort before 4.2.1 (Feb 2026), despite the huge id.
     assert rows[1] is not None
     assert rows[1010000003] is not None
     assert rows[1] < rows[1010000003]
 
 
 # --------------------------------------------------------------------- #
-# Backport scenario — the whole reason for this refactor
+# Backport scenario — high id, in-lineage date
 # --------------------------------------------------------------------- #
 
 
 @pytest.fixture
 def backport_session(memory_session):
-    """A DB where 4.0.1 has a higher ID than 4.2.1.
+    """A DB where 4.0.1 has a higher ID than 4.2.1 but an in-lineage date.
 
     Layout::
 
-        ReleaseID  Code    Date         (chronology)
+        ReleaseID  Code    Date         (id vs lineage)
         --------   -----   ----------   ------------
         1          3.4     2024-02-06
         2          3.5     2024-07-11
@@ -134,12 +126,12 @@ def backport_session(memory_session):
         4          4.1     2025-04-28
         5          4.2     2025-10-31
         1010000003 4.2.1   2026-02-15
-        1010000004 4.0.1   2026-06-30   <- backport, post-4.2.1 by date
+        1010000004 4.0.1   2025-02-01   <- highest id, date within 4.0 lineage
 
     A module version valid from ``4.0`` to ``4.2`` (start_release_id=3,
     end_release_id=5) should be considered valid at ``4.0.1`` because
-    4.0.1 ∈ [4.0, 4.2). ID-based comparison says no (1010000004 > 5);
-    code-based comparison says yes.
+    4.0.1's date (2025-02-01) falls in [4.0, 4.2). ID-based comparison
+    says no (1010000004 > 5); date-based comparison says yes.
     """
     session = memory_session
     session.add_all(
@@ -157,7 +149,7 @@ def backport_session(memory_session):
             Release(
                 release_id=1010000004,
                 code="4.0.1",
-                date=date(2026, 6, 30),
+                date=date(2025, 2, 1),
             ),
             Framework(framework_id=1, code="FW"),
             Module(module_id=1, framework_id=1),
@@ -232,7 +224,7 @@ def test_backport_release_excludes_pre_4_0(backport_session):
 
 
 def test_get_tables_at_backport_release(backport_session):
-    """DataDictionary.get_tables filters TableVersions by code-version."""
+    """DataDictionary.get_tables filters TableVersions by date-version."""
     svc = DataDictionaryService(backport_session)
     tables = svc.get_tables(release_code="4.0.1")
     assert "T1" in tables, (
@@ -240,30 +232,120 @@ def test_get_tables_at_backport_release(backport_session):
     )
 
 
-def test_unparseable_release_code_excluded(memory_session):
-    """A Release whose code can't be parsed has no sort_order.
+def test_nonsemver_release_code_orders_by_date(memory_session):
+    """A non-versioned working release (``"Playground"``) orders by date.
 
-    Filtering against such a release_id raises a clear error rather
-    than silently mis-counting rows.
+    Regression for issue #185: exporting/scoping at a release whose code
+    is not ``MAJOR.MINOR[.PATCH]`` used to crash. With date ordering the
+    code is never parsed — a "Playground" release published last simply
+    resolves to the current rows, with no special-casing and no crash.
     """
     from dpmcore.dpm_xl.utils.filters import filter_by_release
 
     session = memory_session
-    session.add(Release(release_id=1, code="draft", date=date(2024, 1, 1)))
+    session.add_all(
+        [
+            Release(release_id=1, code="4.2", date=date(2025, 10, 31)),
+            Release(release_id=9999, code="Playground", date=date(2026, 9, 1)),
+            # Live from 4.2, never ended -> active at Playground.
+            TableVersion(
+                table_vid=1,
+                table_id=1,
+                start_release_id=1,
+                end_release_id=None,
+            ),
+            # Ended at 4.2 -> superseded before Playground.
+            TableVersion(
+                table_vid=2, table_id=2, start_release_id=1, end_release_id=1
+            ),
+        ]
+    )
     session.commit()
 
     q = session.query(TableVersion)
-    with pytest.raises(ValueError, match="could not be parsed"):
+    filtered = filter_by_release(
+        q,
+        start_col=TableVersion.start_release_id,
+        end_col=TableVersion.end_release_id,
+        release_id=9999,
+    )
+    vids = {tv.table_vid for tv in filtered.all()}
+    assert vids == {1}, "Playground (latest date) yields the current rows"
+
+
+def test_four_segment_release_orders_by_date(memory_session):
+    """A four-segment EBA code (``4.2.1.3``) range-filters its lineage.
+
+    Regression for the CODIS export at release ``4.2.1.3``: the code has
+    too many segments to parse as semver, but date ordering never parses
+    it, so it behaves as a real release sitting just after ``4.2.1``.
+    """
+    from dpmcore.dpm_xl.utils.filters import filter_by_release
+
+    session = memory_session
+    session.add_all(
+        [
+            Release(release_id=1, code="4.2", date=date(2025, 10, 31)),
+            Release(release_id=2, code="4.2.1", date=date(2026, 2, 15)),
+            Release(release_id=3, code="4.2.1.3", date=date(2026, 6, 11)),
+            Release(release_id=4, code="4.3", date=date(2026, 10, 1)),
+            # Live from 4.2, never ended -> active at 4.2.1.3.
+            TableVersion(
+                table_vid=1,
+                table_id=1,
+                start_release_id=1,
+                end_release_id=None,
+            ),
+            # Window [4.2, 4.3) -> covers 4.2.1.3.
+            TableVersion(
+                table_vid=2, table_id=2, start_release_id=1, end_release_id=4
+            ),
+            # Window [4.2, 4.2.1) -> ended before 4.2.1.3.
+            TableVersion(
+                table_vid=3, table_id=3, start_release_id=1, end_release_id=2
+            ),
+            # Starts at 4.3 -> after the target.
+            TableVersion(
+                table_vid=4,
+                table_id=4,
+                start_release_id=4,
+                end_release_id=None,
+            ),
+        ]
+    )
+    session.commit()
+
+    q = session.query(TableVersion)
+    filtered = filter_by_release(
+        q,
+        start_col=TableVersion.start_release_id,
+        end_col=TableVersion.end_release_id,
+        release_id=3,
+    )
+    vids = {tv.table_vid for tv in filtered.all()}
+    assert vids == {1, 2}, (
+        "4.2.1.3 range-filters its lineage: includes rows live across it, "
+        "excludes rows that ended before it or start after it"
+    )
+
+
+def test_unknown_release_id_still_raises(memory_session):
+    """An unknown release_id (no Release row) still raises loudly."""
+    from dpmcore.dpm_xl.utils.filters import filter_by_release
+
+    session = memory_session
+    q = session.query(TableVersion)
+    with pytest.raises(ValueError, match="no Release row matches"):
         filter_by_release(
             q,
             start_col=TableVersion.start_release_id,
             end_col=TableVersion.end_release_id,
-            release_id=1,
+            release_id=424242,
         )
 
 
 # --------------------------------------------------------------------- #
-# filter_item_version (IN-list expanded from semver-parsed sort order)
+# filter_item_version (IN-list expanded from date-based sort order)
 # --------------------------------------------------------------------- #
 
 
@@ -272,9 +354,9 @@ def test_filter_item_version_handles_backport(backport_session):
 
     The query joins TableVersion to ItemCategory using
     ``filter_item_version`` — the JOIN condition expands into
-    ``release_id IN (...)`` lists built from the semver-parsed sort
-    order of each release's ``code``. An ItemCategory valid 4.0..4.2
-    (FK start=3 end=5) must match a TableVersion at the 4.0.1 backport.
+    ``release_id IN (...)`` lists built from the date-based sort order of
+    each release's ``date``. An ItemCategory valid 4.0..4.2 (FK start=3
+    end=5) must match a TableVersion at the 4.0.1 backport.
     """
     session = backport_session
     session.add(Category(category_id=1, code="C1"))

--- a/tests/integration/releases/test_release_sort_order.py
+++ b/tests/integration/releases/test_release_sort_order.py
@@ -43,12 +43,13 @@ from dpmcore.services.hierarchy import HierarchyService
 
 
 def test_compute_sort_order_from_date() -> None:
-    assert compute_sort_order(None) is None
     assert compute_sort_order(date(2025, 3, 4)) == date(2025, 3, 4).toordinal()
     # Earlier date sorts before a later one.
     assert compute_sort_order(date(2024, 1, 1)) < compute_sort_order(
         date(2024, 6, 1)
     )
+    # An undated (unpublished) release sorts after every real date.
+    assert compute_sort_order(None) > compute_sort_order(date(9999, 12, 31))
 
 
 def test_compute_sort_order_is_monotone_in_date() -> None:
@@ -68,14 +69,19 @@ def test_compute_sort_order_is_monotone_in_date() -> None:
     assert len(set(orders)) == len(orders)
 
 
-def test_resolve_sort_order_raises_for_undated_and_unknown(memory_session):
-    """resolve_sort_order raises on a missing date or an unknown id."""
+def test_resolve_sort_order_undated_is_latest_unknown_raises(memory_session):
+    """resolve_sort_order ranks an undated release as the latest.
+
+    An undated (unpublished) release resolves to the "latest" sentinel,
+    sorting after every dated release; only a genuinely unknown id (no
+    Release row) raises.
+    """
     session = memory_session
-    session.add(Release(release_id=1, code="4.2", date=None))
+    session.add(Release(release_id=1, code="4.2", date=date(2025, 10, 31)))
+    session.add(Release(release_id=2, code="Playground", date=None))
     session.commit()
 
-    with pytest.raises(ValueError, match="has no date"):
-        resolve_sort_order(session, 1)
+    assert resolve_sort_order(session, 2) > resolve_sort_order(session, 1)
     with pytest.raises(ValueError, match="no Release row matches"):
         resolve_sort_order(session, 999)
 
@@ -459,12 +465,66 @@ def test_get_last_release_orders_by_date_not_id(memory_session):
     assert ModuleVersionQuery.get_last_release(session) == 1010000003
 
 
-def test_get_last_release_none_when_no_dated_release(memory_session):
-    """``get_last_release`` returns ``None`` when no release has a date."""
+def test_get_last_release_undated_release_is_latest(memory_session):
+    """An undated (unpublished) release is the latest, beating dated ones."""
     from dpmcore.dpm_xl.model_queries import ModuleVersionQuery
 
     session = memory_session
-    session.add(Release(release_id=1, code="4.2", date=None))
+    session.add_all(
+        [
+            Release(release_id=1, code="4.2", date=date(2025, 10, 31)),
+            Release(release_id=2, code="4.2.1", date=date(2026, 2, 15)),
+            Release(release_id=9999, code="Playground", date=None),
+        ]
+    )
     session.commit()
 
-    assert ModuleVersionQuery.get_last_release(session) is None
+    assert ModuleVersionQuery.get_last_release(session) == 9999
+
+
+def test_get_last_release_none_when_no_releases(memory_session):
+    """``get_last_release`` returns ``None`` when there are no releases."""
+    from dpmcore.dpm_xl.model_queries import ModuleVersionQuery
+
+    assert ModuleVersionQuery.get_last_release(memory_session) is None
+
+
+def test_undated_release_resolves_to_current_rows(memory_session):
+    """An undated working release range-filters to the current rows.
+
+    The real issue #185 scenario: an unpublished "Playground" release
+    with no date. It ranks as the latest, so ``filter_by_release`` at it
+    keeps rows live from the last dated release and drops those already
+    superseded — with no code parsing and no crash.
+    """
+    from dpmcore.dpm_xl.utils.filters import filter_by_release
+
+    session = memory_session
+    session.add_all(
+        [
+            Release(release_id=1, code="4.2", date=date(2025, 10, 31)),
+            Release(release_id=9999, code="Playground", date=None),
+            # Live from 4.2, never ended -> active at Playground.
+            TableVersion(
+                table_vid=1,
+                table_id=1,
+                start_release_id=1,
+                end_release_id=None,
+            ),
+            # Ended at 4.2 -> superseded before Playground.
+            TableVersion(
+                table_vid=2, table_id=2, start_release_id=1, end_release_id=1
+            ),
+        ]
+    )
+    session.commit()
+
+    q = session.query(TableVersion)
+    filtered = filter_by_release(
+        q,
+        start_col=TableVersion.start_release_id,
+        end_col=TableVersion.end_release_id,
+        release_id=9999,
+    )
+    vids = {tv.table_vid for tv in filtered.all()}
+    assert vids == {1}, "undated Playground (latest) yields the current rows"

--- a/tests/integration/releases/test_release_sort_order.py
+++ b/tests/integration/releases/test_release_sort_order.py
@@ -421,3 +421,50 @@ def test_filter_item_version_handles_backport(backport_session):
         "ItemCategory valid 4.0..4.2 must match a TableVersion at the "
         "4.0.1 backport via filter_item_version's IN-list filter."
     )
+
+
+# --------------------------------------------------------------------- #
+# get_last_release — latest by date, not by opaque id
+# --------------------------------------------------------------------- #
+
+
+def test_get_last_release_orders_by_date_not_id(memory_session):
+    """``get_last_release`` returns the latest release by date, not max id.
+
+    Regression for the non-monotonic ``ReleaseID`` scheme: the backport
+    ``4.0.1`` carries the highest id (``1010000004``) but an in-lineage
+    date, so ``max(release_id)`` would wrongly pick it as "latest". The
+    true latest by date is ``4.2.1``.
+    """
+    from dpmcore.dpm_xl.model_queries import ModuleVersionQuery
+
+    session = memory_session
+    session.add_all(
+        [
+            Release(release_id=5, code="4.2", date=date(2025, 10, 31)),
+            Release(
+                release_id=1010000003,
+                code="4.2.1",
+                date=date(2026, 2, 15),
+            ),
+            Release(
+                release_id=1010000004,
+                code="4.0.1",
+                date=date(2025, 2, 1),
+            ),
+        ]
+    )
+    session.commit()
+
+    assert ModuleVersionQuery.get_last_release(session) == 1010000003
+
+
+def test_get_last_release_none_when_no_dated_release(memory_session):
+    """``get_last_release`` returns ``None`` when no release has a date."""
+    from dpmcore.dpm_xl.model_queries import ModuleVersionQuery
+
+    session = memory_session
+    session.add(Release(release_id=1, code="4.2", date=None))
+    session.commit()
+
+    assert ModuleVersionQuery.get_last_release(session) is None

--- a/tests/integration/services/layout_exporter/_helpers.py
+++ b/tests/integration/services/layout_exporter/_helpers.py
@@ -7,6 +7,8 @@ individual tests can pick exactly the shape they need.
 
 from __future__ import annotations
 
+from datetime import date
+
 from sqlalchemy.orm import Session
 
 from dpmcore.orm.glossary import (
@@ -43,8 +45,8 @@ from dpmcore.orm.variables import Variable, VariableVersion
 
 
 def seed_releases(session: Session) -> None:
-    session.add(Release(release_id=1, code="1.0"))
-    session.add(Release(release_id=2, code="2.0"))
+    session.add(Release(release_id=1, code="1.0", date=date(2020, 1, 1)))
+    session.add(Release(release_id=2, code="2.0", date=date(2021, 1, 1)))
 
 
 def seed_data_types(session: Session) -> None:

--- a/tests/integration/services/test_scope_release_axis.py
+++ b/tests/integration/services/test_scope_release_axis.py
@@ -6,7 +6,7 @@ Rules pinned here, verified against EBA's own pre-calculated
 
 1. **Release axis only.** A module version is in scope for release R purely
    on the release-validity axis (``StartReleaseID``..``EndReleaseID``, compared
-   on the semver sort order). The old reference-date ``_apply_fallback_for_equal_dates``
+   on the date sort order). The old reference-date ``_apply_fallback_for_equal_dates``
    could substitute a version absent from R -- e.g. ``FINREP9DP 1.1.0`` (a 4.2.1
    version) leaking into release 4.2 -- producing an invalid scope and the
    downstream ``Release X predates module version ...`` error a consumer hit.
@@ -55,27 +55,27 @@ _INVARIANT_SAMPLE = 15
 
 
 def _ordered_releases(session):
-    """All releases, sorted by semver sort order (not the opaque ID)."""
+    """All releases, sorted by date sort order (not the opaque ID)."""
     return sorted(
         session.query(Release).all(),
-        key=lambda r: compute_sort_order(r.code) or 0,
+        key=lambda r: compute_sort_order(r.date) or 0,
     )
 
 
 def _release_sort_by_id(session):
     """``{release_id: sort_order}`` for window/release-axis comparisons.
 
-    Asserts every ``Release.code`` parses, so ``target_sort`` is always an
-    ``int`` downstream: an unparseable code would otherwise make the oracle
+    Asserts every release has a date, so ``target_sort`` is always an
+    ``int`` downstream: a missing date would otherwise make the oracle
     crash with a ``TypeError`` (``int <= None``) instead of failing clearly.
     """
     sort_by_id = {
-        r.release_id: compute_sort_order(r.code)
+        r.release_id: compute_sort_order(r.date)
         for r in session.query(Release).all()
     }
     assert all(v is not None for v in sort_by_id.values()), (
-        "fixture has an unparseable Release.code; the oracle assumes every "
-        "release code parses as MAJOR.MINOR[.PATCH]"
+        "fixture has a Release with no date; the oracle assumes every "
+        "release has a date to order by"
     )
     return sort_by_id
 
@@ -84,9 +84,9 @@ def _valid_in_release(mv, target_sort, sort_by_id):
     """Whether ``mv``'s release window contains ``target_sort``.
 
     Faithful mirror of ``filter_by_release`` (``start <= target`` and
-    ``(end is open or target < end)`` on the semver sort order), including
+    ``(end is open or target < end)`` on the date sort order), including
     its handling of unresolved bounds: a start/end whose release yields no
-    sort order (unparseable code or orphan FK) excludes the row, exactly as
+    sort order (no date or orphan FK) excludes the row, exactly as
     ``release_ids_for_sort_order`` drops ``None`` sort orders from the
     in-lists. Only a NULL ``end_release_id`` is a genuinely open window.
     """
@@ -236,7 +236,7 @@ def test_scope_matches_eba_persisted_scope_per_release(fixture_session):
 
     saw_fallback = False
     for rel in _ordered_releases(session):
-        target_sort = compute_sort_order(rel.code)
+        target_sort = compute_sort_order(rel.date)
         base = {
             vid
             for vid, mv in versions.items()
@@ -290,7 +290,7 @@ def test_scoped_versions_are_backward_only_and_not_single_day(fixture_session):
 
     The two invariants, swept across a sample of real F_01.02 operations:
     every module version in a computed scope must (a) start on or before the
-    target release on the semver sort order (never forward -- the #151
+    target release on the date sort order (never forward -- the #151
     guarantee, which the #182 fallback must not break; the fallback may reach
     backward past the release window, so full ``start <= release < end``
     validity is not required) and (b) have a non-collapsed reference-date
@@ -309,7 +309,7 @@ def test_scoped_versions_are_backward_only_and_not_single_day(fixture_session):
     for code in codes:
         expression = _latest_expression(session, code)
         for rel in releases:
-            target_sort = compute_sort_order(rel.code)
+            target_sort = compute_sort_order(rel.date)
             result = svc.calculate_from_expression(
                 expression=expression, release_code=rel.code
             )
@@ -401,16 +401,16 @@ class TestResolveExplicitRelease:
             svc._resolve_release("FINREP9DP", "1.0.0", "9.9.9")
 
 
-class TestResolveExplicitReleaseSemverOrder:
+class TestResolveExplicitReleaseDateOrder:
     """Window checks against an in-memory schema (no optional fixture DB).
 
     ``TestResolveExplicitRelease`` above skips whenever ``test_data.db`` is
-    absent, so on a bare checkout / CI the semver sort-order branches of
+    absent, so on a bare checkout / CI the date sort-order branches of
     ``_resolve_explicit_release`` would go uncovered. These tests seed a tiny
     schema with a deliberately NON-monotonic ``ReleaseID`` layout -- release
-    4.2 is given a larger id than 4.2.1 -- so each one fails if the window
-    check ever compares the raw ``release_id`` instead of the semver sort
-    order derived from ``Release.code``.
+    4.2 is given a larger id than 4.2.1, while the dates follow the lineage --
+    so each one fails if the window check ever compares the raw ``release_id``
+    instead of the ``Release.date`` sort order.
     """
 
     @pytest.fixture
@@ -453,16 +453,17 @@ class TestResolveExplicitReleaseSemverOrder:
         memory_session.flush()
         return ASTGeneratorService(memory_session)
 
-    def test_before_window_predates_by_semver(self, svc):
+    def test_before_window_predates_by_date(self, svc):
         # MODX starts at 4.2.1 (id 5); request 4.2 (id 1010000003). Raw-id
-        # compare (1010000003 < 5) would NOT predate; semver (4.2 < 4.2.1) does.
+        # compare (1010000003 < 5) would NOT predate; by date (4.2 < 4.2.1)
+        # it does.
         with pytest.raises(ValueError, match="predates module version"):
             svc._resolve_release("MODX", "1.0.0", "4.2")
 
-    def test_past_end_by_semver(self, svc):
+    def test_past_end_by_date(self, svc):
         # MODY ends at 4.2 (id 1010000003); request 4.2.1 (id 5). Raw-id
-        # compare (5 >= 1010000003) would say in-window; semver (4.2.1 >= 4.2)
-        # is past the end.
+        # compare (5 >= 1010000003) would say in-window; by date (4.2.1 >= 4.2)
+        # it is past the end.
         with pytest.raises(ValueError, match="past the end"):
             svc._resolve_release("MODY", "1.0.0", "4.2.1")
 

--- a/tests/unit/migration/test_ecb_validations_import.py
+++ b/tests/unit/migration/test_ecb_validations_import.py
@@ -1,4 +1,5 @@
 import uuid
+from datetime import date
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -268,9 +269,15 @@ class TestEcbValidationsImport:
 
         session = sessionmaker(bind=sqlite_engine_with_schema)()
         try:
-            session.add(Release(release_id=1, code="4.0"))
-            session.add(Release(release_id=2, code="4.1"))
-            session.add(Release(release_id=3, code="4.2"))
+            session.add(
+                Release(release_id=1, code="4.0", date=date(2024, 1, 1))
+            )
+            session.add(
+                Release(release_id=2, code="4.1", date=date(2024, 2, 1))
+            )
+            session.add(
+                Release(release_id=3, code="4.2", date=date(2024, 3, 1))
+            )
             session.flush()
 
             result = EcbValidationsImportService._get_valid_release_ids(
@@ -287,9 +294,15 @@ class TestEcbValidationsImport:
 
         session = sessionmaker(bind=sqlite_engine_with_schema)()
         try:
-            session.add(Release(release_id=1, code="4.0"))
-            session.add(Release(release_id=2, code="4.1"))
-            session.add(Release(release_id=3, code="4.2"))
+            session.add(
+                Release(release_id=1, code="4.0", date=date(2024, 1, 1))
+            )
+            session.add(
+                Release(release_id=2, code="4.1", date=date(2024, 2, 1))
+            )
+            session.add(
+                Release(release_id=3, code="4.2", date=date(2024, 3, 1))
+            )
             session.flush()
 
             result = EcbValidationsImportService._get_valid_release_ids(
@@ -299,15 +312,20 @@ class TestEcbValidationsImport:
         finally:
             session.close()
 
-    def test_get_valid_release_ids_unparseable_start_raises(
+    def test_get_valid_release_ids_undated_start_raises(
         self, sqlite_engine_with_schema
     ):
         from dpmcore.orm.infrastructure import Release
 
         session = sessionmaker(bind=sqlite_engine_with_schema)()
         try:
-            session.add(Release(release_id=1, code="garbage"))
-            session.add(Release(release_id=2, code="4.1"))
+            # Release order is by date; a release with no date cannot be
+            # placed, so a window bound on it raises rather than silently
+            # dropping rows.
+            session.add(Release(release_id=1, code="4.0", date=None))
+            session.add(
+                Release(release_id=2, code="4.1", date=date(2024, 2, 1))
+            )
             session.flush()
 
             with pytest.raises(
@@ -319,15 +337,17 @@ class TestEcbValidationsImport:
         finally:
             session.close()
 
-    def test_get_valid_release_ids_unparseable_end_raises(
+    def test_get_valid_release_ids_undated_end_raises(
         self, sqlite_engine_with_schema
     ):
         from dpmcore.orm.infrastructure import Release
 
         session = sessionmaker(bind=sqlite_engine_with_schema)()
         try:
-            session.add(Release(release_id=1, code="4.0"))
-            session.add(Release(release_id=2, code="garbage"))
+            session.add(
+                Release(release_id=1, code="4.0", date=date(2024, 1, 1))
+            )
+            session.add(Release(release_id=2, code="4.1", date=None))
             session.flush()
 
             with pytest.raises(

--- a/tests/unit/migration/test_ecb_validations_import.py
+++ b/tests/unit/migration/test_ecb_validations_import.py
@@ -312,17 +312,37 @@ class TestEcbValidationsImport:
         finally:
             session.close()
 
-    def test_get_valid_release_ids_undated_start_raises(
+    def test_get_valid_release_ids_undated_start_is_latest(
         self, sqlite_engine_with_schema
     ):
         from dpmcore.orm.infrastructure import Release
 
         session = sessionmaker(bind=sqlite_engine_with_schema)()
         try:
-            # Release order is by date; a release with no date cannot be
-            # placed, so a window bound on it raises rather than silently
-            # dropping rows.
-            session.add(Release(release_id=1, code="4.0", date=None))
+            # An undated (unpublished) release ranks as the latest, so a
+            # range starting at it is valid and contains just itself.
+            session.add(
+                Release(release_id=1, code="4.0", date=date(2024, 1, 1))
+            )
+            session.add(Release(release_id=2, code="Playground", date=None))
+            session.flush()
+
+            result = EcbValidationsImportService._get_valid_release_ids(
+                session, start_release_id=2, end_release_id=None
+            )
+            assert result == [2]
+        finally:
+            session.close()
+
+    def test_get_valid_release_ids_unknown_start_raises(
+        self, sqlite_engine_with_schema
+    ):
+        from dpmcore.orm.infrastructure import Release
+
+        session = sessionmaker(bind=sqlite_engine_with_schema)()
+        try:
+            # A window bound with no matching Release row cannot be placed,
+            # so it raises rather than silently dropping rows.
             session.add(
                 Release(release_id=2, code="4.1", date=date(2024, 2, 1))
             )
@@ -337,7 +357,7 @@ class TestEcbValidationsImport:
         finally:
             session.close()
 
-    def test_get_valid_release_ids_undated_end_raises(
+    def test_get_valid_release_ids_unknown_end_raises(
         self, sqlite_engine_with_schema
     ):
         from dpmcore.orm.infrastructure import Release
@@ -347,7 +367,6 @@ class TestEcbValidationsImport:
             session.add(
                 Release(release_id=1, code="4.0", date=date(2024, 1, 1))
             )
-            session.add(Release(release_id=2, code="4.1", date=None))
             session.flush()
 
             with pytest.raises(

--- a/tests/unit/migration/test_migration_service.py
+++ b/tests/unit/migration/test_migration_service.py
@@ -343,6 +343,28 @@ class TestRenameWithMetadata:
         assert result.database_path is not None
         assert "3.9" in result.database_path.name
 
+    def test_undated_current_release_is_latest(self, tmp_path):
+        db_path = tmp_path / "dpm.db"
+        engine = create_engine(f"sqlite:///{db_path}", future=True)
+        service = MigrationService(engine)
+
+        csv_dir = tmp_path / "csv"
+        csv_dir.mkdir()
+        # Two current releases: a dated 4.2 and an undated working
+        # release. The undated one ranks as the latest, so its code
+        # names the exported file.
+        (csv_dir / "Release.csv").write_text(
+            "ReleaseID,Code,Date,IsCurrent\n"
+            "1,4.2,2026-01-01,1\n"
+            "2,Playground,,1\n",
+            encoding="utf-8",
+        )
+
+        result = service.migrate_from_csv_dir(str(csv_dir))
+
+        assert result.database_path is not None
+        assert "Playground" in result.database_path.name
+
     def test_sanitises_unsafe_characters_in_release_code(self, tmp_path):
         db_path = tmp_path / "dpm.db"
         engine = create_engine(f"sqlite:///{db_path}", future=True)

--- a/tests/unit/server/test_structure_framework.py
+++ b/tests/unit/server/test_structure_framework.py
@@ -174,7 +174,7 @@ def seeded_engine(engine):
                 end_release_id=None,
             ),
             # COREP modules — only at release 4.0 (end_release_id=2 →
-            # excluded from 4.1 by the semver-aware filter).
+            # excluded from 4.1 by the date-based filter).
             ModuleVersion(
                 module_vid=20000,
                 module_id=200,

--- a/tests/unit/server/test_structure_release.py
+++ b/tests/unit/server/test_structure_release.py
@@ -284,3 +284,35 @@ class TestExistingEndpoints:
     def test_health(self, client):
         resp = client.get("/api/v1/health")
         assert resp.status_code == 200
+
+
+class TestQueryReleasesUndatedIsLatest:
+    """query_releases ranks an undated working release as the latest."""
+
+    def test_undated_release_is_latest(self, engine):
+        from dpmcore.services.structure import StructureService
+
+        with Session(engine) as session:
+            session.add_all(
+                [
+                    Release(release_id=1, code="4.2", date=date(2025, 10, 31)),
+                    Release(
+                        release_id=2, code="4.2.1", date=date(2026, 2, 15)
+                    ),
+                    Release(release_id=9999, code="Playground", date=None),
+                ]
+            )
+            session.commit()
+            svc = StructureService(session)
+
+            latest, _ = svc.query_releases(latest=True)
+            assert [r["code"] for r in latest] == ["Playground"]
+
+            all_rows, total = svc.query_releases()
+            assert total == 3
+            # Latest first: undated Playground, then 4.2.1, then 4.2.
+            assert [r["code"] for r in all_rows] == [
+                "Playground",
+                "4.2.1",
+                "4.2",
+            ]

--- a/tests/unit/server/test_structure_versioning_regression.py
+++ b/tests/unit/server/test_structure_versioning_regression.py
@@ -2,12 +2,11 @@
 
 Covers two correctness fixes:
 
-* Release ordering must use the semver-parsed ``sort_order`` of
-  ``Release.code``, NOT the opaque ``release_id`` FK (non-monotonic
-  from DPM 4.2.1) nor ``date``. A chronological backport published
-  with a high id / late date must still sort inside its semver
-  lineage. (``_get_all_releases`` / ``_window_alive`` /
-  ``_version_at_release``.)
+* Release ordering must use the ``Release.date``-based ``sort_order``,
+  NOT the opaque ``release_id`` FK (non-monotonic from DPM 4.2.1). A
+  backport carries a high id but a date that follows its lineage, so
+  ordering by date places it correctly where ordering by id would not.
+  (``_get_all_releases`` / ``_window_alive`` / ``_version_at_release``.)
 * At ``release=*`` a property's enumeration window is keyed per
   ItemCategory *version*, not per ``property_id`` — so two versions of
   the same property each surface the enumeration valid at their own
@@ -51,20 +50,20 @@ def engine():
 # Fixture 1 — non-monotonic release ids (backport scenario)
 # ------------------------------------------------------------------ #
 #
-# Three releases whose release_id AND date order disagree with semver:
+# Three releases whose release_id order disagrees with the lineage,
+# while the dates follow it:
 #   code 4.0 -> release_id 100, date 2024-01
-#   code 4.2 -> release_id 101, date 2024-06
-#   code 4.1 -> release_id 200, date 2024-09   (a backport: highest id
-#                                                and latest date, but
-#                                                semver-wise between).
+#   code 4.1 -> release_id 200, date 2024-06   (a backport: highest id,
+#                                                but a date in lineage).
+#   code 4.2 -> release_id 101, date 2024-09
 #
 # Category MC (created at 4.0) with two items:
 #   A: alive from 4.0 onward.
 #   B: added at 4.1 (release_id 200) onward.
 #
-# Correct (sort_order) walk => versions {A} @4.0, {A,B} @4.1, and the
-# version active at 4.2 is {A,B}. A release_id/date walk would break
-# early and report {A} at 4.2.
+# Correct (date sort_order) walk => versions {A} @4.0, {A,B} @4.1, and
+# the version active at 4.2 is {A,B}. A release_id walk would break
+# early (200 > 101) and report {A} at 4.2.
 # ------------------------------------------------------------------ #
 
 
@@ -90,14 +89,14 @@ def backport_engine(engine):
             Release(
                 release_id=101,
                 code="4.2",
-                date=date(2024, 6, 1),
+                date=date(2024, 9, 1),
                 status="Final",
                 is_current=True,
             ),
             Release(
                 release_id=200,
                 code="4.1",
-                date=date(2024, 9, 1),
+                date=date(2024, 6, 1),
                 status="Final",
                 is_current=False,
             ),
@@ -178,12 +177,12 @@ def backport_client(backport_engine):
 
 
 class TestSortOrderNotReleaseId:
-    def test_versions_listed_in_semver_order(self, backport_client):
+    def test_versions_listed_in_date_order(self, backport_client):
         resp = backport_client.get("/api/v1/structure/category/*/1/*")
         assert resp.status_code == 200
         cats = resp.json()["data"]["categories"]
         releases = [c["release"] for c in cats]
-        # Semver order, not release_id (100,101,200) order.
+        # Lineage/date order, not release_id (100,101,200) order.
         assert releases == ["4.0", "4.1"]
 
     def test_item_added_by_backport_visible_at_later_release(
@@ -207,11 +206,11 @@ class TestSortOrderNotReleaseId:
         item_ids = {i["id"] for i in cat["items"]}
         assert item_ids == {10}
 
-    def test_latest_resolves_to_highest_semver(self, backport_client):
+    def test_latest_resolves_to_highest_date(self, backport_client):
         resp = backport_client.get("/api/v1/structure/category/*/1/~")
         assert resp.status_code == 200
         cat = resp.json()["data"]["categories"][0]
-        # Latest semver is 4.2; active version there was created at 4.1.
+        # Latest by date is 4.2; active version there was created at 4.1.
         assert cat["release"] == "4.1"
         assert {i["id"] for i in cat["items"]} == {10, 11}
 

--- a/tests/unit/services/test_ast_generator.py
+++ b/tests/unit/services/test_ast_generator.py
@@ -642,30 +642,31 @@ class TestResolveRelease:
 
 
 class TestLatestReleaseInWindow:
-    def test_undated_start_release_raises(self):
+    def test_unknown_start_release_raises(self):
         svc, _, _ = _bare_svc()
         svc.session = MagicMock()
         mv = SimpleNamespace(start_release_id=42, end_release_id=None)
         # resolve_sort_order issues session.query(Release.date).filter(
-        # Release.release_id == ...).first(); a release with no date has
-        # no sort order, so the helper raises.
+        # Release.release_id == ...).first(); no matching Release row
+        # (first() returns None) has no sort order, so the helper raises.
+        # An undated release, by contrast, resolves to the latest sentinel.
         svc.session.query.return_value.filter.return_value.first.return_value = (  # noqa: E501
-            None,
+            None
         )
         with pytest.raises(
             ValueError, match="window start release 42 has no sort_order"
         ):
             svc._latest_release_in_window(mv)
 
-    def test_undated_end_release_raises(self):
+    def test_unknown_end_release_raises(self):
         svc, _, _ = _bare_svc()
         svc.session = MagicMock()
         mv = SimpleNamespace(start_release_id=1, end_release_id=99)
         # Two resolve_sort_order calls: first returns a dated release,
-        # second returns an undated one so the end-bound resolver raises.
+        # second finds no Release row so the end-bound resolver raises.
         svc.session.query.return_value.filter.return_value.first.side_effect = [  # noqa: E501
             (date(2024, 1, 1),),
-            (None,),
+            None,
         ]
         with pytest.raises(
             ValueError, match="window end release 99 has no sort_order"

--- a/tests/unit/services/test_ast_generator.py
+++ b/tests/unit/services/test_ast_generator.py
@@ -630,8 +630,8 @@ class TestResolveRelease:
         with pytest.raises(ValueError, match="ModuleVersion not found"):
             svc._resolve_release("X", "1.0", None)
 
-    # Explicit-release window checks now compare semver sort orders, which
-    # need real Release rows. They are covered against the EBA fixture DB in
+    # Explicit-release window checks now compare date-based sort orders,
+    # which need real Release rows. They are covered against the EBA DB in
     # tests/integration/services/test_scope_release_axis.py rather than with
     # blanket ORM mocks (see issue #151).
 
@@ -642,31 +642,30 @@ class TestResolveRelease:
 
 
 class TestLatestReleaseInWindow:
-    def test_unparseable_start_release_raises(self):
+    def test_undated_start_release_raises(self):
         svc, _, _ = _bare_svc()
         svc.session = MagicMock()
         mv = SimpleNamespace(start_release_id=42, end_release_id=None)
-        # resolve_sort_order issues session.query(Release.code).filter(
-        # Release.release_id == ...).first(); return an unparseable code
-        # so compute_sort_order produces None and the helper raises.
+        # resolve_sort_order issues session.query(Release.date).filter(
+        # Release.release_id == ...).first(); a release with no date has
+        # no sort order, so the helper raises.
         svc.session.query.return_value.filter.return_value.first.return_value = (  # noqa: E501
-            "garbage",
+            None,
         )
         with pytest.raises(
             ValueError, match="window start release 42 has no sort_order"
         ):
             svc._latest_release_in_window(mv)
 
-    def test_unparseable_end_release_raises(self):
+    def test_undated_end_release_raises(self):
         svc, _, _ = _bare_svc()
         svc.session = MagicMock()
         mv = SimpleNamespace(start_release_id=1, end_release_id=99)
-        # Two resolve_sort_order calls: first returns a parseable code,
-        # second returns an unparseable one so the end-bound resolver
-        # raises.
+        # Two resolve_sort_order calls: first returns a dated release,
+        # second returns an undated one so the end-bound resolver raises.
         svc.session.query.return_value.filter.return_value.first.side_effect = [  # noqa: E501
-            ("4.0",),
-            ("garbage",),
+            (date(2024, 1, 1),),
+            (None,),
         ]
         with pytest.raises(
             ValueError, match="window end release 99 has no sort_order"


### PR DESCRIPTION
## Summary

Closes #185

Release ordering now runs off `Release.date` instead of parsing the version code, so every code format orders the same way — classic `MAJOR.MINOR[.PATCH]`, EBA's four-segment codes like `4.2.1.3`, and non-versioned working releases like `"Playground"` — without crashing on codes that aren't semver. A release with no publication date is an unpublished working release and is treated as the latest, so requesting it returns the current rows. This rule is applied consistently everywhere releases are ordered: range/scope filtering, `get_last_release`, the release listing and single-release lookups, the structure "latest" endpoint, and the export filename. `get_last_release` and the "latest" lookups now pick by date rather than by the opaque `ReleaseID`, which is no longer monotonic from DPM 4.2.1 onwards.

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [x] Documentation updated (if applicable)

## Impact / Risk

- No API, CLI, REST, or Django model changes.
- No schema or migration changes
- Behaviour change: an undated release now ranks as the latest instead of being excluded, and release ordering follows publication date rather than the version code.
