### PR TITLE
fix(ast): downgrade deprecated "null" string literal to a warning

### DIFF
--- a/src/dpmcore/dpm_xl/ast/constructor.py
+++ b/src/dpmcore/dpm_xl/ast/constructor.py
@@ -811,7 +811,7 @@ class ASTVisitor(dpm_xlParserVisitor):
                 # used the string literal ``"null"`` as a null sentinel. The
                 # grammar accepts it and the intent is unambiguous, so treat
                 # it as a proper Null Constant and surface a deprecation
-                # warning instead of aborting semantic analysis with 0-3.
+                # warning instead of aborting semantic analysis.
                 add_semantic_warning(
                     'Deprecated use of the "null" string literal; '
                     "prefer the ``isnull(...)`` function or the bare "

--- a/src/dpmcore/dpm_xl/ast/constructor.py
+++ b/src/dpmcore/dpm_xl/ast/constructor.py
@@ -64,6 +64,7 @@ from dpmcore.dpm_xl.grammar.generated.dpm_xlParserVisitor import (
     dpm_xlParserVisitor,
 )
 from dpmcore.dpm_xl.utils.tokens import TABLE_GROUP_PREFIX
+from dpmcore.dpm_xl.warning_collector import add_semantic_warning
 from dpmcore.errors import SemanticError
 
 
@@ -806,7 +807,17 @@ class ASTVisitor(dpm_xlParserVisitor):
         elif type_ == dpm_xlParser.STRING_LITERAL:
             value = value[1:-1]
             if value == "null":
-                raise SemanticError("0-3")
+                # Historical DPM-XL expressions shipped in older DB releases
+                # used the string literal ``"null"`` as a null sentinel. The
+                # grammar accepts it and the intent is unambiguous, so treat
+                # it as a proper Null Constant and surface a deprecation
+                # warning instead of aborting semantic analysis with 0-3.
+                add_semantic_warning(
+                    'Deprecated use of the "null" string literal; '
+                    "prefer the ``isnull(...)`` function or the bare "
+                    "``null`` keyword."
+                )
+                return Constant(type_="Null", value=None)
             return Constant(type_="String", value=value)
         elif type_ == dpm_xlParser.BOOLEAN_LITERAL:
             constant_value: bool

--- a/src/dpmcore/errors.py
+++ b/src/dpmcore/errors.py
@@ -71,7 +71,6 @@ centralised_messages: Dict[str, str] = {
         "Cannot specify {argument} more than one"
         " time in the same cell reference."
     ),
-    "0-3": ("Cannot use null literal, you must use the isnull function"),
     # Variable not found
     "1-1": "The following items were not found: {items}.",
     "1-2": ("Cell expression {cell_expression} was not found."),

--- a/src/dpmcore/services/semantic.py
+++ b/src/dpmcore/services/semantic.py
@@ -229,10 +229,14 @@ class SemanticService:
                 if exists is None:
                     raise SemanticError("1-21", release_id=release_id)
 
-            ast = self._syntax.parse(expression)
-            self.ast = ast
-
             with collect_warnings() as wc:
+                # ``parse`` is inside the collector so warnings emitted from
+                # AST construction (e.g. deprecated ``"null"`` string literal
+                # in ``visitLiteral``) are captured alongside the ones from
+                # the analyzer pass.
+                ast = self._syntax.parse(expression)
+                self.ast = ast
+
                 oc = OperandsChecking(
                     session=self.session,
                     expression=expression,

--- a/tests/unit/ast/test_default_null.py
+++ b/tests/unit/ast/test_default_null.py
@@ -106,3 +106,92 @@ def test_default_null_survives_with_clause_propagation():
     assert isinstance(f00_varid.default, Constant)
     assert f00_varid.default.type == "Null"
     assert f00_varid.default.value is None
+
+
+# ---------------------------------------------------------------------------
+# Deprecated ``"null"`` string literal (issue #205).
+#
+# Historical DB releases used ``"null"`` (a string literal containing the
+# word ``null``) as a null sentinel. The grammar accepts it and the intent
+# is unambiguous, so ``visitLiteral`` now materialises it as a proper
+# ``Null`` Constant and emits a deprecation warning instead of aborting
+# with ``SemanticError("0-3")``.
+# ---------------------------------------------------------------------------
+
+
+def test_string_literal_null_no_longer_raises_semantic_error():
+    """The historical ``"null"`` string literal now parses instead of
+    raising ``SemanticError("0-3")`` — the AST construction path from
+    the issue's reproducer must complete without an exception.
+    """
+    from antlr4 import CommonTokenStream, InputStream
+
+    from dpmcore.dpm_xl.ast.constructor import ASTVisitor
+    from dpmcore.dpm_xl.grammar.generated.dpm_xlLexer import dpm_xlLexer
+    from dpmcore.dpm_xl.grammar.generated.dpm_xlParser import dpm_xlParser
+
+    expression = (
+        "with {tB_05.01, default: 0, interval: false}: "
+        'if({c0030} != "null") then ({c0040} != "null") endif'
+    )
+    lexer = dpm_xlLexer(InputStream(expression))
+    parser = dpm_xlParser(CommonTokenStream(lexer))
+    tree = parser.start()
+    ast = ASTVisitor().visit(tree)
+    # No exception: an AST was produced.
+    assert isinstance(ast, Start)
+
+
+def test_string_literal_null_produces_null_constant():
+    """A bare ``"null"`` string literal in a comparison materialises as a
+    ``Constant(type_="Null", value=None)`` — the same shape the bare
+    ``null`` keyword produces (see ``test_default_null_parses_as_null_constant``).
+    """
+    ast = SyntaxService().parse('1 != "null"')
+    # Start -> BinOp -> right operand is the deprecated literal.
+    binop = ast.children[0]
+    assert isinstance(binop, BinOp)
+    assert binop.op == "!="
+    assert isinstance(binop.right, Constant)
+    assert binop.right.type == "Null"
+    assert binop.right.value is None
+
+
+def test_string_literal_null_emits_deprecation_warning_at_parse_time():
+    """The deprecation warning is emitted from ``visitLiteral`` during
+    AST construction and captured by any active
+    :func:`collect_warnings` context — ``SemanticService.validate``
+    surrounds its ``parse`` call with such a context so the warning
+    reaches ``SemanticResult.warning``.
+    """
+    from dpmcore.dpm_xl.warning_collector import collect_warnings
+
+    with collect_warnings() as wc:
+        SyntaxService().parse('1 != "null"')
+
+    warning = wc.get_combined_warning()
+    assert warning is not None
+    assert '"null" string literal' in warning
+    assert "isnull" in warning
+
+
+def test_string_literal_null_reproducer_parses_with_warning():
+    """Reproducer from issue #205: the historical expression parses
+    without raising and every occurrence of ``"null"`` on the parse
+    path contributes a deprecation warning to the active collector.
+    Semantic validation against a DB is deferred to the integration
+    suite; this test only pins the parse-time behaviour.
+    """
+    from dpmcore.dpm_xl.warning_collector import collect_warnings
+
+    expression = (
+        "with {tB_05.01, default: 0, interval: false}: "
+        'if({c0030} != "null") then ({c0040} != "null") endif'
+    )
+    with collect_warnings() as wc:
+        SyntaxService().parse(expression)
+
+    warning = wc.get_combined_warning()
+    assert warning is not None
+    # Two occurrences of ``"null"`` in the source → two warning lines.
+    assert warning.count('"null" string literal') == 2

--- a/tests/unit/ast/test_default_null.py
+++ b/tests/unit/ast/test_default_null.py
@@ -115,14 +115,14 @@ def test_default_null_survives_with_clause_propagation():
 # word ``null``) as a null sentinel. The grammar accepts it and the intent
 # is unambiguous, so ``visitLiteral`` now materialises it as a proper
 # ``Null`` Constant and emits a deprecation warning instead of aborting
-# with ``SemanticError("0-3")``.
+# semantic analysis.
 # ---------------------------------------------------------------------------
 
 
 def test_string_literal_null_no_longer_raises_semantic_error():
-    """The historical ``"null"`` string literal now parses instead of
-    raising ``SemanticError("0-3")`` — the AST construction path from
-    the issue's reproducer must complete without an exception.
+    """The historical ``"null"`` string literal now parses without
+    raising a ``SemanticError`` — the AST construction path from the
+    issue's reproducer must complete without an exception.
     """
     from antlr4 import CommonTokenStream, InputStream
 


### PR DESCRIPTION
## Summary

Historical DPM-XL expressions in dpmcore's supported DB releases use a
``"null"`` string literal (a STRING_LITERAL whose text is the word
``null``) as a null sentinel — for example:

if({c0030} != "null") then ({c0040} != "null") endif

The AST visitor aborted these with ``SemanticError("0-3")`` — a hard
failure — even though the grammar accepts the input and the author's
intent is unambiguous.

``visitLiteral`` now materialises the ``"null"`` string literal as
``Constant(type_="Null", value=None)`` (the same node the bare
``null`` keyword produces via ``default: null``) and surfaces a
deprecation warning through ``add_semantic_warning`` instead of
raising.

To make sure the warning reaches ``SemanticResult.warning``,
``SemanticService.validate`` now wraps ``_syntax.parse(...)`` inside
its ``collect_warnings`` context. Warnings emitted from AST
construction are captured alongside the ones from the analyzer pass.

Tests added in ``tests/unit/ast/test_default_null.py`` covering: no
exception on the reproducer expression, ``"null"`` literal
materialises as a ``Null`` Constant, warning emitted at parse time,
and both occurrences of ``"null"`` in the reproducer expression
contribute to the warning stream.

Fixes #205

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [ ] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [ ] Documentation updated (if applicable)

## Impact / Risk

- No public API changes.
- No DB schema change.
- Behavioural change: expressions containing the ``"null"`` string
  literal now validate with a deprecation warning instead of failing
  with ``SemanticError("0-3")``. Downstream code that treated ``0-3``
  as an expected error for these inputs will see success with a
  warning instead.

## Notes

- Warning is surfaced through ``SemanticResult.warning``. Callers of
  the lower-level ``ASTVisitor().visit(...)`` outside a
  ``collect_warnings`` context still get the AST; the warning is
  silently discarded on that path.