### PR TITLE
feat(services): add ExpressionMetadataService and data-dictionary gap…

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,24 @@ with connect("sqlite:///dpm.db") as db:
     print(result.module_versions)
 ```
 
+**Expression metadata — tables / headers / frameworks touched by an expression:**
+
+```python
+from dpmcore import connect
+
+with connect("sqlite:///dpm.db") as db:
+    meta = db.services.expression_metadata
+    expr = "{tF_01.01, r0010, c0010} = 100"
+
+    tables = meta.get_referenced_tables(expr, release_code="4.2.1")
+    headers = meta.get_referenced_headers(expr, release_code="4.2.1")
+    frameworks = meta.get_referenced_frameworks(expr, release_code="4.2.1")
+
+    # Each entry is a plain dict — no ORM instances leak.
+    # header_type reflects the axis USED in the expression
+    # (r*→"Row", c*→"Column", s*→"Sheet"), not Header.direction.
+```
+
 **Explorer — reverse lookups:**
 
 ```python
@@ -565,6 +583,7 @@ src/dpmcore/
 │   ├── semantic.py        SemanticService
 │   ├── ast_generator.py   ASTGeneratorService (engine-ready)
 │   ├── scope_calculator.py ScopeCalculatorService
+│   ├── expression_metadata.py ExpressionMetadataService
 │   ├── data_dictionary.py DataDictionaryService
 │   ├── explorer.py        ExplorerService
 │   ├── hierarchy.py       HierarchyService

--- a/docs/api/expression_metadata.rst
+++ b/docs/api/expression_metadata.rst
@@ -1,0 +1,56 @@
+``dpmcore.services.expression_metadata``
+========================================
+
+.. module:: dpmcore.services.expression_metadata
+
+Resolve the DPM entities (tables, headers, frameworks) that a DPM-XL
+expression references. Where
+:class:`~dpmcore.services.scope_calculator.ScopeCalculatorService`
+answers "which module versions does this expression touch?", this
+service answers "given that expression, which concrete tables /
+headers / frameworks do I need to persist alongside it?".
+
+Callers get plain ``list[dict]`` back — no ORM instances leak — so
+the results are safe to hand to a downstream ORM or serializer
+without holding onto the SQLAlchemy session.
+
+Usage
+-----
+
+.. code-block:: python
+
+   from dpmcore import connect
+
+   with connect("sqlite:///dpm.db") as db:
+       svc = db.services.expression_metadata
+
+       tables = svc.get_referenced_tables(
+           expression="{tF_01.01, r0010, c0010} = 100",
+           release_id=42,
+       )
+       headers = svc.get_referenced_headers(
+           expression="{tF_01.01, r0010, c0010} = 100",
+           release_id=42,
+       )
+       frameworks = svc.get_referenced_frameworks(
+           expression="{tF_01.01, r0010, c0010} = 100",
+           release_id=42,
+       )
+
+The ``header_type`` field on each header entry reflects the header's
+*use* in the expression (``r*`` → ``"Row"``, ``c*`` → ``"Column"``,
+``s*`` → ``"Sheet"``), not the catalog ``Header.direction`` — two
+tables that share a code but are transposed relative to each other
+both emit rows whose ``header_type`` matches the syntax the
+expression used.
+
+Any parser or semantic failure degrades to an empty list rather than
+raising.
+
+ExpressionMetadataService
+-------------------------
+
+.. autoclass:: ExpressionMetadataService
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -15,6 +15,7 @@ All services are accessible through :attr:`DpmConnection.services`:
        db.services.semantic         # SemanticService
        db.services.ast_generator    # ASTGeneratorService
        db.services.scope_calculator # ScopeCalculatorService
+       db.services.expression_metadata # ExpressionMetadataService
        db.services.data_dictionary  # DataDictionaryService
        db.services.explorer         # ExplorerService
        db.services.hierarchy        # HierarchyService
@@ -52,6 +53,7 @@ Read-only service references
    semantic
    ast_generator
    scope_calculator
+   expression_metadata
    data_dictionary
    explorer
    hierarchy

--- a/src/dpmcore/connection.py
+++ b/src/dpmcore/connection.py
@@ -32,6 +32,9 @@ if TYPE_CHECKING:
     from dpmcore.services.data_dictionary import DataDictionaryService
     from dpmcore.services.dpm_xl import DpmXlService
     from dpmcore.services.explorer import ExplorerService
+    from dpmcore.services.expression_metadata import (
+        ExpressionMetadataService,
+    )
     from dpmcore.services.hierarchy import HierarchyService
     from dpmcore.services.layout_exporter import LayoutExporterService
     from dpmcore.services.meili_json import MeiliJsonService
@@ -101,6 +104,19 @@ class _ServiceAccessor:
                 self._session,
             )
         service: ScopeCalculatorService = self._cache["scope_calculator"]
+        return service
+
+    @property
+    def expression_metadata(self) -> ExpressionMetadataService:
+        from dpmcore.services.expression_metadata import (
+            ExpressionMetadataService,
+        )
+
+        if "expression_metadata" not in self._cache:
+            self._cache["expression_metadata"] = ExpressionMetadataService(
+                self._session,
+            )
+        service: ExpressionMetadataService = self._cache["expression_metadata"]
         return service
 
     # ------------------------------------------------------------------ #

--- a/src/dpmcore/services/_open_keys.py
+++ b/src/dpmcore/services/_open_keys.py
@@ -1,0 +1,84 @@
+"""Shared helper: open-key (compound-key) lookups per table.
+
+Kept as a module-level function rather than a service method so both
+:class:`~dpmcore.services.data_dictionary.DataDictionaryService` and
+:class:`~dpmcore.services.scope_calculator.ScopeCalculatorService` can
+use it without one service reaching into the private surface of the
+other.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Dict, List, Optional
+
+from sqlalchemy import or_
+
+from dpmcore.orm.glossary import ItemCategory, Property
+from dpmcore.orm.infrastructure import DataType
+from dpmcore.orm.query_utils import chunked_in
+from dpmcore.orm.rendering import TableVersion
+from dpmcore.orm.variables import KeyComposition, VariableVersion
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+
+def get_open_keys_for_tables(
+    session: "Session",
+    table_codes: List[str],
+    release_id: Optional[int] = None,
+) -> Dict[str, Dict[str, str]]:
+    """Return ``{table_code: {property_code: data_type_code}}``.
+
+    Identifies the open-key (compound-key) variables of each table by
+    walking ``TableVersion`` → ``KeyComposition`` → ``VariableVersion``
+    → ``Property`` → ``ItemCategory`` (for the property code) →
+    ``DataType`` (for the type code). When ``release_id`` is given the
+    query restricts to ``TableVersion`` rows whose release window
+    contains it.
+    """
+    result: Dict[str, Dict[str, str]] = {code: {} for code in table_codes}
+    if not table_codes:
+        return result
+
+    query = (
+        session.query(
+            TableVersion.code.label("table_code"),
+            ItemCategory.code.label("property_code"),
+            DataType.code.label("data_type_code"),
+        )
+        .select_from(DataType)
+        .join(Property, DataType.data_type_id == Property.data_type_id)
+        .join(ItemCategory, Property.property_id == ItemCategory.item_id)
+        .join(
+            VariableVersion,
+            ItemCategory.item_id == VariableVersion.property_id,
+        )
+        .join(
+            KeyComposition,
+            VariableVersion.variable_vid == KeyComposition.variable_vid,
+        )
+        .join(
+            TableVersion,
+            KeyComposition.key_id == TableVersion.key_id,
+        )
+    )
+
+    if release_id is not None:
+        query = query.filter(
+            or_(
+                TableVersion.end_release_id.is_(None),
+                TableVersion.end_release_id > release_id,
+            ),
+            TableVersion.start_release_id <= release_id,
+        )
+
+    query = query.distinct().order_by(TableVersion.code, ItemCategory.code)
+    rows = chunked_in(query, TableVersion.code, table_codes)
+    for row in rows:
+        tcode = row.table_code
+        pcode = row.property_code
+        dcode = row.data_type_code or ""
+        if tcode and pcode:
+            result.setdefault(tcode, {})[pcode] = dcode
+    return result

--- a/src/dpmcore/services/data_dictionary.py
+++ b/src/dpmcore/services/data_dictionary.py
@@ -113,7 +113,8 @@ class DataDictionaryService:
         date: Optional[str] = ...,
         release_code: Optional[str] = ...,
         verbose: Literal[False] = ...,
-    ) -> List[str]: ...
+    ) -> List[str]:
+        pass
 
     @overload
     def get_tables(
@@ -123,7 +124,8 @@ class DataDictionaryService:
         release_code: Optional[str] = ...,
         *,
         verbose: Literal[True],
-    ) -> List[Dict[str, Optional[str]]]: ...
+    ) -> List[Dict[str, Optional[str]]]:
+        pass
 
     def get_tables(
         self,

--- a/src/dpmcore/services/data_dictionary.py
+++ b/src/dpmcore/services/data_dictionary.py
@@ -98,9 +98,23 @@ class DataDictionaryService:
         release_id: Optional[int] = None,
         date: Optional[str] = None,
         release_code: Optional[str] = None,
-    ) -> List[str]:
-        """Return available table codes."""
-        q = self.session.query(TableVersion.code)
+        verbose: bool = False,
+    ) -> List[Any]:
+        """Return available tables.
+
+        When ``verbose`` is ``False`` (default) returns a list of table
+        codes. When ``verbose`` is ``True`` returns a list of dicts with
+        ``{code, name, description}`` for each active table version.
+        """
+        q: Any
+        if verbose:
+            q = self.session.query(
+                TableVersion.code,
+                TableVersion.name,
+                TableVersion.description,
+            )
+        else:
+            q = self.session.query(TableVersion.code)
 
         if date:
             if release_id is not None or release_code is not None:
@@ -135,6 +149,11 @@ class DataDictionaryService:
                 )
 
         q = q.order_by(TableVersion.code)
+        if verbose:
+            return [
+                {"code": r[0], "name": r[1], "description": r[2]}
+                for r in q.all()
+            ]
         return [row[0] for row in q.all()]
 
     def get_table_version(
@@ -159,6 +178,41 @@ class DataDictionaryService:
             )
         row = q.first()
         return row.to_dict() if row else None
+
+    def get_open_keys_for_tables(
+        self,
+        table_codes: List[str],
+        release_id: Optional[int] = None,
+        release_code: Optional[str] = None,
+    ) -> Dict[str, Dict[str, str]]:
+        """Return ``{table_code: {property_code: data_type_code}}``.
+
+        Identifies the open-key (compound-key) variables of each table
+        by walking ``TableVersion`` → ``KeyComposition`` →
+        ``VariableVersion`` → ``Property`` → ``ItemCategory`` (for the
+        property code) → ``DataType`` (for the type code).
+        """
+        release_id = resolve_release_id(
+            self.session, release_id=release_id, release_code=release_code
+        )
+        from dpmcore.services.scope_calculator import ScopeCalculatorService
+
+        return ScopeCalculatorService(self.session)._get_open_keys_for_tables(
+            table_codes, release_id=release_id
+        )
+
+    def get_open_keys_for_table(
+        self,
+        table_code: str,
+        release_id: Optional[int] = None,
+        release_code: Optional[str] = None,
+    ) -> Dict[str, str]:
+        """Return ``{property_code: data_type_code}`` for one table."""
+        return self.get_open_keys_for_tables(
+            [table_code],
+            release_id=release_id,
+            release_code=release_code,
+        ).get(table_code, {})
 
     # ------------------------------------------------------------------ #
     # Items

--- a/src/dpmcore/services/data_dictionary.py
+++ b/src/dpmcore/services/data_dictionary.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union, overload
 
 from sqlalchemy import distinct
 
@@ -20,6 +20,9 @@ from dpmcore.orm.packaging import (
 )
 from dpmcore.orm.release_sort_order import compute_sort_order
 from dpmcore.orm.rendering import TableVersion
+from dpmcore.services._open_keys import (
+    get_open_keys_for_tables as _get_open_keys_for_tables,
+)
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -93,13 +96,32 @@ class DataDictionaryService:
     # Tables
     # ------------------------------------------------------------------ #
 
+    @overload
+    def get_tables(
+        self,
+        release_id: Optional[int] = ...,
+        date: Optional[str] = ...,
+        release_code: Optional[str] = ...,
+        verbose: Literal[False] = ...,
+    ) -> List[str]: ...
+
+    @overload
+    def get_tables(
+        self,
+        release_id: Optional[int] = ...,
+        date: Optional[str] = ...,
+        release_code: Optional[str] = ...,
+        *,
+        verbose: Literal[True],
+    ) -> List[Dict[str, Optional[str]]]: ...
+
     def get_tables(
         self,
         release_id: Optional[int] = None,
         date: Optional[str] = None,
         release_code: Optional[str] = None,
         verbose: bool = False,
-    ) -> List[Any]:
+    ) -> Union[List[str], List[Dict[str, Optional[str]]]]:
         """Return available tables.
 
         When ``verbose`` is ``False`` (default) returns a list of table
@@ -195,10 +217,8 @@ class DataDictionaryService:
         release_id = resolve_release_id(
             self.session, release_id=release_id, release_code=release_code
         )
-        from dpmcore.services.scope_calculator import ScopeCalculatorService
-
-        return ScopeCalculatorService(self.session)._get_open_keys_for_tables(
-            table_codes, release_id=release_id
+        return _get_open_keys_for_tables(
+            self.session, table_codes, release_id=release_id
         )
 
     def get_open_keys_for_table(

--- a/src/dpmcore/services/data_dictionary.py
+++ b/src/dpmcore/services/data_dictionary.py
@@ -2,7 +2,17 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union, overload
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    Union,
+    overload,
+)
 
 from sqlalchemy import distinct
 

--- a/src/dpmcore/services/expression_metadata.py
+++ b/src/dpmcore/services/expression_metadata.py
@@ -28,7 +28,7 @@ service holds no state beyond its SQLAlchemy session.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 from sqlalchemy import and_, or_
 
@@ -99,17 +99,14 @@ class ExpressionMetadataService:
         On a syntax/semantic error (or when the expression references
         nothing that resolves), returns ``[]``.
         """
-        oc = self._prepare_operands(expression, release_id, release_code)
-        if oc is None:
+        prepared = self._prepare_operands(expression, release_id, release_code)
+        if prepared is None:
             return []
+        oc, release_id = prepared
 
         table_vids = self._extract_table_vids(oc)
         if not table_vids:
             return []
-
-        release_id = resolve_release_id(
-            self.session, release_id=release_id, release_code=release_code
-        )
 
         query = (
             self.session.query(
@@ -194,8 +191,11 @@ class ExpressionMetadataService:
 
         On a syntax/semantic error, returns ``[]``.
         """
-        oc = self._prepare_operands(expression, release_id, release_code)
-        if oc is None or oc.data is None or oc.data.empty:
+        prepared = self._prepare_operands(expression, release_id, release_code)
+        if prepared is None:
+            return []
+        oc, _ = prepared
+        if oc.data is None or oc.data.empty:
             return []
 
         table_vids = self._extract_table_vids(oc)
@@ -295,17 +295,14 @@ class ExpressionMetadataService:
 
         On a syntax/semantic error, returns ``[]``.
         """
-        oc = self._prepare_operands(expression, release_id, release_code)
-        if oc is None:
+        prepared = self._prepare_operands(expression, release_id, release_code)
+        if prepared is None:
             return []
+        oc, release_id = prepared
 
         table_vids = self._extract_table_vids(oc)
         if not table_vids:
             return []
-
-        release_id = resolve_release_id(
-            self.session, release_id=release_id, release_code=release_code
-        )
 
         query = (
             self.session.query(Framework)
@@ -350,25 +347,29 @@ class ExpressionMetadataService:
         expression: str,
         release_id: Optional[int],
         release_code: Optional[str],
-    ) -> Optional[OperandsChecking]:
+    ) -> Optional[Tuple[OperandsChecking, Optional[int]]]:
         """Parse ``expression`` and run ``OperandsChecking``.
 
-        Returns ``None`` when the expression cannot be parsed or when
-        the semantic pass raises — callers use that to return ``[]``.
+        Returns ``(operands, resolved_release_id)`` on success. Callers
+        can reuse ``resolved_release_id`` to avoid resolving the release
+        again downstream. Returns ``None`` when the expression cannot
+        be parsed or when the semantic pass raises — callers use that
+        to return ``[]``.
         """
         try:
-            release_id = resolve_release_id(
+            resolved_release_id = resolve_release_id(
                 self.session,
                 release_id=release_id,
                 release_code=release_code,
             )
             ast = self._syntax.parse(expression)
-            return OperandsChecking(
+            oc = OperandsChecking(
                 session=self.session,
                 expression=expression,
                 ast=ast,
-                release_id=release_id,
+                release_id=resolved_release_id,
             )
+            return oc, resolved_release_id
         except SemanticError as exc:
             logger.debug("Expression rejected by semantics: %s", exc)
             return None

--- a/src/dpmcore/services/expression_metadata.py
+++ b/src/dpmcore/services/expression_metadata.py
@@ -42,7 +42,6 @@ from dpmcore.orm.packaging import (
     ModuleVersionComposition,
 )
 from dpmcore.orm.rendering import (
-    Header,
     HeaderVersion,
     TableVersion,
     TableVersionHeader,
@@ -53,12 +52,6 @@ if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
 logger = logging.getLogger(__name__)
-
-
-# Mapping from DPM ``Header.direction`` to the header-usage label the
-# expression syntax uses ("r*"→Row, "c*"→Column, "s*"→Sheet). Kept in
-# sync with the label emitted by :meth:`get_referenced_headers`.
-_DIRECTION_TO_USAGE = {"X": "Row", "Y": "Column", "Z": "Sheet"}
 
 
 class ExpressionMetadataService:
@@ -214,7 +207,6 @@ class ExpressionMetadataService:
                 HeaderVersion.code,
                 HeaderVersion.label,
                 TableVersionHeader.table_vid,
-                Header.direction,
                 TableVersion.code.label("table_code"),
                 TableVersion.name.label("table_name"),
             )
@@ -222,7 +214,6 @@ class ExpressionMetadataService:
                 TableVersionHeader,
                 TableVersionHeader.header_vid == HeaderVersion.header_vid,
             )
-            .join(Header, Header.header_id == HeaderVersion.header_id)
             .join(
                 TableVersion,
                 TableVersion.table_vid == TableVersionHeader.table_vid,
@@ -243,17 +234,10 @@ class ExpressionMetadataService:
             usages = code_usage.get(row.code or "")
             if not usages:
                 continue
-            # Prefer the usage whose axis matches the catalog direction
-            # when the header is used on multiple axes in the same
-            # expression: this makes the round-trip deterministic and
-            # keeps the (code, header_type) pair singular per table.
-            catalog_usage = _DIRECTION_TO_USAGE.get(row.direction or "")
-            ordered = (
-                [catalog_usage] + [u for u in usages if u != catalog_usage]
-                if catalog_usage and catalog_usage in usages
-                else list(usages)
-            )
-            for usage in ordered:
+            # Emit one row per axis the expression uses (Row/Column/Sheet)
+            # for this (code, table_vid). `seen` prevents duplicates when
+            # the DB has multiple header versions for the same code.
+            for usage in usages:
                 key = (row.code or "", usage, row.table_vid)
                 if key in seen:
                     continue
@@ -269,7 +253,6 @@ class ExpressionMetadataService:
                         "table_name": row.table_name or "",
                     }
                 )
-                break
 
         result.sort(
             key=lambda r: (

--- a/src/dpmcore/services/expression_metadata.py
+++ b/src/dpmcore/services/expression_metadata.py
@@ -1,0 +1,417 @@
+"""Expression-level metadata lookups.
+
+Given a DPM-XL expression, resolve the concrete DPM entities it
+references — tables, headers, frameworks — with enough context to
+persist them (e.g. onto a ``ValidationVersion``) without callers ever
+touching the ORM.
+
+Callers::
+
+    with connect(url) as db:
+        tables = db.services.expression_metadata.get_referenced_tables(
+            expression="{tF_01.01, r0010, c0010} = 100",
+            release_id=42,
+        )
+        headers = db.services.expression_metadata.get_referenced_headers(
+            expression="{tF_01.01, r0010, c0010} = 100",
+            release_id=42,
+        )
+        fws = db.services.expression_metadata.get_referenced_frameworks(
+            expression="{tF_01.01, r0010, c0010} = 100",
+            release_id=42,
+        )
+
+All three return plain ``list[dict]`` sorted deterministically. The
+service holds no state beyond its SQLAlchemy session.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+from sqlalchemy import and_, or_
+
+from dpmcore.dpm_xl.ast.operands import OperandsChecking
+from dpmcore.dpm_xl.utils.filters import resolve_release_id
+from dpmcore.errors import SemanticError
+from dpmcore.orm.packaging import (
+    Framework,
+    Module,
+    ModuleVersion,
+    ModuleVersionComposition,
+)
+from dpmcore.orm.rendering import (
+    Header,
+    HeaderVersion,
+    TableVersion,
+    TableVersionHeader,
+)
+from dpmcore.services.syntax import SyntaxService
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+
+# Mapping from DPM ``Header.direction`` to the header-usage label the
+# expression syntax uses ("r*"→Row, "c*"→Column, "s*"→Sheet). Kept in
+# sync with the label emitted by :meth:`get_referenced_headers`.
+_DIRECTION_TO_USAGE = {"X": "Row", "Y": "Column", "Z": "Sheet"}
+
+
+class ExpressionMetadataService:
+    """Resolve DPM entities referenced by a DPM-XL expression.
+
+    The service parses the expression once (via ``SyntaxService`` +
+    ``OperandsChecking``) and then queries the ORM to hydrate the
+    referenced tables, headers, and frameworks.
+
+    Args:
+        session: An open SQLAlchemy session.
+    """
+
+    def __init__(self, session: "Session") -> None:
+        """Build the service bound to ``session``."""
+        self.session = session
+        self._syntax = SyntaxService()
+
+    # ------------------------------------------------------------------ #
+    # Public API
+    # ------------------------------------------------------------------ #
+
+    def get_referenced_tables(
+        self,
+        expression: str,
+        release_id: Optional[int] = None,
+        release_code: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """Return the tables referenced by ``expression``.
+
+        Each entry is a plain dict with the keys ``table_vid``,
+        ``code``, ``name``, ``description``, ``module_vid``,
+        ``module_code``, ``module_name``, ``module_version``.
+
+        Result is sorted by ``(code, table_vid, module_vid)`` so
+        callers can diff-persist deterministically.
+
+        On a syntax/semantic error (or when the expression references
+        nothing that resolves), returns ``[]``.
+        """
+        oc = self._prepare_operands(expression, release_id, release_code)
+        if oc is None:
+            return []
+
+        table_vids = self._extract_table_vids(oc)
+        if not table_vids:
+            return []
+
+        release_id = resolve_release_id(
+            self.session, release_id=release_id, release_code=release_code
+        )
+
+        query = (
+            self.session.query(
+                TableVersion.table_vid,
+                TableVersion.code,
+                TableVersion.name,
+                TableVersion.description,
+                ModuleVersionComposition.module_vid,
+                ModuleVersion.code.label("module_code"),
+                ModuleVersion.name.label("module_name"),
+                ModuleVersion.version_number,
+            )
+            .join(
+                ModuleVersionComposition,
+                ModuleVersionComposition.table_vid == TableVersion.table_vid,
+            )
+            .join(
+                ModuleVersion,
+                ModuleVersion.module_vid
+                == ModuleVersionComposition.module_vid,
+            )
+            .filter(TableVersion.table_vid.in_(table_vids))
+        )
+
+        if release_id is not None:
+            query = query.filter(
+                ModuleVersion.start_release_id <= release_id,
+                or_(
+                    ModuleVersion.end_release_id.is_(None),
+                    ModuleVersion.end_release_id > release_id,
+                ),
+            )
+
+        rows = query.distinct().all()
+
+        result = [
+            {
+                "table_vid": row.table_vid,
+                "code": row.code or "",
+                "name": row.name or "",
+                "description": row.description or "",
+                "module_vid": row.module_vid,
+                "module_code": row.module_code or "",
+                "module_name": row.module_name or "",
+                "module_version": row.version_number or "",
+            }
+            for row in rows
+        ]
+        result.sort(
+            key=lambda r: (
+                r["code"],
+                r["table_vid"] or 0,
+                r["module_vid"] or 0,
+            )
+        )
+        return result
+
+    def get_referenced_headers(
+        self,
+        expression: str,
+        release_id: Optional[int] = None,
+        table_vid: Optional[int] = None,
+        release_code: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """Return the headers referenced by ``expression``.
+
+        Each entry is a plain dict with ``header_vid``, ``code``,
+        ``label``, ``header_type`` (one of ``"Row"``, ``"Column"``,
+        ``"Sheet"``), ``table_vid``, ``table_code``, ``table_name``.
+
+        ``header_type`` reflects the header's *use* in the expression
+        (r*/c*/s*), not the catalog ``Header.direction``: two tables
+        that share a header code but are transposed relative to each
+        other both emit rows whose ``header_type`` matches the syntax
+        the expression used.
+
+        ``table_vid``, when passed, narrows the result to headers of
+        that specific table version.
+
+        Result is sorted deterministically by
+        ``(table_vid, header_type, code, header_vid)``.
+
+        On a syntax/semantic error, returns ``[]``.
+        """
+        oc = self._prepare_operands(expression, release_id, release_code)
+        if oc is None or oc.data is None or oc.data.empty:
+            return []
+
+        table_vids = self._extract_table_vids(oc)
+        if table_vid is not None:
+            table_vids = [v for v in table_vids if v == table_vid]
+        if not table_vids:
+            return []
+
+        code_usage = self._collect_header_usage(oc)
+        if not code_usage:
+            return []
+
+        rows = (
+            self.session.query(
+                HeaderVersion.header_vid,
+                HeaderVersion.code,
+                HeaderVersion.label,
+                TableVersionHeader.table_vid,
+                Header.direction,
+                TableVersion.code.label("table_code"),
+                TableVersion.name.label("table_name"),
+            )
+            .join(
+                TableVersionHeader,
+                TableVersionHeader.header_vid == HeaderVersion.header_vid,
+            )
+            .join(Header, Header.header_id == HeaderVersion.header_id)
+            .join(
+                TableVersion,
+                TableVersion.table_vid == TableVersionHeader.table_vid,
+            )
+            .filter(
+                and_(
+                    TableVersionHeader.table_vid.in_(table_vids),
+                    HeaderVersion.code.in_(list(code_usage.keys())),
+                )
+            )
+            .distinct()
+            .all()
+        )
+
+        result: List[Dict[str, Any]] = []
+        seen: set[tuple[str, str, Optional[int]]] = set()
+        for row in rows:
+            usages = code_usage.get(row.code or "")
+            if not usages:
+                continue
+            # Prefer the usage whose axis matches the catalog direction
+            # when the header is used on multiple axes in the same
+            # expression: this makes the round-trip deterministic and
+            # keeps the (code, header_type) pair singular per table.
+            catalog_usage = _DIRECTION_TO_USAGE.get(row.direction or "")
+            ordered = (
+                [catalog_usage] + [u for u in usages if u != catalog_usage]
+                if catalog_usage and catalog_usage in usages
+                else list(usages)
+            )
+            for usage in ordered:
+                key = (row.code or "", usage, row.table_vid)
+                if key in seen:
+                    continue
+                seen.add(key)
+                result.append(
+                    {
+                        "header_vid": row.header_vid,
+                        "code": row.code or "",
+                        "label": row.label or "",
+                        "header_type": usage,
+                        "table_vid": row.table_vid,
+                        "table_code": row.table_code or "",
+                        "table_name": row.table_name or "",
+                    }
+                )
+                break
+
+        result.sort(
+            key=lambda r: (
+                r["table_vid"] or 0,
+                r["header_type"],
+                r["code"],
+                r["header_vid"] or 0,
+            )
+        )
+        return result
+
+    def get_referenced_frameworks(
+        self,
+        expression: str,
+        release_id: Optional[int] = None,
+        release_code: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """Return the frameworks touched by ``expression``.
+
+        Each entry is a plain dict with ``framework_id``, ``code``,
+        ``name``, ``description``. Result is deduped and sorted by
+        ``(code, framework_id)``.
+
+        On a syntax/semantic error, returns ``[]``.
+        """
+        oc = self._prepare_operands(expression, release_id, release_code)
+        if oc is None:
+            return []
+
+        table_vids = self._extract_table_vids(oc)
+        if not table_vids:
+            return []
+
+        release_id = resolve_release_id(
+            self.session, release_id=release_id, release_code=release_code
+        )
+
+        query = (
+            self.session.query(Framework)
+            .join(Module, Module.framework_id == Framework.framework_id)
+            .join(ModuleVersion, ModuleVersion.module_id == Module.module_id)
+            .join(
+                ModuleVersionComposition,
+                ModuleVersionComposition.module_vid
+                == ModuleVersion.module_vid,
+            )
+            .filter(ModuleVersionComposition.table_vid.in_(table_vids))
+        )
+
+        if release_id is not None:
+            query = query.filter(
+                ModuleVersion.start_release_id <= release_id,
+                or_(
+                    ModuleVersion.end_release_id.is_(None),
+                    ModuleVersion.end_release_id > release_id,
+                ),
+            )
+
+        rows = query.distinct().all()
+        result = [
+            {
+                "framework_id": fw.framework_id,
+                "code": fw.code or "",
+                "name": fw.name or "",
+                "description": fw.description or "",
+            }
+            for fw in rows
+        ]
+        result.sort(key=lambda r: (r["code"], r["framework_id"] or 0))
+        return result
+
+    # ------------------------------------------------------------------ #
+    # Helpers
+    # ------------------------------------------------------------------ #
+
+    def _prepare_operands(
+        self,
+        expression: str,
+        release_id: Optional[int],
+        release_code: Optional[str],
+    ) -> Optional[OperandsChecking]:
+        """Parse ``expression`` and run ``OperandsChecking``.
+
+        Returns ``None`` when the expression cannot be parsed or when
+        the semantic pass raises — callers use that to return ``[]``.
+        """
+        try:
+            release_id = resolve_release_id(
+                self.session,
+                release_id=release_id,
+                release_code=release_code,
+            )
+            ast = self._syntax.parse(expression)
+            return OperandsChecking(
+                session=self.session,
+                expression=expression,
+                ast=ast,
+                release_id=release_id,
+            )
+        except SemanticError as exc:
+            logger.debug("Expression rejected by semantics: %s", exc)
+            return None
+        except Exception as exc:
+            logger.warning(
+                "Failed to prepare operands for expression: %s", exc
+            )
+            return None
+
+    @staticmethod
+    def _extract_table_vids(oc: OperandsChecking) -> List[int]:
+        """Return the referenced ``table_vid``s in a deterministic order."""
+        if oc.data is None or "table_vid" not in oc.data.columns:
+            return []
+        vids = oc.data["table_vid"].dropna().unique()
+        return sorted(int(v) for v in vids.tolist())
+
+    @staticmethod
+    def _collect_header_usage(
+        oc: OperandsChecking,
+    ) -> Dict[str, List[str]]:
+        """Map each header code to its expression-usage axes.
+
+        Uses the ``row_code``/``column_code``/``sheet_code`` columns of
+        ``OperandsChecking.data``, which already reflect wildcard
+        expansion. The insertion order of the axes ("Row" first, then
+        "Column", then "Sheet") keeps :meth:`get_referenced_headers`
+        stable across runs.
+        """
+        data = oc.data
+        code_usage: Dict[str, List[str]] = {}
+        if data is None:
+            return code_usage
+        for column, label in (
+            ("row_code", "Row"),
+            ("column_code", "Column"),
+            ("sheet_code", "Sheet"),
+        ):
+            if column not in data.columns:
+                continue
+            for code in data[column].dropna().unique().tolist():
+                code = str(code)
+                if not code:
+                    continue
+                code_usage.setdefault(code, []).append(label)
+        return code_usage

--- a/src/dpmcore/services/scope_calculator.py
+++ b/src/dpmcore/services/scope_calculator.py
@@ -14,15 +14,13 @@ from typing import (
     Tuple,
 )
 
-from sqlalchemy import or_
-
 from dpmcore.dpm_xl.ast.operands import OperandsChecking
 from dpmcore.dpm_xl.utils.filters import resolve_release_id
 from dpmcore.dpm_xl.utils.scopes_calculator import (
     OperationScopeService,
 )
 from dpmcore.errors import SemanticError
-from dpmcore.orm.glossary import ItemCategory, Property
+from dpmcore.orm.glossary import Property
 from dpmcore.orm.infrastructure import DataType, Release
 from dpmcore.orm.packaging import (
     ModuleVersion,
@@ -33,7 +31,10 @@ from dpmcore.orm.rendering import (
     TableVersion,
     TableVersionCell,
 )
-from dpmcore.orm.variables import KeyComposition, Variable, VariableVersion
+from dpmcore.orm.variables import Variable, VariableVersion
+from dpmcore.services._open_keys import (
+    get_open_keys_for_tables as _get_open_keys_for_tables,
+)
 from dpmcore.services.syntax import SyntaxService
 
 if TYPE_CHECKING:
@@ -629,8 +630,10 @@ class ScopeCalculatorService:
                     variables_by_tvid[tvid][var_id] = type_code
 
         # Open keys per table_code
-        open_keys_by_code = self._get_open_keys_for_tables(
-            list(vid_to_code.values()), release_id=release_id
+        open_keys_by_code = _get_open_keys_for_tables(
+            self.session,
+            list(vid_to_code.values()),
+            release_id=release_id,
         )
 
         tables: Dict[str, Any] = {}
@@ -640,66 +643,6 @@ class ScopeCalculatorService:
                 "open_keys": open_keys_by_code.get(code, {}),
             }
         return tables
-
-    def _get_open_keys_for_tables(
-        self,
-        table_codes: List[str],
-        release_id: Optional[int] = None,
-    ) -> Dict[str, Dict[str, str]]:
-        """Return ``{table_code: {property_code: data_type_code}}``.
-
-        Identifies the open-key (compound-key) variables of each table
-        by walking ``TableVersion`` → ``KeyComposition`` →
-        ``VariableVersion`` → ``Property`` → ``ItemCategory`` (for the
-        property code) → ``DataType`` (for the type code). When
-        ``release_id`` is given the query restricts to ``TableVersion``
-        rows whose release window contains it.
-        """
-        result: Dict[str, Dict[str, str]] = {code: {} for code in table_codes}
-        if not table_codes:
-            return result
-
-        query = (
-            self.session.query(
-                TableVersion.code.label("table_code"),
-                ItemCategory.code.label("property_code"),
-                DataType.code.label("data_type_code"),
-            )
-            .select_from(DataType)
-            .join(Property, DataType.data_type_id == Property.data_type_id)
-            .join(ItemCategory, Property.property_id == ItemCategory.item_id)
-            .join(
-                VariableVersion,
-                ItemCategory.item_id == VariableVersion.property_id,
-            )
-            .join(
-                KeyComposition,
-                VariableVersion.variable_vid == KeyComposition.variable_vid,
-            )
-            .join(
-                TableVersion,
-                KeyComposition.key_id == TableVersion.key_id,
-            )
-        )
-
-        if release_id is not None:
-            query = query.filter(
-                or_(
-                    TableVersion.end_release_id.is_(None),
-                    TableVersion.end_release_id > release_id,
-                ),
-                TableVersion.start_release_id <= release_id,
-            )
-
-        query = query.distinct().order_by(TableVersion.code, ItemCategory.code)
-        rows = chunked_in(query, TableVersion.code, table_codes)
-        for row in rows:
-            tcode = row.table_code
-            pcode = row.property_code
-            dcode = row.data_type_code or ""
-            if tcode and pcode:
-                result.setdefault(tcode, {})[pcode] = dcode
-        return result
 
     def _get_module_uri(
         self,

--- a/tests/integration/services/test_data_dictionary_gaps.py
+++ b/tests/integration/services/test_data_dictionary_gaps.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 import pytest
 
 from dpmcore.services.data_dictionary import DataDictionaryService
-from dpmcore.services.scope_calculator import ScopeCalculatorService
 
 _RELEASE_CODE = "4.2.1"
 
@@ -63,19 +62,20 @@ def test_get_tables_verbose_returns_names(service, fixture_session):
     assert by_code["F_01.01"]["name"], "expected non-empty name for F_01.01"
 
 
-def test_get_open_keys_for_table_matches_private_helper(
+def test_get_open_keys_for_table_matches_shared_helper(
     service, fixture_session
 ):
-    """The public method must return the same dict as the private helper."""
+    """The public method must return the same dict as the shared helper."""
     release_id = _release_id(fixture_session, _RELEASE_CODE)
 
-    scope_svc = ScopeCalculatorService(fixture_session)
-    private = scope_svc._get_open_keys_for_tables(
-        ["F_01.01"], release_id=release_id
+    from dpmcore.services._open_keys import get_open_keys_for_tables
+
+    shared = get_open_keys_for_tables(
+        fixture_session, ["F_01.01"], release_id=release_id
     ).get("F_01.01", {})
 
     public = service.get_open_keys_for_table("F_01.01", release_id=release_id)
-    assert public == private
+    assert public == shared
 
 
 def test_get_open_keys_for_tables_batch(service, fixture_session):

--- a/tests/integration/services/test_data_dictionary_gaps.py
+++ b/tests/integration/services/test_data_dictionary_gaps.py
@@ -1,0 +1,89 @@
+"""Integration tests for the Gap C/D additions to DataDictionaryService.
+
+Anchored on the MR #136 canonical case at release ``4.2.1``:
+
+* ``get_tables(verbose=True)`` returns dicts with ``code``, ``name`` and
+  ``description``, and covers the same code set as the plain form.
+* ``get_open_keys_for_table(s)`` walks the same joins the pre-existing
+  private ``_get_open_keys_for_tables`` helper does — the public entry
+  point must return an identical shape for a known table.
+
+Tests skip cleanly when ``tests/fixtures/test_data.db`` is absent.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dpmcore.services.data_dictionary import DataDictionaryService
+from dpmcore.services.scope_calculator import ScopeCalculatorService
+
+_RELEASE_CODE = "4.2.1"
+
+
+@pytest.fixture
+def service(fixture_session):
+    return DataDictionaryService(fixture_session)
+
+
+def _release_id(session, code):
+    from dpmcore.orm.infrastructure import Release
+
+    row = session.query(Release).filter(Release.code == code).first()
+    if row is None:
+        pytest.skip(f"Fixture DB has no release with code {code!r}")
+    return row.release_id
+
+
+def test_get_tables_verbose_matches_plain_codes(service, fixture_session):
+    release_id = _release_id(fixture_session, _RELEASE_CODE)
+
+    plain = service.get_tables(release_id=release_id)
+    verbose = service.get_tables(release_id=release_id, verbose=True)
+
+    assert plain, "expected at least one table"
+    assert verbose, "expected at least one table"
+    assert len(verbose) == len(plain)
+
+    # Every entry in verbose must be a dict with the documented keys.
+    for entry in verbose:
+        assert isinstance(entry, dict)
+        assert set(entry) == {"code", "name", "description"}
+
+    # Same set of codes in the same order.
+    assert [e["code"] for e in verbose] == list(plain)
+
+
+def test_get_tables_verbose_returns_names(service, fixture_session):
+    release_id = _release_id(fixture_session, _RELEASE_CODE)
+
+    verbose = service.get_tables(release_id=release_id, verbose=True)
+    by_code = {e["code"]: e for e in verbose}
+    assert "F_01.01" in by_code
+    assert by_code["F_01.01"]["name"], "expected non-empty name for F_01.01"
+
+
+def test_get_open_keys_for_table_matches_private_helper(
+    service, fixture_session
+):
+    """The public method must return the same dict as the private helper."""
+    release_id = _release_id(fixture_session, _RELEASE_CODE)
+
+    scope_svc = ScopeCalculatorService(fixture_session)
+    private = scope_svc._get_open_keys_for_tables(
+        ["F_01.01"], release_id=release_id
+    ).get("F_01.01", {})
+
+    public = service.get_open_keys_for_table("F_01.01", release_id=release_id)
+    assert public == private
+
+
+def test_get_open_keys_for_tables_batch(service, fixture_session):
+    release_id = _release_id(fixture_session, _RELEASE_CODE)
+
+    batch = service.get_open_keys_for_tables(
+        ["F_01.01", "F_02.00"], release_id=release_id
+    )
+    assert set(batch.keys()) == {"F_01.01", "F_02.00"}
+    for value in batch.values():
+        assert isinstance(value, dict)

--- a/tests/integration/services/test_expression_metadata.py
+++ b/tests/integration/services/test_expression_metadata.py
@@ -1,0 +1,142 @@
+"""Integration tests for :class:`ExpressionMetadataService`.
+
+Anchored on the MR #136 canonical case
+``{tF_01.01, r0010, c0010} = 100`` at release ``4.2.1``:
+
+* tables → resolves to F_01.01 across both FINREP9 and FINREP9DP.
+* headers → r0010 comes back as ``Row`` and c0010 as ``Column``
+  (the pydpm equivalent's header-usage-from-syntax rule).
+* frameworks → FINREP appears once, deduped across modules.
+
+Tests skip cleanly when ``tests/fixtures/test_data.db`` is absent.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dpmcore.services.expression_metadata import ExpressionMetadataService
+
+_EXPRESSION = "{tF_01.01, r0010, c0010} = 100"
+_RELEASE_CODE = "4.2.1"
+
+
+@pytest.fixture
+def service(fixture_session):
+    return ExpressionMetadataService(fixture_session)
+
+
+def _release_id(session, code):
+    from dpmcore.orm.infrastructure import Release
+
+    row = session.query(Release).filter(Release.code == code).first()
+    if row is None:
+        pytest.skip(f"Fixture DB has no release with code {code!r}")
+    return row.release_id
+
+
+def test_get_referenced_tables_returns_finrep9_and_finrep9dp(
+    service, fixture_session
+):
+    release_id = _release_id(fixture_session, _RELEASE_CODE)
+
+    tables = service.get_referenced_tables(
+        expression=_EXPRESSION, release_id=release_id
+    )
+
+    assert tables, "expected at least one table row"
+    module_codes = sorted({t["module_code"] for t in tables})
+    assert "FINREP9" in module_codes
+    assert all(t["code"] == "F_01.01" for t in tables)
+    # No ORM leakage: every entry must be a plain dict with the
+    # documented keys.
+    required = {
+        "table_vid",
+        "code",
+        "name",
+        "description",
+        "module_vid",
+        "module_code",
+        "module_name",
+        "module_version",
+    }
+    for row in tables:
+        assert isinstance(row, dict)
+        assert required.issubset(row.keys())
+
+
+def test_get_referenced_headers_reflects_syntax_usage(
+    service, fixture_session
+):
+    release_id = _release_id(fixture_session, _RELEASE_CODE)
+
+    headers = service.get_referenced_headers(
+        expression=_EXPRESSION, release_id=release_id
+    )
+
+    assert headers, "expected header rows"
+
+    # r0010 must be exposed as Row-usage; c0010 as Column-usage.
+    row_labels = {h["header_type"] for h in headers if h["code"] == "0010"}
+    assert {"Row", "Column"}.issubset(row_labels)
+
+
+def test_get_referenced_headers_filters_by_table_vid(service, fixture_session):
+    release_id = _release_id(fixture_session, _RELEASE_CODE)
+    tables = service.get_referenced_tables(
+        expression=_EXPRESSION, release_id=release_id
+    )
+    if not tables:
+        pytest.skip("no tables resolved; upstream test covers reason")
+    target_vid = tables[0]["table_vid"]
+
+    headers = service.get_referenced_headers(
+        expression=_EXPRESSION,
+        release_id=release_id,
+        table_vid=target_vid,
+    )
+
+    assert headers
+    assert {h["table_vid"] for h in headers} == {target_vid}
+
+
+def test_get_referenced_frameworks_dedupes(service, fixture_session):
+    release_id = _release_id(fixture_session, _RELEASE_CODE)
+
+    frameworks = service.get_referenced_frameworks(
+        expression=_EXPRESSION, release_id=release_id
+    )
+
+    codes = [fw["code"] for fw in frameworks]
+    assert codes == sorted(codes), "frameworks must be sorted by code"
+    assert len(codes) == len(set(codes)), "frameworks must be deduped"
+    assert "FINREP" in codes
+
+
+def test_unknown_expression_returns_empty_lists(service, fixture_session):
+    release_id = _release_id(fixture_session, _RELEASE_CODE)
+    bad = "{tXX_NOT_A_TABLE, r0010, c0010} = 100"
+
+    assert service.get_referenced_tables(bad, release_id=release_id) == []
+    assert service.get_referenced_headers(bad, release_id=release_id) == []
+    assert service.get_referenced_frameworks(bad, release_id=release_id) == []
+
+
+def test_syntax_error_returns_empty_lists(service):
+    """A parser-level error must degrade to empty lists, not raise."""
+    assert service.get_referenced_tables("this is not dpm-xl") == []
+    assert service.get_referenced_headers("this is not dpm-xl") == []
+    assert service.get_referenced_frameworks("this is not dpm-xl") == []
+
+
+def test_service_is_wired_on_connection():
+    """The accessor must expose ``services.expression_metadata``."""
+    from dpmcore import connect
+
+    # We can validate the wiring without touching the DB by using an
+    # in-memory URL; the property is lazy, so no query fires.
+    with connect("sqlite:///:memory:") as db:
+        service = db.services.expression_metadata
+        assert isinstance(service, ExpressionMetadataService)
+        # Cached
+        assert db.services.expression_metadata is service

--- a/tests/integration/services/test_expression_metadata.py
+++ b/tests/integration/services/test_expression_metadata.py
@@ -80,6 +80,19 @@ def test_get_referenced_headers_reflects_syntax_usage(
     row_labels = {h["header_type"] for h in headers if h["code"] == "0010"}
     assert {"Row", "Column"}.issubset(row_labels)
 
+    # No duplicates: (table_vid, code, header_type) must be unique.
+    triples = [(h["table_vid"], h["code"], h["header_type"]) for h in headers]
+    assert len(triples) == len(set(triples)), (
+        f"duplicate (table_vid, code, header_type) entries: {triples}"
+    )
+
+    # Only the axes the expression actually uses show up.
+    assert {h["header_type"] for h in headers}.issubset(
+        {"Row", "Column", "Sheet"}
+    )
+    # Every "0010" entry must carry a table_vid that we can trace back.
+    assert all(h["table_vid"] for h in headers if h["code"] == "0010")
+
 
 def test_get_referenced_headers_filters_by_table_vid(service, fixture_session):
     release_id = _release_id(fixture_session, _RELEASE_CODE)


### PR DESCRIPTION
## Summary

- New `ExpressionMetadataService` returns the tables, headers and frameworks referenced by a DPM-XL expression as plain dicts. No ORM instances leak to callers. Syntax and semantic errors return `[]`.
- `DataDictionaryService.get_tables(..., verbose=True)` returns `{code, name, description}` per row.
- `DataDictionaryService.get_open_keys_for_table(s)` exposes the open-key variables of a table.
- `db.services.expression_metadata` is wired on the connection accessor (lazy, cached).
- Docs: new `docs/api/expression_metadata.rst`, README example, index entry.

Closes #188
Closes #190

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [ ] Tests pass (`pytest`) with 100% branch coverage — integration tests skip without fixture DB; unit tests for defensive branches still needed
- [x] Documentation updated

## Impact / Risk

- Public API additions only.
- `get_tables` return type widened from `List[str]` to `List[Any]` to accept the `verbose=True` shape. Consider `typing.overload` in a follow-up.
- `get_open_keys_for_tables` currently calls a private method on `Sc-up to promote it to a shared helper.
- No DB schema or migration changes.

## Notes

- See #188 for the known axis-drop bug in `get_referenced_headers`.
- Unit tests for defensive branches still to be added to keep branch