### PR TITLE
fix(dpm-xl): resolve cell ranges by stored display

### DIFF
--- a/src/dpmcore/dpm_xl/ast/ml_generation.py
+++ b/src/dpmcore/dpm_xl/ast/ml_generation.py
@@ -158,9 +158,21 @@ class MLGeneration(ASTTemplate):
         data_filtered = filter_all_data(
             self.data, table, rows or [], cols or [], sheets or []
         )
-        data_filtered = data_filtered[
-            ["row_code", "column_code", "sheet_code", "variable_id", "cell_id"]
+        # Keep the *_order columns so generate_xyz can rank X/Y/Z by the
+        # stored display order; it drops them again before returning records.
+        projection = [
+            "row_code",
+            "column_code",
+            "sheet_code",
+            "variable_id",
+            "cell_id",
         ]
+        projection += [
+            col
+            for col in ("row_order", "column_order", "sheet_order")
+            if col in data_filtered.columns
+        ]
+        data_filtered = data_filtered[projection]
 
         list_xyz = generate_xyz(data_filtered)
 

--- a/src/dpmcore/dpm_xl/ast/operands.py
+++ b/src/dpmcore/dpm_xl/ast/operands.py
@@ -48,6 +48,10 @@ from dpmcore.dpm_xl.utils.operands_mapping import (
     generate_new_label,
     set_operand_label,
 )
+from dpmcore.dpm_xl.utils.range_resolution import (
+    build_axis_order_map,
+    sort_by_order,
+)
 from dpmcore.errors import SemanticError
 from dpmcore.orm.rendering import (
     Header,
@@ -146,24 +150,47 @@ def _expand_ranges_from_data(node: VarID, node_data: pd.DataFrame) -> None:
 
     # Expand rows if they contain range syntax
     if _has_range_syntax(node.rows):
-        actual_rows = list(node_data["row_code"].dropna().unique().tolist())
+        actual_rows = _sorted_axis_codes(node_data, "row_code", "row_order")
         if actual_rows:
-            # Sort to maintain consistent ordering
-            node.rows = sorted(actual_rows)
+            node.rows = actual_rows
 
     # Expand cols if they contain range syntax
     if _has_range_syntax(node.cols):
-        actual_cols = list(node_data["column_code"].dropna().unique().tolist())
+        actual_cols = _sorted_axis_codes(
+            node_data, "column_code", "column_order"
+        )
         if actual_cols:
-            node.cols = sorted(actual_cols)
+            node.cols = actual_cols
 
     # Expand sheets if they contain range syntax
     if _has_range_syntax(node.sheets):
-        actual_sheets = list(
-            node_data["sheet_code"].dropna().unique().tolist()
+        actual_sheets = _sorted_axis_codes(
+            node_data, "sheet_code", "sheet_order"
         )
         if actual_sheets:
-            node.sheets = sorted(actual_sheets)
+            node.sheets = actual_sheets
+
+
+def _sorted_axis_codes(
+    node_data: pd.DataFrame, code_col: str, order_col: str
+) -> list[str]:
+    """Return the distinct codes of one axis in display order.
+
+    Sorts by the stored order (``*_order``) when that column is present and
+    fully populated; otherwise falls back to a lexicographic sort so codes
+    without a usable order stay deterministic.
+    """
+    codes = node_data[code_col].dropna().unique().tolist()
+    if not codes:
+        return []
+    order_map = (
+        build_axis_order_map(node_data[code_col], node_data[order_col])
+        if order_col in node_data.columns
+        else None
+    )
+    if order_map:
+        return sort_by_order(codes, order_map)
+    return sorted(codes)
 
 
 class OperandsChecking(ASTTemplate, ABC):

--- a/src/dpmcore/dpm_xl/model_queries.py
+++ b/src/dpmcore/dpm_xl/model_queries.py
@@ -23,6 +23,7 @@ from sqlalchemy import and_, func, or_
 from sqlalchemy.orm import aliased
 
 from dpmcore.dpm_xl.utils.filters import filter_by_release
+from dpmcore.dpm_xl.utils.range_resolution import resolve_range_codes
 from dpmcore.orm.glossary import (
     Item,
     ItemCategory,
@@ -1266,6 +1267,15 @@ class ViewDatapointsQuery:
         pd.DataFrame,
     ] = {}
 
+    # ``{axis: {code: order}}`` per (engine, table, release). An axis maps to
+    # ``None`` when it is not fully ordered (a code without a stored order, or
+    # a code with two orders) so range resolution falls back to string
+    # comparison for that whole axis.
+    _AXIS_ORDER_CACHE: dict[
+        tuple[Hashable, str, int | None],
+        dict[str, dict[str, int] | None],
+    ] = {}
+
     # -- internal helpers ------------------------------------------ #
 
     @staticmethod
@@ -1401,6 +1411,102 @@ class ViewDatapointsQuery:
         }
         return query, aliases
 
+    @classmethod
+    def get_axis_orders(
+        cls,
+        session: "Session",
+        table: str,
+        release_id: int | None = None,
+    ) -> dict[str, dict[str, int] | None]:
+        """Return the ``{code: order}`` display order per axis of a table.
+
+        The stored order is ``TableVersionHeader.Order``; this is the single
+        source of truth used to resolve ranges by display order instead of by
+        code text (mirroring ``load_release_sort_orders`` for releases).
+
+        An axis maps to ``None`` when it is **not fully ordered** — some code
+        lacks a stored order (the column is nullable and some headers have no
+        ``TableVersionHeader`` row) or a code carries two different orders.
+        Callers then fall back to string comparison for that whole axis, so
+        order-based and string-based comparison are never mixed within an axis.
+
+        Results are cached per engine + table + release. The table and release
+        scoping mirrors :meth:`get_table_data` so the map matches the code
+        universe of the data query.
+
+        Args:
+            session: SQLAlchemy session.
+            table: Table version code.
+            release_id: Optional release filter.
+
+        Returns:
+            ``{"rows"/"cols"/"sheets": {code: order} | None}``.
+        """
+        engine_key = _get_engine_cache_key(session)
+        cache_key = (engine_key, table, release_id)
+        cached = cls._AXIS_ORDER_CACHE.get(cache_key)
+        if cached is not None:
+            return cached
+
+        query, aliases = cls._create_base_query_with_aliases(session)
+        query = query.add_columns(
+            aliases["hvr"].code.label("row_code"),
+            aliases["hvc"].code.label("column_code"),
+            aliases["hvs"].code.label("sheet_code"),
+            aliases["tvh_row"].order.label("row_order"),
+            aliases["tvh_col"].order.label("column_order"),
+            aliases["tvh_sheet"].order.label("sheet_order"),
+        ).distinct()
+
+        query = query.filter(TableVersion.code == table)
+        if release_id is None:
+            query = query.filter(TableVersion.end_release_id.is_(None))
+        else:
+            query = filter_by_release(
+                query,
+                start_col=ModuleVersion.start_release_id,
+                end_col=ModuleVersion.end_release_id,
+                release_id=release_id,
+            )
+
+        data = read_sql_with_connection(
+            compile_query_for_pandas(query.statement, session),
+            session,
+        )
+
+        axes = {
+            "rows": ("row_code", "row_order"),
+            "cols": ("column_code", "column_order"),
+            "sheets": ("sheet_code", "sheet_order"),
+        }
+        result: dict[str, dict[str, int] | None] = {}
+        for axis, (code_col, order_col) in axes.items():
+            result[axis] = _build_axis_order_map(data, code_col, order_col)
+
+        cls._AXIS_ORDER_CACHE[cache_key] = result
+        return result
+
+    @classmethod
+    def _axis_orders_for(
+        cls,
+        session: "Session",
+        table: str,
+        release_id: int | None,
+        selections: tuple[Sequence[str] | None, ...],
+    ) -> dict[str, dict[str, int] | None]:
+        """Return per-axis order maps, querying only when a range is present.
+
+        Non-range selectors never consult the display order, so the
+        ``get_axis_orders`` query is skipped and every axis maps to ``None``
+        (a no-op for plain ``IN`` / ``==`` selectors).
+        """
+        has_range = any(
+            v is not None and any("-" in x for x in v) for v in selections
+        )
+        if not has_range:
+            return {"rows": None, "cols": None, "sheets": None}
+        return cls.get_axis_orders(session, table, release_id)
+
     # -- public methods -------------------------------------------- #
 
     @classmethod
@@ -1452,6 +1558,9 @@ class ViewDatapointsQuery:
             aliases["hvr"].code.label("row_code"),
             aliases["hvc"].code.label("column_code"),
             aliases["hvs"].code.label("sheet_code"),
+            aliases["tvh_row"].order.label("row_order"),
+            aliases["tvh_col"].order.label("column_order"),
+            aliases["tvh_sheet"].order.label("sheet_order"),
             VariableVersion.variable_id.label("variable_id"),
             DataType.code.label("data_type"),
             TableVersion.table_vid.label("table_vid"),
@@ -1465,17 +1574,31 @@ class ViewDatapointsQuery:
         if release_id is None:
             query = query.filter(TableVersion.end_release_id.is_(None))
 
+        # Range endpoints are resolved against the stored display order, not
+        # the code text; ``get_axis_orders`` supplies the per-axis map (or
+        # ``None`` when the axis has no usable order -> string fallback). Only
+        # fetch it when a range is actually present.
+        axis_orders = cls._axis_orders_for(
+            session, table, release_id, (rows, cols, sheets)
+        )
+
         # Row filter
         if rows is not None and rows != ["*"]:
-            query = _apply_dimension_filter(query, aliases["hvr"].code, rows)
+            query = _apply_dimension_filter(
+                query, aliases["hvr"].code, rows, axis_orders["rows"]
+            )
 
         # Column filter
         if cols is not None and cols != ["*"]:
-            query = _apply_dimension_filter(query, aliases["hvc"].code, cols)
+            query = _apply_dimension_filter(
+                query, aliases["hvc"].code, cols, axis_orders["cols"]
+            )
 
         # Sheet filter
         if sheets is not None and sheets != ["*"]:
-            query = _apply_dimension_filter(query, aliases["hvs"].code, sheets)
+            query = _apply_dimension_filter(
+                query, aliases["hvs"].code, sheets, axis_orders["sheets"]
+            )
 
         if release_id is not None:
             query = filter_by_release(
@@ -1524,6 +1647,9 @@ class ViewDatapointsQuery:
             aliases["hvr"].code.label("row_code"),
             aliases["hvc"].code.label("column_code"),
             aliases["hvs"].code.label("sheet_code"),
+            aliases["tvh_row"].order.label("row_order"),
+            aliases["tvh_col"].order.label("column_order"),
+            aliases["tvh_sheet"].order.label("sheet_order"),
             VariableVersion.variable_id.label("variable_id"),
             DataType.code.label("data_type"),
             TableVersion.table_vid.label("table_vid"),
@@ -1537,6 +1663,16 @@ class ViewDatapointsQuery:
 
         query = query.filter(TableVersion.code == table)
 
+        axis_orders = cls._axis_orders_for(
+            session,
+            table,
+            release_id,
+            (
+                table_info.get("rows"),
+                table_info.get("cols"),
+                table_info.get("sheets"),
+            ),
+        )
         mapping = {
             "rows": aliases["hvr"].code,
             "cols": aliases["hvc"].code,
@@ -1544,14 +1680,11 @@ class ViewDatapointsQuery:
         }
         for key, values in table_info.items():
             if values is not None and key in mapping:
-                col = mapping[key]
-                if "-" in values[0]:
-                    lo, hi = values[0].split("-")
-                    query = query.filter(col.between(lo, hi))
-                elif values[0] == "*":
-                    continue
-                else:
-                    query = query.filter(col.in_(values))
+                clause = _dimension_clause(
+                    mapping[key], values, axis_orders[key]
+                )
+                if clause is not None:
+                    query = query.filter(clause)
 
         if release_id:
             query = filter_by_release(
@@ -1567,38 +1700,122 @@ class ViewDatapointsQuery:
         )
 
 
+def _build_axis_order_map(
+    data: pd.DataFrame, code_col: str, order_col: str
+) -> dict[str, int] | None:
+    """Build ``{code: order}`` for one axis from a distinct code/order frame.
+
+    Returns ``None`` when the axis is not fully ordered — any present code
+    lacks an order, or a code carries two different orders — so the caller
+    falls back to string comparison for that whole axis.
+    """
+    if code_col not in data.columns or order_col not in data.columns:
+        return None
+    sub = data[[code_col, order_col]].drop_duplicates()
+    sub = sub[sub[code_col].notna()]
+    if sub.empty:
+        return {}
+    if sub[order_col].isna().any():
+        return None
+    if sub.groupby(code_col)[order_col].nunique().gt(1).any():
+        return None
+    return {
+        str(code): int(order)
+        for code, order in zip(sub[code_col], sub[order_col], strict=False)
+    }
+
+
+def _resolve_dimension_values(
+    values: Sequence[str],
+    order_map: dict[str, int] | None,
+) -> tuple[set[str], list[tuple[str, str]]]:
+    """Split axis selectors into concrete codes and unresolved ranges.
+
+    Range selectors are expanded to their spanned codes via the display-order
+    map. A range that cannot be resolved by order — reversed, or the axis has
+    no usable order — is returned as an ``(lo, hi)`` endpoint pair for the
+    caller to handle (widen or string ``between``). Wildcards (``*``) are
+    skipped: they mean "the whole axis", i.e. no filter.
+
+    Returns:
+        ``(codes, unresolved_ranges)``.
+    """
+    codes: set[str] = set()
+    unresolved: list[tuple[str, str]] = []
+    for value in values:
+        if value == "*":
+            continue
+        if "-" in value:
+            lo, hi = value.split("-")
+            spanned = (
+                resolve_range_codes(order_map, lo, hi) if order_map else []
+            )
+            if spanned:
+                codes.update(spanned)
+            else:
+                unresolved.append((lo, hi))
+        else:
+            codes.add(value)
+    return codes, unresolved
+
+
 def _apply_dimension_filter(
     query: "Query[Any]",
     # column is either a SQLAlchemy ColumnElement or an InstrumentedAttribute
     # from ORM; see _filter_elements for rationale.
     column: Any,
     values: Sequence[str],
+    order_map: dict[str, int] | None,
 ) -> "Query[Any]":
-    """Apply row/col/sheet dimension filter.
+    """Apply a row/col/sheet dimension filter for ``get_table_data``.
+
+    Ranges are resolved to concrete codes by display order and filtered with
+    ``IN``. If a range cannot be resolved by order (reversed, or the axis is
+    not fully ordered), the axis filter is **widened** — dropped entirely —
+    rather than compared by code text: ``get_table_data`` is always re-filtered
+    by the order-aware ``filter_all_data`` pass, which stays the authoritative
+    narrower and the source of the ``1-2`` endpoint error, so it must never
+    under-fetch.
 
     Args:
         query: SQLAlchemy query.
         column: Header code column.
         values: List of filter values (may have ranges).
+        order_map: ``{code: order}`` for this axis, or ``None`` when the axis
+            has no usable order.
 
     Returns:
         Filtered query.
     """
-    if len(values) == 1 and "-" in values[0]:
-        lo, hi = values[0].split("-")
-        return query.filter(column.between(lo, hi))
+    codes, unresolved = _resolve_dimension_values(values, order_map)
+    if unresolved:
+        return query
+    if not codes:
+        return query
+    return query.filter(column.in_(codes))
 
-    has_range = any("-" in x for x in values)
-    if has_range:
-        filters: list[Any] = []
-        for v in values:
-            if "-" in v:
-                lo, hi = v.split("-")
-                filters.append(column.between(lo, hi))
-            else:
-                filters.append(column == v)
-        return query.filter(or_(*filters))
-    return query.filter(column.in_(values))
+
+def _dimension_clause(
+    column: Any,
+    values: Sequence[str],
+    order_map: dict[str, int] | None,
+) -> Any | None:
+    """Build a dimension filter clause for ``get_filtered_datapoints``.
+
+    Like :func:`_apply_dimension_filter` but returns a clause instead of
+    widening: a range that cannot be resolved by order falls back to a string
+    ``between`` (this method's result is used directly, without a pandas
+    re-filter, so it must still narrow). Returns ``None`` when there is nothing
+    to filter (e.g. an all-wildcard selection).
+    """
+    codes, unresolved = _resolve_dimension_values(values, order_map)
+    clauses: list[Any] = []
+    if codes:
+        clauses.append(column.in_(codes))
+    clauses.extend(column.between(lo, hi) for lo, hi in unresolved)
+    if not clauses:
+        return None
+    return or_(*clauses)
 
 
 # ------------------------------------------------------------------ #

--- a/src/dpmcore/dpm_xl/model_queries.py
+++ b/src/dpmcore/dpm_xl/model_queries.py
@@ -23,7 +23,10 @@ from sqlalchemy import and_, func, or_
 from sqlalchemy.orm import aliased
 
 from dpmcore.dpm_xl.utils.filters import filter_by_release
-from dpmcore.dpm_xl.utils.range_resolution import resolve_range_codes
+from dpmcore.dpm_xl.utils.range_resolution import (
+    build_axis_order_map,
+    resolve_range_codes,
+)
 from dpmcore.orm.glossary import (
     Item,
     ItemCategory,
@@ -1703,26 +1706,17 @@ class ViewDatapointsQuery:
 def _build_axis_order_map(
     data: pd.DataFrame, code_col: str, order_col: str
 ) -> dict[str, int] | None:
-    """Build ``{code: order}`` for one axis from a distinct code/order frame.
+    """Build ``{code: order}`` for one axis from a code/order frame.
 
-    Returns ``None`` when the axis is not fully ordered — any present code
-    lacks an order, or a code carries two different orders — so the caller
-    falls back to string comparison for that whole axis.
+    Thin ``DataFrame`` adapter over
+    :func:`~dpmcore.dpm_xl.utils.range_resolution.build_axis_order_map`:
+    returns ``None`` when the axis is not fully ordered — the order column is
+    absent, some present code lacks an order, or a code carries two different
+    orders — so the caller falls back to string comparison for that whole axis.
     """
     if code_col not in data.columns or order_col not in data.columns:
         return None
-    sub = data[[code_col, order_col]].drop_duplicates()
-    sub = sub[sub[code_col].notna()]
-    if sub.empty:
-        return {}
-    if sub[order_col].isna().any():
-        return None
-    if sub.groupby(code_col)[order_col].nunique().gt(1).any():
-        return None
-    return {
-        str(code): int(order)
-        for code, order in zip(sub[code_col], sub[order_col], strict=False)
-    }
+    return build_axis_order_map(data[code_col], data[order_col])
 
 
 def _resolve_dimension_values(

--- a/src/dpmcore/dpm_xl/utils/data_handlers.py
+++ b/src/dpmcore/dpm_xl/utils/data_handlers.py
@@ -3,8 +3,19 @@ from typing import Any, cast
 
 import pandas as pd
 
+from dpmcore.dpm_xl.utils.range_resolution import (
+    build_axis_order_map,
+    sort_by_order,
+)
 from dpmcore.dpm_xl.utils.tokens import *
 from dpmcore.errors import SemanticError
+
+# Stored-order column that carries the display order for each *_code column.
+_ORDER_COLUMN = {
+    ROW_CODE: ROW_ORDER,
+    COLUMN_CODE: COLUMN_ORDER,
+    SHEET_CODE: SHEET_ORDER,
+}
 
 
 def _raise_cells_not_found(
@@ -60,6 +71,7 @@ def filter_data_by_cell_element(
     element_name: str,
     table_code: str,
     valid_codes: set[str] | None = None,
+    order_map: dict[str, int] | None = None,
 ) -> pd.DataFrame:
     """Filter data by cell elements.
 
@@ -74,16 +86,40 @@ def filter_data_by_cell_element(
         table-wide set, so a range endpoint that is a real code but does
         not intersect the already-selected cells is not misreported as a
         missing cell.
+    :param order_map: the table-wide ``{code: order}`` display order for
+        ``element_name``. When provided (the axis is fully ordered), range
+        membership follows the stored order instead of the code text, so
+        non-numeric / non-padded / mixed-width codes resolve correctly. A
+        reversed range (``order[lo] > order[hi]``) resolves to nothing,
+        preserving today's "cell not found" behaviour. When ``None`` the code
+        text is compared, as before.
     :return: filtered data.
     """
     if valid_codes is None:
         valid_codes = set(series[element_name])
+    order_col = _ORDER_COLUMN.get(element_name)
+    use_order = (
+        bool(order_map)
+        and order_col is not None
+        and (order_col in series.columns)
+    )
+
+    def _in_range(lo: str, hi: str) -> "pd.Series[bool]":
+        """Boolean mask of ``series`` rows inside the range ``lo``-``hi``."""
+        if use_order and order_map is not None and order_col is not None:
+            lo_order = order_map.get(lo)
+            hi_order = order_map.get(hi)
+            if lo_order is None or hi_order is None or lo_order > hi_order:
+                return pd.Series(False, index=series.index)
+            return series[order_col].between(lo_order, hi_order)
+        return series[element_name].between(lo, hi)
+
     if len(cell_elements) == 1 and "-" not in cell_elements[0]:
         series = series[series[element_name] == cell_elements[0]]
     elif len(cell_elements) == 1 and "-" in cell_elements[0]:
         limits = cell_elements[0].split("-")
         _check_range_endpoints(valid_codes, limits, element_name, table_code)
-        series = series[series[element_name].between(limits[0], limits[1])]
+        series = series[_in_range(limits[0], limits[1])]
     else:
         range_control = any("-" in x for x in cell_elements)
         if range_control:  # Range in cell elements, we must separate them
@@ -96,13 +132,18 @@ def filter_data_by_cell_element(
                         valid_codes, limits, element_name, table_code
                     )
                     data_range += list(
-                        series[
-                            series[element_name].between(limits[0], limits[1])
-                        ][element_name].unique()
+                        series[_in_range(limits[0], limits[1])][
+                            element_name
+                        ].unique()
                     )
                 else:
                     data_single.append(x)
-            cell_elements = sorted(set(data_range + data_single))
+            combined = set(data_range + data_single)
+            cell_elements = (
+                sort_by_order(combined, order_map)
+                if use_order and order_map is not None
+                else sorted(combined)
+            )
         series = series[series[element_name].isin(cell_elements)]
         cells_not_found = [
             x
@@ -131,20 +172,53 @@ def filter_all_data(
     row_codes = set(df[ROW_CODE])
     col_codes = set(df[COLUMN_CODE])
     sheet_codes = set(df[SHEET_CODE])
+    # Build each axis's table-wide {code: order} map so ranges resolve by the
+    # stored display order rather than by code text. ``build_axis_order_map``
+    # returns ``None`` when the axis is not fully ordered, which makes
+    # ``filter_data_by_cell_element`` fall back to string comparison.
+    row_orders = _axis_order_map(df, ROW_CODE, ROW_ORDER)
+    col_orders = _axis_order_map(df, COLUMN_CODE, COLUMN_ORDER)
+    sheet_orders = _axis_order_map(df, SHEET_CODE, SHEET_ORDER)
     if rows and rows[0] != "*":
         df = filter_data_by_cell_element(
-            df, rows, ROW_CODE, table_code, row_codes
+            df, rows, ROW_CODE, table_code, row_codes, row_orders
         )
     if cols and cols[0] != "*":
         df = filter_data_by_cell_element(
-            df, cols, COLUMN_CODE, table_code, col_codes
+            df, cols, COLUMN_CODE, table_code, col_codes, col_orders
         )
     if sheets and sheets[0] != "*":
         df = filter_data_by_cell_element(
-            df, sheets, SHEET_CODE, table_code, sheet_codes
+            df, sheets, SHEET_CODE, table_code, sheet_codes, sheet_orders
         )
     df = df.reset_index(drop=True)
     return df
+
+
+def _axis_order_map(
+    df: pd.DataFrame, code_col: str, order_col: str
+) -> dict[str, int] | None:
+    """Build ``{code: order}`` for one axis of ``df`` (``None`` if unordered).
+
+    Returns ``None`` when the order column is absent or the axis is not fully
+    ordered, so the caller falls back to string comparison.
+    """
+    if order_col not in df.columns:
+        return None
+    return build_axis_order_map(df[code_col], df[order_col])
+
+
+def _rank_column(data: pd.DataFrame, code_col: str, order_col: str) -> str:
+    """Return the column to rank/sort an axis by: order when fully populated.
+
+    Uses the stored display-order column when it is present and has no missing
+    values (all-or-nothing per axis), so ``r10`` ranks after ``r9`` rather than
+    after ``r1``. Falls back to the code column otherwise, preserving the
+    previous text-based ranking for tables without a usable order.
+    """
+    if order_col in data.columns and not data[order_col].isna().any():
+        return order_col
+    return code_col
 
 
 def generate_xyz(data: pd.DataFrame) -> list[dict[str, Any]]:
@@ -157,45 +231,58 @@ def generate_xyz(data: pd.DataFrame) -> list[dict[str, Any]]:
     number_of_sheets = len(list(data[SHEET_CODE].unique()))
     group: list[str] = []
 
+    # Rank/sort each axis by its stored display order when available, so the
+    # X/Y/Z coordinates follow the table layout instead of the code text.
+    # This is applied to whatever codes are present, so it fixes wildcard and
+    # explicit-list selections too, not only ranges.
+    row_key = _rank_column(data, ROW_CODE, ROW_ORDER)
+    col_key = _rank_column(data, COLUMN_CODE, COLUMN_ORDER)
+    sheet_key = _rank_column(data, SHEET_CODE, SHEET_ORDER)
+
     if number_of_rows > 1:
-        data.sort_values(by=[ROW_CODE], inplace=True)
-        data[INDEX_X] = data[ROW_CODE].rank(method="dense").astype(int)
-        group.append(ROW_CODE)
+        data.sort_values(by=[row_key], inplace=True)
+        data[INDEX_X] = data[row_key].rank(method="dense").astype(int)
+        group.append(row_key)
 
     if number_of_columns > 1:
-        data.sort_values(by=[COLUMN_CODE], inplace=True)
+        data.sort_values(by=[col_key], inplace=True)
         if data[INDEX_X].isnull().all():
-            data[INDEX_Y] = data[COLUMN_CODE].rank(method="dense").astype(int)
+            data[INDEX_Y] = data[col_key].rank(method="dense").astype(int)
         else:
             col_groups = cast(
-                Iterable[tuple[Any, pd.DataFrame]], data.groupby(ROW_CODE)
+                Iterable[tuple[Any, pd.DataFrame]], data.groupby(row_key)
             )
             for _, group_data in col_groups:
-                group_data.sort_values(by=[COLUMN_CODE], inplace=True)
+                group_data.sort_values(by=[col_key], inplace=True)
                 group_data[INDEX_Y] = (
-                    group_data[COLUMN_CODE].rank(method="dense").astype(int)
+                    group_data[col_key].rank(method="dense").astype(int)
                 )
                 # Add to data[INDEX_Y] the values of group_data[INDEX_Y]
                 data.loc[group_data.index, INDEX_Y] = group_data[INDEX_Y]
-        group.append(COLUMN_CODE)
+        group.append(col_key)
 
     if number_of_sheets > 1:
-        data.sort_values(by=[SHEET_CODE], inplace=True)
+        data.sort_values(by=[sheet_key], inplace=True)
         if len(group) == 0:
-            data[INDEX_Z] = data[SHEET_CODE].rank(method="dense").astype(int)
+            data[INDEX_Z] = data[sheet_key].rank(method="dense").astype(int)
         else:
             sheet_groups = cast(
                 Iterable[tuple[Any, pd.DataFrame]], data.groupby(group)
             )
             for _, group_data in sheet_groups:
-                group_data.sort_values(by=[SHEET_CODE], inplace=True)
+                group_data.sort_values(by=[sheet_key], inplace=True)
                 group_data[INDEX_Z] = (
-                    group_data[SHEET_CODE].rank(method="dense").astype(int)
+                    group_data[sheet_key].rank(method="dense").astype(int)
                 )
                 data.loc[group_data.index, INDEX_Z] = group_data[INDEX_Z]
-        group.append(SHEET_CODE)
+        group.append(sheet_key)
     if len(group) > 0:
         data.sort_values(by=group, inplace=True)
     data.drop_duplicates(keep="first", inplace=True)
+    # The order columns are internal ranking helpers; drop them so the records
+    # keep their previous shape (they never reach the engine output).
+    data = data.drop(
+        columns=[ROW_ORDER, COLUMN_ORDER, SHEET_ORDER], errors="ignore"
+    )
     list_xyz = cast(list[dict[str, Any]], data.to_dict(orient="records"))
     return list_xyz

--- a/src/dpmcore/dpm_xl/utils/range_resolution.py
+++ b/src/dpmcore/dpm_xl/utils/range_resolution.py
@@ -21,13 +21,14 @@ caller's job; :func:`build_axis_order_map` returns ``None`` to signal it.
 
 from __future__ import annotations
 
+import math
 from collections.abc import Iterable, Mapping
 from typing import Any
 
 
 def _is_missing(value: object) -> bool:
-    """Return True for ``None`` or a NaN float (``value != value``)."""
-    return value is None or (isinstance(value, float) and value != value)
+    """Return True for ``None`` or a NaN float."""
+    return value is None or (isinstance(value, float) and math.isnan(value))
 
 
 def resolve_range_codes(

--- a/src/dpmcore/dpm_xl/utils/range_resolution.py
+++ b/src/dpmcore/dpm_xl/utils/range_resolution.py
@@ -1,0 +1,127 @@
+"""Resolve DPM-XL row/column/sheet ranges by stored display order.
+
+A DPM-XL selector may name a range of rows, columns or sheets, e.g.
+``r0010-r0090`` or ``r2-r11``. The engine must expand that range into the
+codes it covers and list them in the table's display order. Comparing the
+code *strings* (``r10`` < ``r2`` because ``"1" < "2"``) only works for codes
+that happen to be numeric and zero-padded to a fixed width; it silently drops
+or mis-orders non-numeric, non-padded or mixed-width codes.
+
+These helpers resolve ranges against the real ordering key —
+``TableVersionHeader.Order`` — exactly as :mod:`dpmcore.orm.release_sort_order`
+resolves release ranges against ``Release.date`` rather than the release code.
+They are pure and DB-free: callers supply a ``{code: order}`` map for one axis
+and these functions never touch a session or a DataFrame.
+
+The ordering column is nullable, so an axis is only resolvable this way when
+*every* code on it carries an order. Deciding that (all-or-nothing per axis,
+never mixing order-based and string-based comparison within one axis) is the
+caller's job; :func:`build_axis_order_map` returns ``None`` to signal it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+
+def _is_missing(value: object) -> bool:
+    """Return True for ``None`` or a NaN float (``value != value``)."""
+    return value is None or (isinstance(value, float) and value != value)
+
+
+def resolve_range_codes(
+    code_to_order: Mapping[str, int], lo: str, hi: str
+) -> list[str]:
+    """Return the codes spanned by the range ``lo``-``hi``, in display order.
+
+    The range covers every code whose stored order lies within
+    ``[order[lo], order[hi]]``, returned ascending by that order.
+
+    A **reversed** range (``order[lo] > order[hi]``) returns ``[]``, preserving
+    the pre-existing behaviour where such an expression selects nothing and so
+    raises a "cell not found" error rather than silently spanning the codes in
+    between. An endpoint absent from ``code_to_order`` also returns ``[]``;
+    endpoint *existence* is validated separately by the caller (see
+    ``_check_range_endpoints``), which raises the user-facing ``1-2`` error.
+
+    Args:
+        code_to_order: ``{code: order}`` for one axis of a table version.
+        lo: The range's first endpoint code.
+        hi: The range's second endpoint code.
+
+    Returns:
+        The spanned codes, ascending by stored order; empty when an endpoint
+        is absent or the range is reversed.
+    """
+    lo_order = code_to_order.get(lo)
+    hi_order = code_to_order.get(hi)
+    if lo_order is None or hi_order is None or lo_order > hi_order:
+        return []
+    spanned = sorted(
+        (
+            (order, code)
+            for code, order in code_to_order.items()
+            if lo_order <= order <= hi_order
+        )
+    )
+    return [code for _, code in spanned]
+
+
+def sort_by_order(
+    codes: Iterable[str], code_to_order: Mapping[str, int]
+) -> list[str]:
+    """Sort ``codes`` by their stored display order.
+
+    Codes absent from ``code_to_order`` sort last in lexicographic order, so
+    the result stays deterministic even when the map is incomplete. Duplicate
+    codes are collapsed.
+
+    Args:
+        codes: The codes to sort.
+        code_to_order: ``{code: order}`` for the codes' axis.
+
+    Returns:
+        The de-duplicated codes in display order.
+    """
+    unique = list(dict.fromkeys(codes))
+    ordered = sorted(
+        (c for c in unique if c in code_to_order),
+        key=lambda c: (code_to_order[c], c),
+    )
+    unordered = sorted(c for c in unique if c not in code_to_order)
+    return ordered + unordered
+
+
+def build_axis_order_map(
+    codes: Iterable[Any], orders: Iterable[Any]
+) -> dict[str, int] | None:
+    """Build a ``{code: order}`` map from parallel code/order sequences.
+
+    Missing codes (``None``/NaN — a cell that lacks that axis, e.g. a table
+    with no sheets) are skipped. Returns ``None`` when the axis is **not fully
+    ordered** — any present code lacks an order, or a code maps to two
+    different orders — so the caller falls back to string comparison for the
+    whole axis and the two orderings are never mixed.
+
+    Args:
+        codes: The axis code of each row (may contain ``None``/NaN).
+        orders: The matching stored order of each row (may contain ``None``/NaN).
+
+    Returns:
+        ``{code: order}`` when every present code has a single integer order,
+        else ``None``.
+    """
+    result: dict[str, int] = {}
+    for code, order in zip(codes, orders, strict=False):
+        if _is_missing(code):
+            continue
+        key = str(code)
+        if _is_missing(order):
+            return None
+        value = int(order)
+        existing = result.get(key)
+        if existing is not None and existing != value:
+            return None
+        result[key] = value
+    return result

--- a/src/dpmcore/dpm_xl/utils/serialization.py
+++ b/src/dpmcore/dpm_xl/utils/serialization.py
@@ -9,6 +9,10 @@ from typing import Any, TypeAlias, cast
 
 from dpmcore.dpm_xl.ast import nodes as ASTObjects
 from dpmcore.dpm_xl.ast.visitor import NodeVisitor
+from dpmcore.dpm_xl.utils.range_resolution import (
+    build_axis_order_map,
+    sort_by_order,
+)
 
 # Recursive JSON alias used for serialized AST payloads.
 NodeValue: TypeAlias = (
@@ -210,6 +214,24 @@ class ASTToJSONVisitor(NodeVisitor):
                             if sheet_match:
                                 record["sheet_code"] = sheet_match.group(1)
 
+                # Build {code: order} per axis from the stored display order
+                # carried on each record (row_order/column_order/sheet_order),
+                # so the x/y/z coordinates follow the table layout rather than
+                # the code text. ``None`` (axis not fully ordered) falls back to
+                # a lexicographic sort, matching the previous behaviour.
+                row_orders = build_axis_order_map(
+                    [r.get("row_code") for r in data_records],
+                    [r.get("row_order") for r in data_records],
+                )
+                col_orders = build_axis_order_map(
+                    [r.get("column_code") for r in data_records],
+                    [r.get("column_order") for r in data_records],
+                )
+                sheet_orders = build_axis_order_map(
+                    [r.get("sheet_code") for r in data_records],
+                    [r.get("sheet_order") for r in data_records],
+                )
+
                 # Group data entries by row_code
                 entries_by_row: dict[str, list[dict[str, Any]]] = {}
                 for record in data_records:
@@ -218,8 +240,12 @@ class ASTToJSONVisitor(NodeVisitor):
                         entries_by_row[row_code] = []
                     entries_by_row[row_code].append(record)
 
-                # Sort rows to ensure consistent numerical ordering for x-coordinate calculation
-                rows = sorted(entries_by_row.keys())
+                # Order rows for the x-coordinate by stored display order.
+                rows = (
+                    sort_by_order(entries_by_row.keys(), row_orders)
+                    if row_orders
+                    else sorted(entries_by_row.keys())
+                )
 
                 # Helper function to detect range syntax (e.g., '0010-0080')
                 def _has_range_syntax(values: Any) -> bool:
@@ -251,8 +277,12 @@ class ASTToJSONVisitor(NodeVisitor):
                         if col and col not in seen_cols:
                             context_cols.append(col)
                             seen_cols.add(col)
-                    # Sort to ensure consistent numerical ordering for y-coordinate calculation
-                    context_cols.sort()
+                    # Order columns for the y-coordinate by display order.
+                    context_cols = (
+                        sort_by_order(context_cols, col_orders)
+                        if col_orders
+                        else sorted(context_cols)
+                    )
 
                 # Build sheet order from data for z-coordinate calculation
                 # Extract unique sheets and sort them for consistent ordering
@@ -263,7 +293,11 @@ class ASTToJSONVisitor(NodeVisitor):
                     if sheet and sheet not in seen_sheets:
                         context_sheets.append(sheet)
                         seen_sheets.add(sheet)
-                context_sheets.sort()
+                context_sheets = (
+                    sort_by_order(context_sheets, sheet_orders)
+                    if sheet_orders
+                    else sorted(context_sheets)
+                )
 
                 # Transform the data to match expected JSON structure
                 transformed_data: list[dict[str, Any]] = []

--- a/src/dpmcore/dpm_xl/utils/tokens.py
+++ b/src/dpmcore/dpm_xl/utils/tokens.py
@@ -96,6 +96,13 @@ SHEET_CODE = "sheet_code"
 TABLE_CODE = "table_code"
 CELL_COMPONENTS = [ROW_CODE, COLUMN_CODE, SHEET_CODE]
 
+# Stored display order per axis (TableVersionHeader.Order), surfaced
+# alongside each *_code so range membership and X/Y/Z ranking follow the
+# table's display order instead of the lexicographic order of the code text.
+ROW_ORDER = "row_order"
+COLUMN_ORDER = "column_order"
+SHEET_ORDER = "sheet_order"
+
 # Generated validations status
 STATUS = "status"
 STATUS_CORRECT = "Correct"

--- a/tests/unit/dpm_xl/test_data_handlers.py
+++ b/tests/unit/dpm_xl/test_data_handlers.py
@@ -6,6 +6,7 @@ import pytest
 from dpmcore.dpm_xl.utils.data_handlers import (
     filter_all_data,
     filter_data_by_cell_element,
+    generate_xyz,
 )
 from dpmcore.errors import SemanticError
 
@@ -154,3 +155,107 @@ class TestSparseTableRangeEndpoints:
             filter_all_data(data, "T1", ["0010"], ["0010-0099"], ["0000"])
         assert exc.value.code == "1-2"
         assert "c0099" in str(exc.value)
+
+
+def _ordered_columns(*codes: str) -> pd.DataFrame:
+    """Column frame carrying a ``column_order`` = display position (1-based)."""
+    return pd.DataFrame(
+        {
+            "column_code": list(codes),
+            "column_order": list(range(1, len(codes) + 1)),
+        }
+    )
+
+
+class TestOrderBasedRangeMembership:
+    """Ranges resolve by stored display order when an ``order_map`` is given.
+
+    Regression for issue #209: non-padded codes such as ``10``/``11`` sort
+    before ``2`` as text, so the string ``between`` drops them; the order map
+    fixes membership.
+    """
+
+    def test_non_padded_range_includes_high_codes(self):
+        codes = [str(i) for i in range(1, 12)]  # "1".."11" in display order
+        df = _ordered_columns(*codes)
+        order_map = dict(zip(codes, range(1, 12), strict=False))
+        result = filter_data_by_cell_element(
+            df, ["2-11"], "column_code", "T", set(codes), order_map
+        )
+        # 10 and 11 are inside the range and 1 is outside -- the whole point.
+        assert set(result["column_code"]) == {str(i) for i in range(2, 12)}
+
+    def test_reversed_range_selects_nothing(self):
+        codes = [str(i) for i in range(1, 12)]
+        df = _ordered_columns(*codes)
+        order_map = dict(zip(codes, range(1, 12), strict=False))
+        result = filter_data_by_cell_element(
+            df, ["11-2"], "column_code", "T", set(codes), order_map
+        )
+        assert result.empty
+
+    def test_range_within_list_uses_order(self):
+        codes = [str(i) for i in range(1, 12)]
+        df = _ordered_columns(*codes)
+        order_map = dict(zip(codes, range(1, 12), strict=False))
+        result = filter_data_by_cell_element(
+            df, ["1", "9-11"], "column_code", "T", set(codes), order_map
+        )
+        assert set(result["column_code"]) == {"1", "9", "10", "11"}
+
+    def test_no_order_map_falls_back_to_text_between(self):
+        # Zero-padded codes still resolve correctly via the string path.
+        df = _columns("0010", "0020", "0030")
+        result = filter_data_by_cell_element(
+            df, ["0010-0030"], "column_code", "T"
+        )
+        assert sorted(result["column_code"]) == ["0010", "0020", "0030"]
+
+
+def _xyz_frame(row_codes: list[str], with_order: bool) -> pd.DataFrame:
+    """Single-column frame of rows, optionally carrying display-order columns."""
+    data: dict[str, list] = {
+        "row_code": row_codes,
+        "column_code": ["1"] * len(row_codes),
+        "sheet_code": [None] * len(row_codes),
+        "variable_id": list(range(len(row_codes))),
+        "cell_id": list(range(len(row_codes))),
+    }
+    if with_order:
+        # Display order = 1-based position in the given (already sorted) list.
+        data["row_order"] = list(range(1, len(row_codes) + 1))
+        data["column_order"] = [1] * len(row_codes)
+        data["sheet_order"] = [None] * len(row_codes)
+    return pd.DataFrame(data)
+
+
+class TestGenerateXyzOrdering:
+    """X/Y/Z coordinates follow the stored display order, not the code text.
+
+    This ranking path applies to whatever codes are present, so it fixes
+    wildcard (``r*``) and explicit-list selections as well as ranges.
+    """
+
+    def test_x_follows_display_order_for_non_padded_rows(self):
+        # Rows given in display order r1..r11; r10/r11 must rank last.
+        rows = [str(i) for i in range(1, 12)]
+        result = generate_xyz(_xyz_frame(rows, with_order=True))
+        x_by_row = {r["row_code"]: r["x"] for r in result}
+        assert x_by_row["1"] == 1
+        assert x_by_row["2"] == 2
+        assert x_by_row["10"] == 10
+        assert x_by_row["11"] == 11
+
+    def test_order_helper_columns_are_not_leaked(self):
+        rows = [str(i) for i in range(1, 4)]
+        result = generate_xyz(_xyz_frame(rows, with_order=True))
+        assert "row_order" not in result[0]
+        assert "column_order" not in result[0]
+        assert "sheet_order" not in result[0]
+
+    def test_without_order_columns_falls_back_to_text_rank(self):
+        # No order columns -> previous text-based ranking: "10" sorts second.
+        rows = [str(i) for i in range(1, 12)]
+        result = generate_xyz(_xyz_frame(rows, with_order=False))
+        x_by_row = {r["row_code"]: r["x"] for r in result}
+        assert x_by_row["10"] == 2  # lexicographic: "1","10","11","2",...

--- a/tests/unit/dpm_xl/test_range_resolution.py
+++ b/tests/unit/dpm_xl/test_range_resolution.py
@@ -1,0 +1,110 @@
+"""Unit tests for order-based range resolution helpers.
+
+These cover the core of issue #209: ranges must be resolved by the stored
+display order, not by comparing the code text, so non-padded / mixed-width /
+non-numeric codes span and sort correctly.
+"""
+
+import math
+
+from dpmcore.dpm_xl.utils.range_resolution import (
+    build_axis_order_map,
+    resolve_range_codes,
+    sort_by_order,
+)
+
+# Rows r1..r11 in display order -- the classic case where text order
+# ("r10" < "r2") disagrees with display order.
+NON_PADDED = {f"r{i}": i for i in range(1, 12)}
+
+
+class TestResolveRangeCodes:
+    def test_non_padded_range_spans_by_order(self):
+        # r2-r11 must include r10 and r11 (which sort before r2 as text).
+        result = resolve_range_codes(NON_PADDED, "r2", "r11")
+        assert result == [f"r{i}" for i in range(2, 12)]
+
+    def test_result_is_in_display_order_not_text_order(self):
+        result = resolve_range_codes(NON_PADDED, "r8", "r11")
+        assert result == ["r8", "r9", "r10", "r11"]
+
+    def test_zero_padded_range_unchanged(self):
+        padded = {"0010": 1, "0020": 2, "0030": 3}
+        assert resolve_range_codes(padded, "0010", "0030") == [
+            "0010",
+            "0020",
+            "0030",
+        ]
+
+    def test_single_code_range(self):
+        assert resolve_range_codes(NON_PADDED, "r5", "r5") == ["r5"]
+
+    def test_reversed_range_returns_empty(self):
+        # Per the agreed behaviour, a reversed range selects nothing so the
+        # caller still raises the pre-existing "cell not found" error.
+        assert resolve_range_codes(NON_PADDED, "r11", "r2") == []
+
+    def test_missing_low_endpoint_returns_empty(self):
+        assert resolve_range_codes(NON_PADDED, "rX", "r5") == []
+
+    def test_missing_high_endpoint_returns_empty(self):
+        assert resolve_range_codes(NON_PADDED, "r5", "rX") == []
+
+    def test_alphabetic_codes_span_by_order(self):
+        sheets = {"alpha": 1, "beta": 2, "gamma": 3, "delta": 4}
+        assert resolve_range_codes(sheets, "beta", "delta") == [
+            "beta",
+            "gamma",
+            "delta",
+        ]
+
+
+class TestSortByOrder:
+    def test_sorts_by_display_order(self):
+        codes = ["r10", "r2", "r1", "r11"]
+        assert sort_by_order(codes, NON_PADDED) == ["r1", "r2", "r10", "r11"]
+
+    def test_unmapped_codes_sort_last_lexicographically(self):
+        codes = ["r2", "zzz", "r1", "aaa"]
+        assert sort_by_order(codes, NON_PADDED) == ["r1", "r2", "aaa", "zzz"]
+
+    def test_deduplicates(self):
+        assert sort_by_order(["r2", "r2", "r1"], NON_PADDED) == ["r1", "r2"]
+
+
+class TestBuildAxisOrderMap:
+    def test_fully_ordered_axis(self):
+        result = build_axis_order_map(["r1", "r2"], [1, 2])
+        assert result == {"r1": 1, "r2": 2}
+
+    def test_missing_order_returns_none(self):
+        # r2 has no stored order -> axis is not fully ordered -> fall back.
+        assert build_axis_order_map(["r1", "r2"], [1, None]) is None
+
+    def test_nan_order_returns_none(self):
+        assert build_axis_order_map(["r1", "r2"], [1, math.nan]) is None
+
+    def test_conflicting_orders_returns_none(self):
+        # A code that maps to two different orders is untrustworthy.
+        assert build_axis_order_map(["r1", "r1"], [1, 2]) is None
+
+    def test_repeated_consistent_order_is_kept(self):
+        assert build_axis_order_map(["r1", "r1", "r2"], [1, 1, 2]) == {
+            "r1": 1,
+            "r2": 2,
+        }
+
+    def test_missing_codes_are_skipped(self):
+        # A cell that lacks this axis (e.g. no sheets) carries a null code.
+        result = build_axis_order_map(["r1", None, math.nan], [1, None, None])
+        assert result == {"r1": 1}
+
+    def test_no_codes_returns_empty_map(self):
+        assert build_axis_order_map([None, math.nan], [None, None]) == {}
+
+    def test_float_orders_are_coerced_to_int(self):
+        # pandas surfaces a nullable int column as float64.
+        assert build_axis_order_map(["r1", "r2"], [1.0, 2.0]) == {
+            "r1": 1,
+            "r2": 2,
+        }

--- a/tests/unit/dpm_xl/test_serialization_ordering.py
+++ b/tests/unit/dpm_xl/test_serialization_ordering.py
@@ -1,0 +1,59 @@
+"""The JSON serializer ranks x/y/z by stored display order.
+
+The serializer computes cell coordinates on an independent path from
+``generate_xyz``; issue #209 requires both to follow the table's display
+order rather than the code text. A wildcard row selection over non-padded
+codes (``1`` .. ``11``) is the discriminating case: lexicographically ``10``
+and ``11`` sort right after ``1``.
+"""
+
+from types import SimpleNamespace
+
+import pandas as pd
+
+from dpmcore.dpm_xl.utils.serialization import ASTToJSONVisitor
+
+
+def _varid(with_order: bool) -> SimpleNamespace:
+    rows = [str(i) for i in range(1, 12)]  # display order 1..11
+    frame: dict[str, list] = {
+        "row_code": rows,
+        "column_code": ["1"] * 11,
+        "sheet_code": [None] * 11,
+        "data_type": ["m"] * 11,
+        "variable_id": list(range(11)),
+        "cell_id": list(range(11)),
+    }
+    if with_order:
+        frame["row_order"] = list(range(1, 12))
+        frame["column_order"] = [1] * 11
+        frame["sheet_order"] = [None] * 11
+    # Wildcard rows: the row order comes entirely from the data.
+    return SimpleNamespace(
+        table="T",
+        rows=["*"],
+        cols=["1"],
+        sheets=None,
+        data=pd.DataFrame(frame),
+    )
+
+
+def _x_by_row(node: SimpleNamespace) -> dict[str, int]:
+    result = ASTToJSONVisitor(with_context=None).visit_VarID(node)
+    data = result["data"]
+    assert isinstance(data, list)
+    return {rec["row"]: rec["x"] for rec in data}
+
+
+class TestSerializerCoordinateOrdering:
+    def test_x_follows_display_order_for_wildcard_rows(self):
+        x_by_row = _x_by_row(_varid(with_order=True))
+        assert x_by_row["1"] == 1
+        assert x_by_row["2"] == 2
+        assert x_by_row["10"] == 10
+        assert x_by_row["11"] == 11
+
+    def test_without_order_falls_back_to_text_rank(self):
+        x_by_row = _x_by_row(_varid(with_order=False))
+        # Lexicographic: "1","10","11","2",... -> "10" ranks second.
+        assert x_by_row["10"] == 2


### PR DESCRIPTION
## Summary

Closes #209.

A range like `r2-r11` was resolved by comparing the code **text**, so `r10` and `r11` sort before `r2` (`"1" < "2"`) and were dropped from the range. Now ranges are resolved and sorted by the stored display order (`TableVersionHeader.Order`), the same idea already used for releases (`Release.date`). This fixes non-padded, mixed-width and non-numeric codes.

Two rules kept on purpose: an axis falls back to the old text comparison when it is not fully ordered (some code has no order), and a reversed range (`r11-r2`) still selects nothing.

## What changed:

- `dpm_xl/utils/range_resolution.py` (new) — pure, DB-free helpers: build the `{code: order}` map, expand a range by order, sort by order.
- `dpm_xl/utils/tokens.py` — new `row_order` / `column_order` / `sheet_order` columns.
- `dpm_xl/model_queries.py` — queries now read the order columns; `get_axis_orders` builds the per-axis map (cached, only when a range is present).
- `dpm_xl/utils/data_handlers.py` — range membership and X/Y/Z ranking follow the order.
- `dpm_xl/ast/operands.py`, `dpm_xl/ast/ml_generation.py`, `dpm_xl/utils/serialization.py` — range expansion and coordinate sorting use the order.

## Checklist

- [X] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [X] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [ ] Documentation updated (if applicable)

## Impact / Risk

- Breaking changes? No
- Database schema or migration concerns? No
- Notes for release/changelog?

