### PR TITLE
Scope alternative dependencies to shared operations

### DIFF
--- a/src/dpmcore/services/ast_generator.py
+++ b/src/dpmcore/services/ast_generator.py
@@ -1066,10 +1066,14 @@ class ASTGeneratorService:
                 current.get("dependency_modules", {}),
             )
 
+        # Restrict alternatives to the script's genuine dependency modules
+        # so the pairs can never name a module absent from
+        # ``dependency_modules`` (#202 dangling references).
         alt_deps = self._scope_calc.detect_alternative_dependencies(
             scope_results=all_scope_results,
             primary_module_vid=primary_module_vid,
             release_id=release_id,
+            valid_module_uris=set(all_dep_modules),
         )
 
         deduped_intra: List[str] = list(dict.fromkeys(all_intra))

--- a/src/dpmcore/services/scope_calculator.py
+++ b/src/dpmcore/services/scope_calculator.py
@@ -290,12 +290,17 @@ class ScopeCalculatorService:
         )
 
         if scope_result.has_error or not is_cross or primary_has_intra:
+            # This branch builds no dependency modules (the primary owns
+            # the reading, or the scope is not cross-module), so there are
+            # no genuine dependencies for two modules to be alternatives
+            # of: an empty valid-URI set drops every candidate pair (#202).
             alternative_deps: List[List[str]] = []
             if compute_alternative_deps and not scope_result.has_error:
                 alternative_deps = self.detect_alternative_dependencies(
                     scope_results=[scope_result],
                     primary_module_vid=primary_module_vid,
                     release_id=release_id,
+                    valid_module_uris=set(),
                 )
             return {
                 **empty_result,
@@ -350,6 +355,7 @@ class ScopeCalculatorService:
                 scope_results=[scope_result],
                 primary_module_vid=primary_module_vid,
                 release_id=release_id,
+                valid_module_uris=set(dep_modules),
             )
             if compute_alternative_deps
             else []
@@ -433,12 +439,28 @@ class ScopeCalculatorService:
         primary_module_vid: int,
         release_id: Optional[int] = None,
         release_code: Optional[str] = None,
+        valid_module_uris: Optional[Set[str]] = None,
     ) -> List[List[str]]:
         """Detect pairs of external modules that are alternatives.
 
-        Two external modules are alternatives if they each appear as
-        the sole external module alongside the primary module in
-        separate scopes, but never co-exist in the same scope.
+        Two external modules are alternatives only when they are
+        interchangeable dependencies of the *same* operation (#202):
+        within a single operation's scopes they each appear as the sole
+        external module alongside the primary, yet never co-exist in one
+        scope. Each ``ScopeResult`` is one operation, so candidate pairs
+        are collected per scope result — being the sole external of two
+        *different* operations does not make two modules alternatives.
+
+        Args:
+            scope_results: One entry per operation.
+            primary_module_vid: VID of the primary module.
+            release_id: Optional release filter (validated only).
+            release_code: Optional release code (validated only).
+            valid_module_uris: When given, the genuine dependency-module
+                URIs of the script. Pairs referencing a module outside
+                this set are dropped so ``alternative_dependencies`` can
+                never name a module absent from ``dependency_modules``
+                (#202 dangling references).
 
         Returns a list of ``[uri_a, uri_b]`` pairs (sorted).
         """
@@ -449,19 +471,31 @@ class ScopeCalculatorService:
         resolve_release_id(
             self.session, release_id=release_id, release_code=release_code
         )
-        single_ext_vids, all_ext_vid_sets = self._collect_external_vid_sets(
-            scope_results, primary_module_vid
-        )
-        if len(single_ext_vids) < 2:
-            return []
+        # Candidates: pairs sole-external within the *same* operation.
+        # Co-occurrence is tracked across every operation — two modules
+        # that ever share one scope are conjunctive, never alternatives.
+        candidate_pairs: Set[Tuple[int, int]] = set()
+        co_occurring: Set[Tuple[int, int]] = set()
+        for sr in scope_results:
+            single_ext_vids, ext_vid_sets = self._collect_external_vid_sets(
+                [sr], primary_module_vid
+            )
+            co_occurring |= self._co_occurring_pairs(ext_vid_sets)
+            candidate_pairs |= self._sole_external_pairs(single_ext_vids)
 
-        alt_pairs = self._find_alternative_pairs(
-            single_ext_vids, all_ext_vid_sets
-        )
+        alt_pairs = sorted(candidate_pairs - co_occurring)
         if not alt_pairs:
             return []
 
-        return self._map_pairs_to_uris(alt_pairs)
+        uri_pairs = self._map_pairs_to_uris(alt_pairs)
+        if valid_module_uris is not None:
+            uri_pairs = [
+                pair
+                for pair in uri_pairs
+                if pair[0] in valid_module_uris
+                and pair[1] in valid_module_uris
+            ]
+        return uri_pairs
 
     @staticmethod
     def _collect_external_vid_sets(
@@ -492,11 +526,22 @@ class ScopeCalculatorService:
         return single_ext_vids, all_ext_vid_sets
 
     @staticmethod
-    def _find_alternative_pairs(
+    def _sole_external_pairs(
         single_ext_vids: Set[int],
+    ) -> Set[tuple[int, int]]:
+        """All sorted VID pairs among sole-external modules of one op."""
+        sorted_vids = sorted(single_ext_vids)
+        return {
+            (v1, v2)
+            for i, v1 in enumerate(sorted_vids)
+            for v2 in sorted_vids[i + 1 :]
+        }
+
+    @staticmethod
+    def _co_occurring_pairs(
         all_ext_vid_sets: List[frozenset[int]],
-    ) -> List[tuple[int, int]]:
-        """Find VID pairs that are sole-external and never co-occur."""
+    ) -> Set[tuple[int, int]]:
+        """Sorted VID pairs that share a single scope (conjunctive)."""
         co_occurring: Set[tuple[int, int]] = set()
         for ext_set in all_ext_vid_sets:
             if len(ext_set) > 1:
@@ -504,15 +549,7 @@ class ScopeCalculatorService:
                 for i, v1 in enumerate(sorted_vids):
                     for v2 in sorted_vids[i + 1 :]:
                         co_occurring.add((v1, v2))
-
-        pairs = []
-        sorted_singles = sorted(single_ext_vids)
-        for i, v1 in enumerate(sorted_singles):
-            for v2 in sorted_singles[i + 1 :]:
-                pair = (v1, v2) if v1 < v2 else (v2, v1)
-                if pair not in co_occurring:
-                    pairs.append(pair)
-        return pairs
+        return co_occurring
 
     def _map_pairs_to_uris(
         self,

--- a/tests/unit/services/test_scope_calculator.py
+++ b/tests/unit/services/test_scope_calculator.py
@@ -288,21 +288,75 @@ class TestDetectAlternativeDependencies:
         )
         assert result == []
 
-    def test_multiple_scope_results(self):
-        """Works across multiple scope results."""
+    def test_different_operations_are_not_alternatives(self):
+        """Sole-external of *different* operations is not an alternative.
+
+        #202: two modules that are each the sole external of a separate
+        operation share no operation and so are not interchangeable.
+        Each ``ScopeResult`` is one operation.
+        """
         svc, SR = self._make_svc(
             {10: "http://uri/a", 20: "http://uri/b"},
         )
-        sr1 = SR(
-            scopes=[_scope([1, 10])],
-        )
-        sr2 = SR(
-            scopes=[_scope([1, 20])],
-        )
+        sr1 = SR(scopes=[_scope([1, 10])])
+        sr2 = SR(scopes=[_scope([1, 20])])
         result = svc.detect_alternative_dependencies(
             scope_results=[sr1, sr2], primary_module_vid=1
         )
-        assert len(result) == 1
+        assert result == []
+
+    def test_same_pair_across_operations_deduped(self):
+        """A pair that is an alternative in two operations appears once."""
+        svc, SR = self._make_svc(
+            {10: "http://uri/a", 20: "http://uri/b"},
+        )
+        sr1 = SR(scopes=[_scope([1, 10]), _scope([1, 20])])
+        sr2 = SR(scopes=[_scope([1, 10]), _scope([1, 20])])
+        result = svc.detect_alternative_dependencies(
+            scope_results=[sr1, sr2], primary_module_vid=1
+        )
+        assert result == [sorted(["http://uri/a", "http://uri/b"])]
+
+    def test_co_occurrence_in_other_operation_vetoes_pair(self):
+        """Co-occurring in *any* operation disqualifies a pair."""
+        svc, SR = self._make_svc(
+            {10: "http://uri/a", 20: "http://uri/b"},
+        )
+        # Op 1: 10 and 20 look like alternatives.
+        sr1 = SR(scopes=[_scope([1, 10]), _scope([1, 20])])
+        # Op 2: 10 and 20 are required together -> conjunctive, not alt.
+        sr2 = SR(scopes=[_scope([1, 10, 20])])
+        result = svc.detect_alternative_dependencies(
+            scope_results=[sr1, sr2], primary_module_vid=1
+        )
+        assert result == []
+
+    def test_valid_module_uris_drops_dangling_pair(self):
+        """A pair naming a non-dependency module is dropped (#202)."""
+        svc, SR = self._make_svc(
+            {10: "http://uri/a", 20: "http://uri/b"},
+        )
+        sr = SR(scopes=[_scope([1, 10]), _scope([1, 20])])
+        # Only module 10's URI is a genuine dependency module.
+        result = svc.detect_alternative_dependencies(
+            scope_results=[sr],
+            primary_module_vid=1,
+            valid_module_uris={"http://uri/a"},
+        )
+        assert result == []
+
+    def test_valid_module_uris_keeps_genuine_pair(self):
+        """A pair whose modules are both dependencies survives (#202)."""
+        svc, SR = self._make_svc(
+            {10: "http://uri/a", 20: "http://uri/b"},
+        )
+        sr = SR(scopes=[_scope([1, 10]), _scope([1, 20])])
+        result = svc.detect_alternative_dependencies(
+            scope_results=[sr],
+            primary_module_vid=1,
+            valid_module_uris={"http://uri/a", "http://uri/b"},
+        )
+        assert result == [sorted(["http://uri/a", "http://uri/b"])]
 
     def test_uri_failure_skips_pair(self):
         """If URI resolution fails, skip pair."""
@@ -412,30 +466,29 @@ class TestDetectCrossModuleDependencies:
         assert info["intra_instance_validations"] == []
         assert info["cross_instance_dependencies"] == []
 
-    def test_alternative_deps_included(self):
-        """Alternative deps appear in the result."""
-        svc, SR = self._make_svc()
+    @staticmethod
+    def _mv(vid):
+        mv = MagicMock()
+        mv.module_vid = vid
+        mv.version_number = "1.0"
+        mv.from_reference_date = None
+        mv.to_reference_date = None
+        return mv
 
-        mv20 = MagicMock()
-        mv20.module_vid = 20
-        mv20.version_number = "1.0"
-        mv20.from_reference_date = None
-        mv20.to_reference_date = None
+    def test_alternative_deps_dropped_when_not_dependency_modules(self):
+        """A pair naming a non-dependency module is dropped (#202).
 
-        mv30 = MagicMock()
-        mv30.module_vid = 30
-        mv30.version_number = "1.0"
-        mv30.from_reference_date = None
-        mv30.to_reference_date = None
+        With no variable-carrying tables, modules 20 and 30 never become
+        dependency modules, so they must not surface as alternatives even
+        though they are sole-external and never co-occur.
+        """
+        svc, SR = self._make_svc()  # _get_module_tables -> {}
 
         q = svc.session.query.return_value
-        q.filter.return_value.all.return_value = [mv20, mv30]
+        q.filter.return_value.all.return_value = [self._mv(20), self._mv(30)]
 
         sr = SR(
-            scopes=[
-                _scope([10, 20]),
-                _scope([10, 30]),
-            ],
+            scopes=[_scope([10, 20]), _scope([10, 30])],
             is_cross_module=True,
         )
         info = svc.detect_cross_module_dependencies(
@@ -443,7 +496,35 @@ class TestDetectCrossModuleDependencies:
             primary_module_vid=10,
             operation_code="v1",
         )
-        assert "alternative_dependencies" in info
+        assert info["dependency_modules"] == {}
+        assert info["alternative_dependencies"] == []
+
+    def test_alternative_deps_kept_when_dependency_modules(self):
+        """Genuine dependency modules surface as alternatives (#202)."""
+        svc, SR = self._make_svc()
+        svc._get_module_tables = lambda vid, release_id=None: {
+            "T_01": {"variables": {"v1": "x"}, "open_keys": {}},
+        }
+
+        q = svc.session.query.return_value
+        q.filter.return_value.all.return_value = [self._mv(20), self._mv(30)]
+
+        sr = SR(
+            scopes=[_scope([10, 20]), _scope([10, 30])],
+            is_cross_module=True,
+        )
+        info = svc.detect_cross_module_dependencies(
+            scope_result=sr,
+            primary_module_vid=10,
+            operation_code="v1",
+        )
+        assert set(info["dependency_modules"]) == {
+            "http://uri/mod_20",
+            "http://uri/mod_30",
+        }
+        assert info["alternative_dependencies"] == [
+            sorted(["http://uri/mod_20", "http://uri/mod_30"])
+        ]
 
     def test_ref_period_from_time_shifts(self):
         """ref_period uses time_shifts when provided."""


### PR DESCRIPTION
## Summary

Closes #202 

Generated validation scripts declared alternative_dependencies as the full pairwise graph of external modules that each appeared alone with the primary module and never co-occurred, regardless of whether they served the same operations. This produced false alternatives (modules that are dependencies of different operations, sharing no affected operation) and dangling references (a paired module absent from the script's dependency_modules).

Alternatives are now collected per operation: a pair is emitted only when both modules are the sole external module of the same operation and never co-occur in any scope, and the pairs are restricted to the script's genuine
dependency modules so alternative_dependencies can never name a module missing from dependency_modules.

For COREP_OF 3.1.0/4.0.0/4.1.0 the emitted alternatives drop from the full 6-pair graph over {corep_le, corep_lr, 
if_class2, sbp_cr} to none, and the dangling if_class2 reference is removed.

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [ ] Documentation updated (if applicable)

## Impact / Risk

- Breaking changes? (public API / CLI / REST endpoints / Django models)
- Database schema or migration concerns?
- Notes for release/changelog?

## Notes

<!-- Follow-ups, TODOs, or anything reviewers should know. -->
