### PR TITLE
fix(ast): parse parenthesized negative INTEGER_LITERAL tokens

### DIFF
--- a/src/dpmcore/dpm_xl/ast/constructor.py
+++ b/src/dpmcore/dpm_xl/ast/constructor.py
@@ -800,7 +800,9 @@ class ASTVisitor(dpm_xlParserVisitor):
         type_ = token.type
 
         if type_ == dpm_xlParser.INTEGER_LITERAL:
-            return Constant(type_="Integer", value=int(value))
+            return Constant(
+                type_="Integer", value=self._int_literal_value(value)
+            )
         elif type_ == dpm_xlParser.DECIMAL_LITERAL:
             return Constant(type_="Number", value=float(value))
         elif type_ == dpm_xlParser.PERCENT_LITERAL:

--- a/tests/unit/ast/test_integer_literals.py
+++ b/tests/unit/ast/test_integer_literals.py
@@ -1,0 +1,29 @@
+"""Tests for the INTEGER_LITERAL grammar contract.
+
+Negative INTEGER_LITERAL tokens are written wrapped in parentheses,
+e.g. '(-1)' (dpm_xlLexer.g4: INTEGER_LITERAL: DIGITS0_9+ | LPAREN MINUS
+DIGITS0_9+ RPAREN). Both forms must parse to the same Constant value.
+"""
+
+import pytest
+
+from dpmcore.dpm_xl.ast.nodes import Constant
+from dpmcore.services.syntax import SyntaxService
+
+PLAIN_AND_PARENTHESIZED = [
+    ("1", 1),
+    ("(-1)", -1),
+    ("23", 23),
+    ("(-23)", -23),
+    ("0", 0),
+    ("(-0)", 0),
+]
+
+
+@pytest.mark.parametrize(("literal", "value"), PLAIN_AND_PARENTHESIZED)
+def test_integer_literal_produces_constant(literal, value):
+    ast = SyntaxService().parse(f"isnull({literal});")
+    operand = ast.children[0].operand
+    assert isinstance(operand, Constant)
+    assert operand.type == "Integer"
+    assert operand.value == value

--- a/tests/unit/ast/test_time_shift_expression.py
+++ b/tests/unit/ast/test_time_shift_expression.py
@@ -49,6 +49,15 @@ def test_negative_shift_produces_unary_ast_node():
     assert node.shift_number.operand.value == 5
 
 
+def test_parenthesized_negative_shift_produces_constant_ast_node():
+    ast = SyntaxService().parse("time_shift({tT1}, Q, (-5))")
+    node = ast.children[0]
+    assert isinstance(node, TimeShiftOp)
+    assert isinstance(node.shift_number, Constant)
+    assert node.shift_number.type == "Integer"
+    assert node.shift_number.value == -5
+
+
 def test_arithmetic_shift_produces_ast_node():
     ast = SyntaxService().parse("time_shift({tT1}, Q, 5 * 12)")
     node = ast.children[0]


### PR DESCRIPTION
## Summary

Closes #200 

Negative INTEGER_LITERAL tokens are written as `(-1)` (parentheses included in the token, per `dpm_xlLexer.g4`), and `visitLiteral` called `int(value)` on that text directly, `int('(-1)')` is not valid Python, so any negative integer literal crashed AST construction, including `time_shift`'s `shift_number` argument.

Fixed by using the existing `_int_literal_value` helper instead of a bare `int()` call,  it already handles both the plain and parenthesized-negative forms.

## Checklist

- [X] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [X] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [X] Documentation updated (if applicable)

## Impact / Risk

- Breaking changes? (public API / CLI / REST endpoints / Django models)
- Database schema or migration concerns?
- Notes for release/changelog?

## Notes

<!-- Follow-ups, TODOs, or anything reviewers should know. -->
