### PR TITLE
fix: resolve update-db failures against remote PostgreSQL targets

### DIFF
--- a/src/dpmcore/cli/main.py
+++ b/src/dpmcore/cli/main.py
@@ -20,6 +20,24 @@ import click
 from dpmcore import __version__
 
 
+def _print_capped_warnings(
+    console: Any, label: str, warnings: list[str], limit: int = 20
+) -> None:
+    """Print at most *limit* warnings.
+
+    Caps output so a large list can't flood the terminal (e.g. many
+    rows repeating the same underlying error).
+    """
+    for warning in warnings[:limit]:
+        console.print(f"[yellow]{label}:[/yellow] {warning}")
+    omitted = len(warnings) - limit
+    if omitted > 0:
+        console.print(
+            f"[yellow]... and {omitted} more {label.lower()}(s) "
+            "omitted.[/yellow]"
+        )
+
+
 @click.group()
 @click.version_option(version=__version__, prog_name="dpmcore")
 def main() -> None:
@@ -324,8 +342,7 @@ def update_db(
     if result.ecb_validations_imported:
         console.print("[green]ECB validations imported[/green]")
 
-    for warning in migration.warnings:
-        console.print(f"[yellow]Warning:[/yellow] {warning}")
+    _print_capped_warnings(console, "Warning", migration.warnings)
 
     if result.dry_run:
         console.print(

--- a/src/dpmcore/django/models/infrastructure.py
+++ b/src/dpmcore/django/models/infrastructure.py
@@ -129,6 +129,12 @@ class Organisation(models.Model):
         null=True,
         blank=True,
     )
+    url = models.CharField(
+        db_column="URL",
+        max_length=255,
+        null=True,
+        blank=True,
+    )
 
     class Meta:
         managed = False

--- a/src/dpmcore/django/models/operations.py
+++ b/src/dpmcore/django/models/operations.py
@@ -295,6 +295,14 @@ class OperationScope(models.Model):
         null=True,
         blank=True,
     )
+    created_release = models.ForeignKey(
+        "Release",
+        on_delete=models.DO_NOTHING,
+        db_column="CreatedReleaseID",
+        related_name="created_operation_scopes",
+        null=True,
+        blank=True,
+    )
 
     class Meta:
         managed = False

--- a/src/dpmcore/dpm_xl/ast/operands.py
+++ b/src/dpmcore/dpm_xl/ast/operands.py
@@ -238,8 +238,21 @@ class OperandsChecking(ASTTemplate, ABC):
             return
 
         engine = self.session.get_bind()
-        engine_key: Hashable = getattr(engine, "url", repr(engine))
-        cache_key = (engine_key, self.release_id, tuple(sorted(table_codes)))
+        url_key: Hashable = getattr(engine, "url", repr(engine))
+        schema_translate_map = engine.get_execution_options().get(
+            "schema_translate_map"
+        )
+        schema_key = (
+            frozenset(schema_translate_map.items())
+            if schema_translate_map
+            else None
+        )
+        cache_key = (
+            url_key,
+            schema_key,
+            self.release_id,
+            tuple(sorted(table_codes)),
+        )
 
         df_headers = _HEADERS_CACHE.get(cache_key)
         if df_headers is None:
@@ -270,15 +283,11 @@ class OperandsChecking(ASTTemplate, ABC):
                 release_id=self.release_id,
             )
 
-            from dpmcore.dpm_xl.model_queries import (
-                compile_query_for_pandas,
-                read_sql_with_connection,
-            )
+            from dpmcore.dpm_xl.model_queries import read_sql_with_connection
 
-            compiled_query = compile_query_for_pandas(
+            df_headers = read_sql_with_connection(
                 query.statement, self.session
             )
-            df_headers = read_sql_with_connection(compiled_query, self.session)
             _HEADERS_CACHE[cache_key] = df_headers
 
         for table in table_codes:

--- a/src/dpmcore/dpm_xl/ast/operands.py
+++ b/src/dpmcore/dpm_xl/ast/operands.py
@@ -69,7 +69,8 @@ IMPLICIT_OPEN_KEYS = {
 
 
 _HEADERS_CACHE: Dict[
-    Tuple[Hashable, int | None, Tuple[str, ...]], pd.DataFrame
+    Tuple[Hashable, frozenset[Any] | None, int | None, Tuple[str, ...]],
+    pd.DataFrame,
 ] = {}
 
 

--- a/src/dpmcore/dpm_xl/model_queries.py
+++ b/src/dpmcore/dpm_xl/model_queries.py
@@ -9,7 +9,6 @@ legacy ``session.query()`` API for compatibility.
 
 from __future__ import annotations
 
-import warnings
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -90,68 +89,61 @@ def _is_filing_indicator() -> Any:
 
 
 def _get_engine_cache_key(session: "Session") -> Hashable:
-    """Return a hashable key that identifies the engine.
+    """Return a hashable key that identifies the engine and its schema.
+
+    Includes ``schema_translate_map`` so that two sessions bound to
+    the same URL but scoped to different schemas (e.g. distinct
+    staging schemas, or staging vs. the default schema) never share a
+    cache entry.
 
     Args:
         session: SQLAlchemy session.
 
     Returns:
-        A hashable value derived from the bound engine URL.
+        A hashable value derived from the bound engine URL and schema
+        translation options.
     """
     bind = session.get_bind()
-    return getattr(bind, "url", repr(bind))
+    url = getattr(bind, "url", repr(bind))
+    schema_translate_map = bind.get_execution_options().get(
+        "schema_translate_map"
+    )
+    schema_key = (
+        frozenset(schema_translate_map.items())
+        if schema_translate_map
+        else None
+    )
+    return (url, schema_key)
 
 
 def read_sql_with_connection(
-    sql: str,
+    query_statement: Any,
     session: "Session",
 ) -> pd.DataFrame:
-    """Execute ``pd.read_sql`` with proper connection handling.
+    """Execute *query_statement* through *session* and return a DataFrame.
 
-    Uses the raw DBAPI connection to avoid the pandas 2.x
-    deprecation warning about ``DBAPI2`` connections.
+    Goes through ``session.execute()`` rather than compiling to a
+    literal SQL string for a raw DBAPI connection (the previous
+    approach). SQLAlchemy only resolves the engine's
+    ``schema_translate_map`` execution option at actual
+    statement-execution time -- compiling standalone with
+    ``compile_kwargs={"schema_translate_map": ...}`` does not apply
+    it and silently produces unqualified table names, which then
+    resolve against the connection's default ``search_path`` (e.g.
+    ``public``) instead of a migration's staging schema. Executing
+    through the session keeps schema scoping correct for both plain
+    and schema-translated engines.
 
     Args:
-        sql: Compiled SQL string.
+        query_statement: SQLAlchemy statement object (e.g.
+            ``query.statement``).
         session: SQLAlchemy session.
 
     Returns:
         DataFrame with query results.
     """
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore",
-            message=".*pandas only supports SQLAlchemy.*",
-            category=UserWarning,
-        )
-        # pandas accepts DBAPI2 connections at runtime; its type stubs
-        # only advertise SQLAlchemy Connection so we sidestep the mismatch.
-        raw_conn: Any = session.connection().connection
-        return pd.read_sql(sql, raw_conn)
-
-
-def compile_query_for_pandas(
-    query_statement: Any,
-    session: "Session",
-) -> str:
-    """Compile a query statement to a SQL string.
-
-    Performs literal-bind compilation so that the resulting
-    string can be fed directly to ``pd.read_sql``.
-
-    Args:
-        query_statement: SQLAlchemy statement object.
-        session: SQLAlchemy session.
-
-    Returns:
-        Compiled SQL string.
-    """
-    return str(
-        query_statement.compile(
-            dialect=session.get_bind().dialect,
-            compile_kwargs={"literal_binds": True},
-        )
-    )
+    result = session.execute(query_statement)
+    return pd.DataFrame(result.fetchall(), columns=list(result.keys()))
 
 
 # ------------------------------------------------------------------ #
@@ -1303,7 +1295,7 @@ class ViewDatapointsQuery:
                 TableVersionCell,
                 and_(
                     TableVersionCell.table_vid == TableVersion.table_vid,
-                    TableVersionCell.is_void == 0,
+                    TableVersionCell.is_void.is_(False),
                 ),
             )
             .outerjoin(
@@ -1485,10 +1477,7 @@ class ViewDatapointsQuery:
                 release_id=release_id,
             )
 
-        data = read_sql_with_connection(
-            compile_query_for_pandas(query.statement, session),
-            session,
-        )
+        data = read_sql_with_connection(query.statement, session)
 
         if len(data) > 0:
             data = data.sort_values("variable_id", na_position="last")
@@ -1561,10 +1550,7 @@ class ViewDatapointsQuery:
                 release_id=release_id,
             )
 
-        return read_sql_with_connection(
-            compile_query_for_pandas(query.statement, session),
-            session,
-        )
+        return read_sql_with_connection(query.statement, session)
 
 
 def _apply_dimension_filter(
@@ -1697,10 +1683,7 @@ class ViewKeyComponentsQuery:
             active_only_fallback=True,
         )
         query = query.distinct()
-        return read_sql_with_connection(
-            compile_query_for_pandas(query.statement, session),
-            session,
-        )
+        return read_sql_with_connection(query.statement, session)
 
 
 # ------------------------------------------------------------------ #
@@ -1779,10 +1762,7 @@ class ViewOpenKeysQuery:
             active_only_fallback=True,
         )
         query = query.distinct()
-        return read_sql_with_connection(
-            compile_query_for_pandas(query.statement, session),
-            session,
-        )
+        return read_sql_with_connection(query.statement, session)
 
 
 # ------------------------------------------------------------------ #
@@ -1863,7 +1843,4 @@ class ViewModulesQuery:
             )
             .distinct()
         )
-        return read_sql_with_connection(
-            compile_query_for_pandas(query.statement, session),
-            session,
-        )
+        return read_sql_with_connection(query.statement, session)

--- a/src/dpmcore/loaders/migration.py
+++ b/src/dpmcore/loaders/migration.py
@@ -696,7 +696,63 @@ class MigrationService:
         for table_name, df in data.items():
             self._load_table(table_name, df, warnings, identity_cols)
 
+        self._resync_postgresql_sequences(data)
+
         return warnings
+
+    def _resync_postgresql_sequences(self, data: Dict[str, Any]) -> None:
+        """Resync SERIAL/IDENTITY sequences after loading explicit PKs.
+
+        ``df.to_sql`` inserts every DataFrame column verbatim, including
+        single-column integer primary keys copied from the Access
+        source. Unlike SQL Server's ``IDENTITY_INSERT``, PostgreSQL
+        never advances a column's sequence when a value is supplied
+        explicitly, so a later ORM insert that relies on the sequence
+        default (e.g. a new ``OperationScope`` row) can collide with a
+        row that was just bulk-loaded. Resync each loaded table's
+        sequence to ``MAX(pk)`` once loading completes.
+        """
+        if self._engine.dialect.name != "postgresql" or self._schema is None:
+            return
+
+        preparer = self._engine.dialect.identifier_preparer
+
+        with self._engine.begin() as conn:
+            for table_name in data:
+                orm_table = Base.metadata.tables.get(table_name)
+                if orm_table is None:
+                    continue
+
+                pk_columns = list(orm_table.primary_key.columns)
+                if len(pk_columns) != 1:
+                    continue
+
+                pk_column = pk_columns[0].name
+                quoted_pk_column = preparer.quote(pk_column)
+                qualified_table = (
+                    f"{preparer.quote_schema(self._schema)}."
+                    f"{preparer.quote(table_name)}"
+                )
+
+                sequence = conn.execute(
+                    text("SELECT pg_get_serial_sequence(:table, :column)"),
+                    {"table": qualified_table, "column": pk_column},
+                ).scalar()
+                if sequence is None:
+                    continue
+
+                max_id = conn.execute(
+                    text(
+                        f"SELECT MAX({quoted_pk_column}) FROM {qualified_table}"
+                    )
+                ).scalar()
+                if max_id is None:
+                    continue
+
+                conn.execute(
+                    text("SELECT setval(:sequence, :max_id)"),
+                    {"sequence": sequence, "max_id": max_id},
+                )
 
     def _load_table(
         self,

--- a/src/dpmcore/loaders/migration.py
+++ b/src/dpmcore/loaders/migration.py
@@ -741,11 +741,11 @@ class MigrationService:
                 if sequence is None:
                     continue
 
-                max_id = conn.execute(
-                    text(
-                        f"SELECT MAX({quoted_pk_column}) FROM {qualified_table}"
-                    )
-                ).scalar()
+                max_id_sql = (
+                    f"SELECT MAX({quoted_pk_column}) "  # noqa: S608
+                    f"FROM {qualified_table}"
+                )
+                max_id = conn.execute(text(max_id_sql)).scalar()
                 if max_id is None:
                     continue
 

--- a/src/dpmcore/orm/infrastructure.py
+++ b/src/dpmcore/orm/infrastructure.py
@@ -148,6 +148,7 @@ class Organisation(Base):
         acronym: Short form.
         id_prefix: Numeric prefix (unique).
         row_guid: FK to Concept.
+        url: Organisation website.
     """
 
     __tablename__ = "Organisation"
@@ -169,6 +170,7 @@ class Organisation(Base):
             name="fk_org_concept",
         ),
     )
+    url: Mapped[Optional[str]] = mapped_column("URL", String(255))
 
     concept: Mapped[Optional["Concept"]] = relationship(
         "Concept", foreign_keys=[row_guid]

--- a/src/dpmcore/orm/operations.py
+++ b/src/dpmcore/orm/operations.py
@@ -374,6 +374,7 @@ class OperationScope(Base):
         severity: Severity level label.
         from_submission_date: Effective start date.
         row_guid: Row GUID.
+        created_release_id: FK to the Release that created this scope.
     """
 
     __tablename__ = "OperationScope"
@@ -392,6 +393,11 @@ class OperationScope(Base):
         "FromSubmissionDate", Date
     )
     row_guid: Mapped[Optional[str]] = mapped_column("RowGUID", String(38))
+    created_release_id: Mapped[Optional[int]] = mapped_column(
+        "CreatedReleaseID",
+        Integer,
+        ForeignKey("Release.ReleaseID"),
+    )
 
     operation_version: Mapped[Optional["OperationVersion"]] = relationship(
         "OperationVersion", back_populates="operation_scopes"

--- a/src/dpmcore/services/ecb_validations_import.py
+++ b/src/dpmcore/services/ecb_validations_import.py
@@ -37,6 +37,21 @@ def _stable_uuid(*parts: object) -> str:
     return f"{{{str(uuid.uuid5(_ECB_UUID_NAMESPACE, text)).upper()}}}"
 
 
+def _format_warnings(warnings: List[str], limit: int = 20) -> str:
+    """Render at most *limit* warnings.
+
+    Caps the rendered text so a large warning list (e.g. hundreds of
+    rows repeating the same cascading transaction-abort message)
+    can't flood a terminal or log.
+    """
+    if not warnings:
+        return " No warnings were logged during the run."
+    shown = warnings[:limit]
+    omitted = len(warnings) - len(shown)
+    tail = f" (+{omitted} more omitted)" if omitted > 0 else ""
+    return f" Warnings logged: {shown}{tail}"
+
+
 class EcbValidationsImportError(Exception):
     """Raised when ECB validations cannot be imported."""
 
@@ -81,20 +96,54 @@ class EcbValidationsImportService:
 
         df.columns = df.columns.str.strip().str.lower()
 
+        warnings: List[str] = []
         session = sessionmaker(bind=self._engine)()
         try:
-            result = self._import_ecb_validations_df(session, df)
+            result = self._import_ecb_validations_df(session, df, warnings)
             session.commit()
-            return result
         except Exception as exc:
             session.rollback()
             if isinstance(exc, EcbValidationsImportError):
                 raise
             raise EcbValidationsImportError(
-                f"Failed to import ECB validations from '{csv_path}': {exc}"
+                f"Failed to import ECB validations from '{csv_path}':"
+                f" {exc}.{_format_warnings(warnings)}"
             ) from exc
         finally:
             session.close()
+
+        self._verify_persisted(warnings)
+        return result
+
+    def _verify_persisted(self, warnings: List[str]) -> None:
+        """Confirm the commit actually reached the database.
+
+        A DB-level error inside the per-row loop (e.g. a transient
+        network failure against a remote target) can be swallowed by
+        an inner ``except Exception`` without an explicit rollback.
+        SQLAlchemy then silently recovers the ``Session`` on next use,
+        discarding every already-flushed-but-uncommitted row from
+        earlier in the same transaction -- so ``session.commit()``
+        succeeds trivially with nothing left to persist. Re-checking
+        with a fresh connection after commit catches that hollow
+        "success" instead of reporting it as one.
+        """
+        verify_session = sessionmaker(bind=self._engine)()
+        try:
+            ecb_org_count = (
+                verify_session.query(Organisation)
+                .filter(Organisation.acronym == "ECB")
+                .count()
+            )
+        finally:
+            verify_session.close()
+
+        if not ecb_org_count:
+            raise EcbValidationsImportError(
+                "ECB validations import reported success but no data "
+                "was persisted (missing 'ECB' Organisation row)."
+                f"{_format_warnings(warnings)}"
+            )
 
     @staticmethod
     def _normalize_text(value: Any) -> Optional[str]:
@@ -263,6 +312,7 @@ class EcbValidationsImportService:
         expression: Optional[str],
         start_release_id: int,
         latest_release_id: Optional[int],
+        warnings: Optional[List[str]] = None,
     ) -> Set[str]:
         if expression is None or not str(expression).strip():
             return set()
@@ -284,8 +334,14 @@ class EcbValidationsImportService:
 
         try:
             table_codes = try_with_release(start_release_id)
-        except Exception:
+        except Exception as exc:
             table_codes = set()
+            if warnings is not None:
+                warnings.append(
+                    "Table code resolution failed for expression"
+                    f" {expression!r} at release {start_release_id}:"
+                    f" {exc}"
+                )
 
         if not table_codes and latest_release_id not in {
             None,
@@ -293,8 +349,14 @@ class EcbValidationsImportService:
         }:
             try:
                 table_codes = try_with_release(latest_release_id)
-            except Exception:
+            except Exception as exc:
                 table_codes = set()
+                if warnings is not None:
+                    warnings.append(
+                        "Table code resolution failed for expression"
+                        f" {expression!r} at release {latest_release_id}:"
+                        f" {exc}"
+                    )
 
         return table_codes
 
@@ -447,7 +509,7 @@ class EcbValidationsImportService:
         return op_version.operation_vid, created_count
 
     def _import_ecb_validations_df(  # noqa: C901
-        self, session: Session, df: Any
+        self, session: Session, df: Any, warnings: List[str]
     ) -> EcbValidationsImportResult:
         required_columns = {"vr_code", "start_release"}
         missing = required_columns - set(df.columns)
@@ -475,7 +537,6 @@ class EcbValidationsImportService:
             default=None,
         )
 
-        warnings: List[str] = []
         counters = {
             "operation_id": self._next_int_id(
                 session, Operation, "operation_id"
@@ -628,6 +689,7 @@ class EcbValidationsImportService:
                 expression=expression,
                 start_release_id=release.release_id,
                 latest_release_id=latest_release_id,
+                warnings=warnings,
             )
             references_created += self._create_table_references(
                 session,
@@ -664,29 +726,28 @@ class EcbValidationsImportService:
                     )
                     if scope_result.has_error:
                         warnings.append(
-                            f"Scope calculation failed for '{code}' in"
-                            f" release {release_id}:"
+                            f"Scope calculation failed for"
+                            f" '{code}' in release {release_id}:"
                             f" {scope_result.error_message}"
                         )
                         continue
 
-                    ordered_scopes = sorted(
-                        scope_result.scopes,
-                        key=lambda scope: tuple(
+                    def _module_vids(scope_obj: Any) -> tuple:
+                        return tuple(
                             sorted(
                                 comp.module_vid
-                                for comp in scope.operation_scope_compositions
+                                for comp in (
+                                    scope_obj.operation_scope_compositions
+                                )
                             )
-                        ),
+                        )
+
+                    ordered_scopes = sorted(
+                        scope_result.scopes, key=_module_vids
                     )
 
                     for scope_index, scope in enumerate(ordered_scopes):
-                        module_vids = tuple(
-                            sorted(
-                                comp.module_vid
-                                for comp in scope.operation_scope_compositions
-                            )
-                        )
+                        module_vids = _module_vids(scope)
 
                         scope.operation_vid = operation_version.operation_vid
                         scope.is_active = active_value

--- a/src/dpmcore/services/ecb_validations_import.py
+++ b/src/dpmcore/services/ecb_validations_import.py
@@ -732,7 +732,7 @@ class EcbValidationsImportService:
                         )
                         continue
 
-                    def _module_vids(scope_obj: Any) -> tuple:
+                    def _module_vids(scope_obj: Any) -> tuple[int, ...]:
                         return tuple(
                             sorted(
                                 comp.module_vid

--- a/tests/integration/releases/test_release_filters_semantic.py
+++ b/tests/integration/releases/test_release_filters_semantic.py
@@ -78,15 +78,9 @@ def test_operands_check_headers_calls_filter_by_release_with_correct_args(
         operands_module, "filter_by_release", fake_filter_by_release
     )
 
-    # Stub out the pandas/SQLAlchemy helpers so the test doesn't touch
+    # Stub out the pandas/SQLAlchemy helper so the test doesn't touch
     # a real DB.
     import dpmcore.dpm_xl.model_queries as model_queries
-
-    monkeypatch.setattr(
-        model_queries,
-        "compile_query_for_pandas",
-        lambda stmt, session: stmt,
-    )
 
     def fake_read_sql(sql, session):
         return pd.DataFrame(

--- a/tests/unit/cli/test_cli_warnings.py
+++ b/tests/unit/cli/test_cli_warnings.py
@@ -1,0 +1,64 @@
+"""Tests for ``_print_capped_warnings``."""
+
+from unittest.mock import MagicMock
+
+from dpmcore.cli.main import _print_capped_warnings
+
+
+class TestPrintCappedWarnings:
+    def test_empty_list_prints_nothing(self):
+        console = MagicMock()
+
+        _print_capped_warnings(console, "Warning", [])
+
+        console.print.assert_not_called()
+
+    def test_small_list_prints_every_warning_without_omission_note(self):
+        console = MagicMock()
+
+        _print_capped_warnings(console, "Warning", ["a", "b"])
+
+        assert console.print.call_count == 2
+        printed = [call.args[0] for call in console.print.call_args_list]
+        assert "Warning:[/yellow] a" in printed[0]
+        assert "Warning:[/yellow] b" in printed[1]
+        assert not any("omitted" in line for line in printed)
+
+    def test_exactly_at_default_limit_prints_no_omission_note(self):
+        console = MagicMock()
+        warnings = [f"w{i}" for i in range(20)]
+
+        _print_capped_warnings(console, "Warning", warnings)
+
+        assert console.print.call_count == 20
+
+    def test_over_default_limit_caps_at_20_and_reports_the_rest(self):
+        console = MagicMock()
+        warnings = [f"w{i}" for i in range(25)]
+
+        _print_capped_warnings(console, "Warning", warnings)
+
+        assert console.print.call_count == 21
+        printed = [call.args[0] for call in console.print.call_args_list]
+        assert "w19" in printed[19]
+        assert "w20" not in printed[19]
+        assert "... and 5 more warning(s) omitted." in printed[20]
+
+    def test_respects_custom_limit(self):
+        console = MagicMock()
+
+        _print_capped_warnings(console, "Warning", ["a", "b", "c"], limit=2)
+
+        assert console.print.call_count == 3
+        printed = [call.args[0] for call in console.print.call_args_list]
+        assert "... and 1 more warning(s) omitted." in printed[2]
+
+    def test_label_is_lowercased_in_omission_note(self):
+        console = MagicMock()
+        warnings = [f"w{i}" for i in range(3)]
+
+        _print_capped_warnings(console, "Error", warnings, limit=1)
+
+        printed = [call.args[0] for call in console.print.call_args_list]
+        assert "Error:[/yellow] w0" in printed[0]
+        assert "2 more error(s) omitted." in printed[1]

--- a/tests/unit/dpm_xl/test_model_queries_cache.py
+++ b/tests/unit/dpm_xl/test_model_queries_cache.py
@@ -1,0 +1,103 @@
+"""Tests for engine/schema-aware query caching in ``model_queries``.
+
+Covers the fix where ``_get_engine_cache_key`` and
+``read_sql_with_connection`` started accounting for
+``schema_translate_map``: two sessions bound to the same engine URL but
+scoped to different schemas (e.g. distinct staging schemas, or staging
+vs. the default schema) must never share a cache entry.
+"""
+
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from dpmcore.dpm_xl import model_queries
+from dpmcore.orm.base import Base
+from dpmcore.orm.infrastructure import Release
+
+
+def _session_for(engine):
+    return sessionmaker(bind=engine)()
+
+
+class TestGetEngineCacheKey:
+    def test_same_engine_produces_equal_keys(self):
+        engine = create_engine("sqlite:///:memory:")
+
+        key_a = model_queries._get_engine_cache_key(_session_for(engine))
+        key_b = model_queries._get_engine_cache_key(_session_for(engine))
+
+        assert key_a == key_b
+
+    def test_schema_translate_map_changes_the_key(self):
+        engine = create_engine("sqlite:///:memory:")
+        scoped_engine = engine.execution_options(
+            schema_translate_map={None: "staging"}
+        )
+
+        plain_key = model_queries._get_engine_cache_key(
+            _session_for(engine)
+        )
+        scoped_key = model_queries._get_engine_cache_key(
+            _session_for(scoped_engine)
+        )
+
+        assert plain_key != scoped_key
+
+    def test_different_schemas_produce_different_keys(self):
+        engine = create_engine("sqlite:///:memory:")
+        engine_a = engine.execution_options(
+            schema_translate_map={None: "staging_a"}
+        )
+        engine_b = engine.execution_options(
+            schema_translate_map={None: "staging_b"}
+        )
+
+        key_a = model_queries._get_engine_cache_key(_session_for(engine_a))
+        key_b = model_queries._get_engine_cache_key(_session_for(engine_b))
+
+        assert key_a != key_b
+
+    def test_same_schema_translate_map_produces_equal_keys(self):
+        engine = create_engine("sqlite:///:memory:")
+        engine_a = engine.execution_options(
+            schema_translate_map={None: "staging"}
+        )
+        engine_b = engine.execution_options(
+            schema_translate_map={None: "staging"}
+        )
+
+        key_a = model_queries._get_engine_cache_key(_session_for(engine_a))
+        key_b = model_queries._get_engine_cache_key(_session_for(engine_b))
+
+        assert key_a == key_b
+
+
+class TestReadSqlWithConnection:
+    def test_returns_dataframe_matching_query_columns_and_rows(self):
+        engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(engine)
+        session = _session_for(engine)
+        session.add(Release(release_id=1, code="4.0"))
+        session.add(Release(release_id=2, code="4.2"))
+        session.commit()
+
+        stmt = select(Release.release_id, Release.code).order_by(
+            Release.release_id
+        )
+
+        df = model_queries.read_sql_with_connection(stmt, session)
+
+        assert list(df.columns) == ["release_id", "code"]
+        assert df["code"].tolist() == ["4.0", "4.2"]
+
+    def test_empty_result_returns_empty_dataframe_with_columns(self):
+        engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(engine)
+        session = _session_for(engine)
+
+        stmt = select(Release.release_id, Release.code)
+
+        df = model_queries.read_sql_with_connection(stmt, session)
+
+        assert df.empty
+        assert list(df.columns) == ["release_id", "code"]

--- a/tests/unit/dpm_xl/test_model_queries_cache.py
+++ b/tests/unit/dpm_xl/test_model_queries_cache.py
@@ -34,9 +34,7 @@ class TestGetEngineCacheKey:
             schema_translate_map={None: "staging"}
         )
 
-        plain_key = model_queries._get_engine_cache_key(
-            _session_for(engine)
-        )
+        plain_key = model_queries._get_engine_cache_key(_session_for(engine))
         scoped_key = model_queries._get_engine_cache_key(
             _session_for(scoped_engine)
         )

--- a/tests/unit/dpm_xl/test_operands_headers_cache.py
+++ b/tests/unit/dpm_xl/test_operands_headers_cache.py
@@ -60,7 +60,9 @@ def patched_query_helpers(monkeypatch):
         calls.append(session)
         return pd.DataFrame(columns=_HEADER_COLUMNS)
 
-    monkeypatch.setattr(model_queries, "read_sql_with_connection", fake_read_sql)
+    monkeypatch.setattr(
+        model_queries, "read_sql_with_connection", fake_read_sql
+    )
     return calls
 
 

--- a/tests/unit/dpm_xl/test_operands_headers_cache.py
+++ b/tests/unit/dpm_xl/test_operands_headers_cache.py
@@ -1,0 +1,122 @@
+"""Tests for the schema-aware ``_HEADERS_CACHE`` in ``OperandsChecking``.
+
+Before the fix, ``_HEADERS_CACHE`` keyed cached header lookups only by
+engine URL. Two sessions bound to the same engine URL but scoped to
+different schemas (e.g. two distinct staging schemas from separate
+``update-db`` runs, or a staging schema vs. the default schema) would
+collide on the same cache entry and silently reuse headers resolved
+against the wrong schema. This module verifies ``check_headers`` now
+keys its cache on ``schema_translate_map`` too.
+"""
+
+import pandas as pd
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+import dpmcore.dpm_xl.model_queries as model_queries
+from dpmcore.dpm_xl.ast import operands as operands_module
+
+_HEADER_COLUMNS = [
+    "Code",
+    "StartReleaseID",
+    "EndReleaseID",
+    "Direction",
+    "HasOpenRows",
+    "HasOpenColumns",
+    "HasOpenSheets",
+]
+
+
+@pytest.fixture(autouse=True)
+def _clear_headers_cache():
+    yield
+    operands_module._HEADERS_CACHE.clear()
+
+
+def _make_oc(session, table="C_01.00"):
+    oc = object.__new__(operands_module.OperandsChecking)
+    oc.session = session
+    oc.release_id = 5
+    oc.tables = {table: {}}
+    return oc
+
+
+@pytest.fixture
+def patched_query_helpers(monkeypatch):
+    """Stub the pieces that would otherwise hit a real DB.
+
+    Returns the list of sessions ``read_sql_with_connection`` was
+    called with, so tests can assert how many times the "DB" was
+    actually queried.
+    """
+    monkeypatch.setattr(
+        operands_module, "filter_by_release", lambda query, **kwargs: query
+    )
+
+    calls = []
+
+    def fake_read_sql(stmt, session):
+        calls.append(session)
+        return pd.DataFrame(columns=_HEADER_COLUMNS)
+
+    monkeypatch.setattr(model_queries, "read_sql_with_connection", fake_read_sql)
+    return calls
+
+
+class TestHeadersCacheSchemaAwareness:
+    def test_different_schema_translate_maps_both_query_the_db(
+        self, patched_query_helpers
+    ):
+        engine = create_engine("sqlite:///:memory:")
+        engine_a = engine.execution_options(
+            schema_translate_map={None: "staging_a"}
+        )
+        engine_b = engine.execution_options(
+            schema_translate_map={None: "staging_b"}
+        )
+
+        _make_oc(sessionmaker(bind=engine_a)()).check_headers()
+        _make_oc(sessionmaker(bind=engine_b)()).check_headers()
+
+        assert len(patched_query_helpers) == 2
+
+    def test_schema_scoped_and_unscoped_sessions_both_query_the_db(
+        self, patched_query_helpers
+    ):
+        engine = create_engine("sqlite:///:memory:")
+        scoped_engine = engine.execution_options(
+            schema_translate_map={None: "staging"}
+        )
+
+        _make_oc(sessionmaker(bind=engine)()).check_headers()
+        _make_oc(sessionmaker(bind=scoped_engine)()).check_headers()
+
+        assert len(patched_query_helpers) == 2
+
+    def test_same_schema_translate_map_reuses_cached_result(
+        self, patched_query_helpers
+    ):
+        engine = create_engine("sqlite:///:memory:")
+        engine_a = engine.execution_options(
+            schema_translate_map={None: "staging"}
+        )
+        engine_b = engine.execution_options(
+            schema_translate_map={None: "staging"}
+        )
+
+        _make_oc(sessionmaker(bind=engine_a)()).check_headers()
+        _make_oc(sessionmaker(bind=engine_b)()).check_headers()
+
+        assert len(patched_query_helpers) == 1
+
+    def test_repeated_call_on_same_session_reuses_cached_result(
+        self, patched_query_helpers
+    ):
+        engine = create_engine("sqlite:///:memory:")
+        oc = _make_oc(sessionmaker(bind=engine)())
+
+        oc.check_headers()
+        oc.check_headers()
+
+        assert len(patched_query_helpers) == 1

--- a/tests/unit/migration/test_ecb_validations_import.py
+++ b/tests/unit/migration/test_ecb_validations_import.py
@@ -10,6 +10,7 @@ from dpmcore.orm.infrastructure import Organisation
 from dpmcore.services.ecb_validations_import import (
     EcbValidationsImportError,
     EcbValidationsImportService,
+    _format_warnings,
     _stable_uuid,
 )
 
@@ -804,6 +805,102 @@ class TestEcbValidationsImport:
                 match="Failed to import ECB validations",
             ):
                 service_with_schema.import_csv(str(csv_file))
+
+    def test_import_csv_raises_when_commit_persists_nothing(
+        self, service_with_schema, tmp_path
+    ):
+        """A hollow commit (no ECB org row) must surface as an error.
+
+        Regression test for the "silent transaction abort" failure mode:
+        a swallowed mid-loop DB error can leave ``session.commit()``
+        succeeding with nothing actually persisted. Simulated here by
+        stubbing out ``_import_ecb_validations_df`` entirely, so the
+        session commits without ever creating the ECB organisation.
+        """
+        csv_file = tmp_path / "valid.csv"
+        csv_file.write_text(
+            "vr_code,start_release\nV1,4.0\n", encoding="utf-8"
+        )
+
+        with patch.object(
+            service_with_schema,
+            "_import_ecb_validations_df",
+            return_value=MagicMock(),
+        ):
+            with pytest.raises(
+                EcbValidationsImportError,
+                match="no data was persisted",
+            ):
+                service_with_schema.import_csv(str(csv_file))
+
+
+# ---------------------------------------------------------------------------
+# _verify_persisted
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyPersisted:
+    def test_passes_silently_when_ecb_organisation_exists(
+        self, service_with_schema, sqlite_engine_with_schema
+    ):
+        session = sessionmaker(bind=sqlite_engine_with_schema)()
+        try:
+            session.add(
+                Organisation(
+                    org_id=1,
+                    name="European Central Bank",
+                    acronym="ECB",
+                    id_prefix=1,
+                )
+            )
+            session.commit()
+        finally:
+            session.close()
+
+        service_with_schema._verify_persisted([])
+
+    def test_raises_when_no_ecb_organisation_exists(self, service_with_schema):
+        with pytest.raises(
+            EcbValidationsImportError,
+            match="no data was persisted",
+        ):
+            service_with_schema._verify_persisted([])
+
+    def test_error_message_includes_warnings(self, service_with_schema):
+        with pytest.raises(EcbValidationsImportError, match="oops"):
+            service_with_schema._verify_persisted(["oops"])
+
+
+# ---------------------------------------------------------------------------
+# _format_warnings
+# ---------------------------------------------------------------------------
+
+
+class TestFormatWarnings:
+    def test_empty_list_returns_no_warnings_message(self):
+        assert (
+            _format_warnings([])
+            == " No warnings were logged during the run."
+        )
+
+    def test_small_list_shows_all_warnings_without_omission_note(self):
+        result = _format_warnings(["a", "b"])
+        assert result == " Warnings logged: ['a', 'b']"
+        assert "omitted" not in result
+
+    def test_caps_at_default_limit_of_20(self):
+        warnings = [f"warning-{i}" for i in range(25)]
+
+        result = _format_warnings(warnings)
+
+        assert "warning-19" in result
+        assert "warning-20" not in result
+        assert "(+5 more omitted)" in result
+
+    def test_respects_custom_limit(self):
+        result = _format_warnings(["a", "b", "c"], limit=2)
+
+        assert result == " Warnings logged: ['a', 'b'] (+1 more omitted)"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/migration/test_ecb_validations_import.py
+++ b/tests/unit/migration/test_ecb_validations_import.py
@@ -580,6 +580,42 @@ class TestEcbValidationsImport:
 
         assert result == set()
 
+    def test_extract_table_codes_for_expression_records_warnings_on_failure(
+        self, service_with_schema, sqlite_engine_with_schema
+    ):
+        session = sessionmaker(bind=sqlite_engine_with_schema)()
+        warnings: list = []
+
+        with (
+            patch(
+                "dpmcore.services.ecb_validations_import.SyntaxService"
+            ) as syntax_cls,
+            patch(
+                "dpmcore.services.ecb_validations_import.OperandsChecking"
+            ) as checker_cls,
+        ):
+            syntax_cls.return_value.parse.return_value = object()
+            checker_cls.side_effect = RuntimeError("cannot inspect tables")
+
+            result = service_with_schema._extract_table_codes_for_expression(
+                session,
+                expression="broken expression",
+                start_release_id=1,
+                latest_release_id=2,
+                warnings=warnings,
+            )
+
+        session.close()
+
+        assert result == set()
+        assert len(warnings) == 2
+        assert all(
+            "Table code resolution failed for expression" in w
+            for w in warnings
+        )
+        assert "release 1" in warnings[0]
+        assert "release 2" in warnings[1]
+
     def test_create_table_references_returns_zero_when_no_table_codes(
         self, service_with_schema, sqlite_engine_with_schema
     ):

--- a/tests/unit/migration/test_ecb_validations_import.py
+++ b/tests/unit/migration/test_ecb_validations_import.py
@@ -879,8 +879,7 @@ class TestVerifyPersisted:
 class TestFormatWarnings:
     def test_empty_list_returns_no_warnings_message(self):
         assert (
-            _format_warnings([])
-            == " No warnings were logged during the run."
+            _format_warnings([]) == " No warnings were logged during the run."
         )
 
     def test_small_list_shows_all_warnings_without_omission_note(self):

--- a/tests/unit/migration/test_migration_service.py
+++ b/tests/unit/migration/test_migration_service.py
@@ -1050,8 +1050,8 @@ class TestLoadTableIdentityInsert:
 def _postgres_engine_mock() -> MagicMock:
     engine = MagicMock()
     engine.dialect.name = "postgresql"
-    engine.dialect.identifier_preparer.quote_schema.side_effect = (
-        lambda s: f'"{s}"'
+    engine.dialect.identifier_preparer.quote_schema.side_effect = lambda s: (
+        f'"{s}"'
     )
     engine.dialect.identifier_preparer.quote.side_effect = lambda s: f'"{s}"'
     return engine

--- a/tests/unit/migration/test_migration_service.py
+++ b/tests/unit/migration/test_migration_service.py
@@ -1040,3 +1040,106 @@ class TestLoadTableIdentityInsert:
 
         sqls = [str(c.args[0]) for c in conn.execute.call_args_list]
         assert any("OFF" in s for s in sqls)
+
+
+# ---------------------------------------------------------------------------
+# _resync_postgresql_sequences
+# ---------------------------------------------------------------------------
+
+
+def _postgres_engine_mock() -> MagicMock:
+    engine = MagicMock()
+    engine.dialect.name = "postgresql"
+    engine.dialect.identifier_preparer.quote_schema.side_effect = (
+        lambda s: f'"{s}"'
+    )
+    engine.dialect.identifier_preparer.quote.side_effect = lambda s: f'"{s}"'
+    return engine
+
+
+class TestResyncPostgresqlSequences:
+    def test_noop_when_dialect_is_not_postgresql(self):
+        engine = MagicMock()
+        engine.dialect.name = "sqlite"
+        service = MigrationService(engine, schema="staging")
+
+        service._resync_postgresql_sequences({"Organisation": None})
+
+        engine.begin.assert_not_called()
+
+    def test_noop_when_schema_is_none(self):
+        engine = _postgres_engine_mock()
+        service = MigrationService(engine, schema=None)
+
+        service._resync_postgresql_sequences({"Organisation": None})
+
+        engine.begin.assert_not_called()
+
+    def test_resyncs_sequence_for_single_pk_table(self):
+        engine = _postgres_engine_mock()
+        conn = engine.begin.return_value.__enter__.return_value
+        conn.execute.side_effect = [
+            MagicMock(scalar=lambda: "staging.organisation_orgid_seq"),
+            MagicMock(scalar=lambda: 42),
+            MagicMock(),
+        ]
+
+        service = MigrationService(engine, schema="staging")
+        service._resync_postgresql_sequences({"Organisation": None})
+
+        assert conn.execute.call_count == 3
+
+        sequence_call, max_call, setval_call = conn.execute.call_args_list
+        assert sequence_call.args[1] == {
+            "table": '"staging"."Organisation"',
+            "column": "OrgID",
+        }
+        assert "MAX" in str(max_call.args[0])
+        assert '"staging"."Organisation"' in str(max_call.args[0])
+        assert setval_call.args[1] == {
+            "sequence": "staging.organisation_orgid_seq",
+            "max_id": 42,
+        }
+
+    def test_skips_table_not_known_to_orm(self):
+        engine = _postgres_engine_mock()
+        conn = engine.begin.return_value.__enter__.return_value
+
+        service = MigrationService(engine, schema="staging")
+        service._resync_postgresql_sequences({"NotARealTable": None})
+
+        conn.execute.assert_not_called()
+
+    def test_skips_table_with_composite_primary_key(self):
+        engine = _postgres_engine_mock()
+        conn = engine.begin.return_value.__enter__.return_value
+
+        service = MigrationService(engine, schema="staging")
+        service._resync_postgresql_sequences(
+            {"OperationScopeComposition": None}
+        )
+
+        conn.execute.assert_not_called()
+
+    def test_skips_when_column_has_no_serial_sequence(self):
+        engine = _postgres_engine_mock()
+        conn = engine.begin.return_value.__enter__.return_value
+        conn.execute.side_effect = [MagicMock(scalar=lambda: None)]
+
+        service = MigrationService(engine, schema="staging")
+        service._resync_postgresql_sequences({"Organisation": None})
+
+        assert conn.execute.call_count == 1
+
+    def test_skips_when_table_is_empty(self):
+        engine = _postgres_engine_mock()
+        conn = engine.begin.return_value.__enter__.return_value
+        conn.execute.side_effect = [
+            MagicMock(scalar=lambda: "staging.organisation_orgid_seq"),
+            MagicMock(scalar=lambda: None),
+        ]
+
+        service = MigrationService(engine, schema="staging")
+        service._resync_postgresql_sequences({"Organisation": None})
+
+        assert conn.execute.call_count == 2

--- a/tests/unit/orm/_schema_snapshot.txt
+++ b/tests/unit/orm/_schema_snapshot.txt
@@ -311,6 +311,7 @@ TABLE OperationNode
   COL UseIntervalArithmetics pg=BOOLEAN mssql=BIT null=True pk=False ai=auto fks=
   PK NodeID
 TABLE OperationScope
+  COL CreatedReleaseID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Release.ReleaseID
   COL FromSubmissionDate pg=DATE mssql=DATETIME null=True pk=False ai=auto fks=
   COL IsActive pg=SMALLINT mssql=SMALLINT null=True pk=False ai=auto fks=
   COL OperationScopeID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=
@@ -363,6 +364,7 @@ TABLE Organisation
   COL Name pg=VARCHAR(200) mssql=VARCHAR(200) null=True pk=False ai=auto fks=
   COL OrgID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=
   COL RowGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=True pk=False ai=auto fks=Concept.ConceptGUID
+  COL URL pg=VARCHAR(255) mssql=VARCHAR(255) null=True pk=False ai=auto fks=
   PK OrgID
   UNIQUE IDPrefix
   UNIQUE Name


### PR DESCRIPTION
Running `dpmcore update-db` against a local SQLite target worked, but a remote PostgreSQL target hit two problems: the process got stuck in a loop, and `--keep-staging` runs leaked queries against the `public` schema instead of the staging schema.

Root causes and fixes:
- Query result caches (`_HEADERS_CACHE` in ast/operands.py, `_TABLE_DATA_CACHE`/`_get_engine_cache_key` in model_queries.py) keyed only on engine URL, not on `schema_translate_map`. Two sessions bound to the same engine URL but scoped to different schemas (staging vs. `public`) collided on the same cache entry, silently reusing headers resolved against the wrong schema.
- `read_sql_with_connection` compiled queries to a literal SQL string and ran them over a raw DBAPI connection. `schema_translate_map` is only honored by SQLAlchemy at real statement-execution time, so the compiled string always resolved unqualified table names against the connection's default `search_path` (`public`). Now executes via `session.execute()` directly.
- PostgreSQL never advances a SERIAL sequence when `df.to_sql` inserts explicit PK values from the Access source, so a later ORM insert relying on the sequence default (e.g. a new `OperationScope` row) could collide with a just-loaded row. `MigrationService` now resyncs each loaded table's sequence to `MAX(pk)` after bulk loading.
- A DB error mid-import (e.g. a transient network failure against a remote target) could be swallowed without an explicit rollback, leaving `session.commit()` succeeding with nothing persisted. `EcbValidationsImportService` now verifies persistence after commit and raises instead of reporting a false success.
- Two ORM columns present in the latest DPM database update were missing from the ORM/Django models: `Organisation.url` and `OperationScope.created_release_id`.

Verified locally: SQLite and local PostgreSQL targets now produce byte-identical row counts across all 70 tables after a full `update-db` run from the same Access source.

## Summary

<!-- Short description of the change and why it's needed. -->

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [ ] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [ ] Documentation updated (if applicable)

## Impact / Risk

- Breaking changes? (public API / CLI / REST endpoints / Django models)
- Database schema or migration concerns?
- Notes for release/changelog?

## Notes

<!-- Follow-ups, TODOs, or anything reviewers should know. -->
