### PR TITLE
fix: bridge ghost siblings when window-checking explicit release

### DIFF
--- a/src/dpmcore/services/ast_generator.py
+++ b/src/dpmcore/services/ast_generator.py
@@ -52,6 +52,19 @@ def _normalize_variable_code(code: str) -> str:
     return code
 
 
+def _is_ghost_mv(mv: Any) -> bool:
+    """Whether a ``ModuleVersion`` is a ghost (collapsed reference window).
+
+    Mirrors :func:`_collapsed_mask` in ``dpm_xl.model_queries``: a ghost
+    has both reference dates set and equal.
+    """
+    return (
+        mv.from_reference_date is not None
+        and mv.to_reference_date is not None
+        and mv.from_reference_date == mv.to_reference_date
+    )
+
+
 def _format_date(value: Any, fallback: Optional[str] = None) -> Optional[str]:
     """Format a ``date`` / ``datetime`` / string as ``YYYY-MM-DD``."""
     if value is None:
@@ -420,6 +433,17 @@ class ASTGeneratorService:
         :mod:`dpmcore.orm.release_sort_order`), not the raw id. Raises
         ``ValueError`` if the release is unknown, predates
         ``start_release_id``, or is past ``end_release_id``.
+
+        Coordinates with the ghost-version fallback in
+        :func:`dpmcore.dpm_xl.model_queries._resolve_with_ghost_fallback`:
+        when ``mv`` is being used as the fallback for a ghost that
+        follows it, ``mv``'s effective end release is virtually extended
+        past the ghost(s) to the start of the next non-ghost sibling —
+        or ``None`` when only ghosts follow (issue #221). The
+        ``predates`` branch is never relaxed:
+        ``_latest_prior_non_collapsed_vids`` picks fallbacks strictly
+        backward, so a legitimate ghost-fallback can never produce an MV
+        whose start ``predates`` the requested release.
         """
         from dpmcore.orm.infrastructure import Release
         from dpmcore.orm.release_sort_order import resolve_sort_order
@@ -444,15 +468,146 @@ class ASTGeneratorService:
                 f"{module_code} {module_version} "
                 f"(starts at release_id={start})."
             )
-        if end is not None and target >= resolve_sort_order(
-            self.session, end, role="module version end release"
-        ):
-            raise ValueError(
-                f"Release {release} is past the end of module "
-                f"version {module_code} {module_version} "
-                f"(ends at release_id={end})."
-            )
+        if end is not None:
+            effective_end_id = self._effective_end_release_id(mv)
+            if effective_end_id is not None and target >= resolve_sort_order(
+                self.session,
+                effective_end_id,
+                role="module version effective end release",
+            ):
+                raise ValueError(
+                    f"Release {release} is past the end of module "
+                    f"version {module_code} {module_version} "
+                    f"(ends at release_id={end})."
+                )
         return release_row
+
+    def _effective_end_release_id(self, mv: Any) -> Optional[int]:
+        """Compute ``mv``'s effective end, extended past ghost siblings.
+
+        When ``mv`` is used as ghost-fallback (its content substitutes
+        for a ghost of the same module covering releases past ``mv``'s
+        own end), the effective end virtually extends past those ghost
+        siblings. The extension follows a contiguous chain of ghost
+        siblings starting at (or overlapping) ``mv.end_release_id``:
+
+        - If the chain is followed by a non-ghost sibling, the effective
+          end is that sibling's ``start_release_id``.
+        - If only ghosts follow (open-ended ghost, or the last ghost's
+          end is null), the effective end is ``None`` (open).
+        - If no ghost adjoins ``mv``'s end, the effective end is
+          ``mv.end_release_id`` unchanged.
+
+        Args:
+            mv: The ``ModuleVersion`` being window-checked.
+
+        Returns:
+            The release id to use as the effective upper bound of
+            ``mv``'s window, or ``None`` if it is open-ended.
+        """
+        from dpmcore.orm.packaging import ModuleVersion
+        from dpmcore.orm.release_sort_order import resolve_sort_order
+
+        if mv.end_release_id is None:
+            return None
+        if self.session is None or mv.module_id is None:
+            return mv.end_release_id
+        session = self.session
+        end_sort = resolve_sort_order(
+            session,
+            mv.end_release_id,
+            role="module version end release",
+        )
+        siblings = (
+            session.query(ModuleVersion)
+            .filter(ModuleVersion.module_id == mv.module_id)
+            .filter(ModuleVersion.module_vid != mv.module_vid)
+            .all()
+        )
+        candidates = self._siblings_past_end(siblings, end_sort)
+        return self._walk_ghost_chain(mv, candidates, end_sort)
+
+    def _siblings_past_end(
+        self, siblings: Iterable[Any], end_sort: int
+    ) -> List[Tuple[int, bool, Any]]:
+        """Filter and sort siblings whose window extends past ``end_sort``."""
+        from dpmcore.orm.release_sort_order import resolve_sort_order
+
+        session = self.session
+        if session is None:
+            raise RuntimeError("session required")
+
+        def sort_or_none(
+            release_id: Optional[int], role: str
+        ) -> Optional[int]:
+            if release_id is None:
+                return None
+            return resolve_sort_order(session, release_id, role=role)
+
+        candidates: List[Tuple[int, bool, Any]] = []
+        for sibling in siblings:
+            sibling_end_sort = sort_or_none(
+                sibling.end_release_id, "sibling module version end release"
+            )
+            if sibling_end_sort is not None and sibling_end_sort <= end_sort:
+                continue
+            sibling_start_sort = sort_or_none(
+                sibling.start_release_id,
+                "sibling module version start release",
+            )
+            # Missing start acts as unbounded below; cap the sort key at
+            # ``end_sort`` so such siblings sit at the chain's head.
+            effective_start = (
+                end_sort
+                if sibling_start_sort is None
+                else max(sibling_start_sort, end_sort)
+            )
+            candidates.append(
+                (effective_start, _is_ghost_mv(sibling), sibling)
+            )
+        candidates.sort(key=lambda item: item[0])
+        return candidates
+
+    def _walk_ghost_chain(
+        self,
+        mv: Any,
+        candidates: List[Tuple[int, bool, Any]],
+        end_sort: int,
+    ) -> Optional[int]:
+        """Walk sibling candidates to find ``mv``'s effective end."""
+        from dpmcore.orm.release_sort_order import resolve_sort_order
+
+        session = self.session
+        if session is None:
+            raise RuntimeError("session required")
+        saw_ghost = False
+        boundary = end_sort
+        for start_sort, ghost, sibling in candidates:
+            if start_sort > boundary:
+                break
+            if ghost:
+                saw_ghost = True
+                if sibling.end_release_id is None:
+                    return None
+                boundary = max(
+                    boundary,
+                    resolve_sort_order(
+                        session,
+                        sibling.end_release_id,
+                        role="sibling module version end release",
+                    ),
+                )
+                continue
+            if saw_ghost:
+                # First non-ghost after a chain of ghosts terminates the
+                # virtual extension at its ``start_release_id``.
+                return sibling.start_release_id
+            # A non-ghost adjoins ``mv``'s end directly (no ghost bridge),
+            # so no extension applies — keep the schema value.
+            return mv.end_release_id
+        if saw_ghost:
+            return None
+        return mv.end_release_id
 
     def _latest_release_in_window(self, mv: Any) -> Any:
         """Pick the latest ``released`` Release covering *mv*'s window.

--- a/src/dpmcore/services/ast_generator.py
+++ b/src/dpmcore/services/ast_generator.py
@@ -52,19 +52,6 @@ def _normalize_variable_code(code: str) -> str:
     return code
 
 
-def _is_ghost_mv(mv: Any) -> bool:
-    """Whether a ``ModuleVersion`` is a ghost (collapsed reference window).
-
-    Mirrors :func:`_collapsed_mask` in ``dpm_xl.model_queries``: a ghost
-    has both reference dates set and equal.
-    """
-    return (
-        mv.from_reference_date is not None
-        and mv.to_reference_date is not None
-        and mv.from_reference_date == mv.to_reference_date
-    )
-
-
 def _format_date(value: Any, fallback: Optional[str] = None) -> Optional[str]:
     """Format a ``date`` / ``datetime`` / string as ``YYYY-MM-DD``."""
     if value is None:
@@ -562,9 +549,12 @@ class ASTGeneratorService:
                 if sibling_start_sort is None
                 else max(sibling_start_sort, end_sort)
             )
-            candidates.append(
-                (effective_start, _is_ghost_mv(sibling), sibling)
+            is_ghost = (
+                sibling.from_reference_date is not None
+                and sibling.to_reference_date is not None
+                and sibling.from_reference_date == sibling.to_reference_date
             )
+            candidates.append((effective_start, is_ghost, sibling))
         candidates.sort(key=lambda item: item[0])
         return candidates
 
@@ -582,6 +572,7 @@ class ASTGeneratorService:
             raise RuntimeError("session required")
         saw_ghost = False
         boundary = end_sort
+        last_ghost_end_id: Optional[int] = None
         for start_sort, ghost, sibling in candidates:
             if start_sort > boundary:
                 break
@@ -589,14 +580,14 @@ class ASTGeneratorService:
                 saw_ghost = True
                 if sibling.end_release_id is None:
                     return None
-                boundary = max(
-                    boundary,
-                    resolve_sort_order(
-                        session,
-                        sibling.end_release_id,
-                        role="sibling module version end release",
-                    ),
+                sibling_end_sort = resolve_sort_order(
+                    session,
+                    sibling.end_release_id,
+                    role="sibling module version end release",
                 )
+                if sibling_end_sort > boundary:
+                    boundary = sibling_end_sort
+                    last_ghost_end_id = sibling.end_release_id
                 continue
             if saw_ghost:
                 # First non-ghost after a chain of ghosts terminates the
@@ -605,8 +596,11 @@ class ASTGeneratorService:
             # A non-ghost adjoins ``mv``'s end directly (no ghost bridge),
             # so no extension applies — keep the schema value.
             return mv.end_release_id
+        # Chain of ghosts with no non-ghost following it: the effective
+        # end is the last bounded ghost's ``end_release_id``. (An
+        # open-ended ghost would have returned ``None`` inside the loop.)
         if saw_ghost:
-            return None
+            return last_ghost_end_id
         return mv.end_release_id
 
     def _latest_release_in_window(self, mv: Any) -> Any:

--- a/tests/integration/services/test_scope_release_axis.py
+++ b/tests/integration/services/test_scope_release_axis.py
@@ -475,3 +475,187 @@ class TestResolveExplicitReleaseDateOrder:
     def test_unknown_release_rejected(self, svc):
         with pytest.raises(ValueError, match="Release not found"):
             svc._resolve_release("MODX", "1.0.0", "9.9")
+
+
+class TestResolveExplicitReleaseGhostFallback:
+    """Window-check coordination with ghost-fallback (issue #221).
+
+    When the release-window resolution has legitimately handed the AST
+    generator a non-ghost ModuleVersion as the fallback for a ghost of
+    the same module (see
+    ``dpm_xl.model_queries._resolve_with_ghost_fallback``), the strict
+    window-check on the non-ghost must NOT reject the requested release
+    -- it belongs to the ghost's window. The check must still reject
+    releases that no ghost of that module covers.
+    """
+
+    @pytest.fixture
+    def svc(self, memory_session):
+        # Non-monotonic IDs (mirrors TestResolveExplicitReleaseDateOrder)
+        # to make sure the ghost check uses date sort order, not raw IDs.
+        memory_session.add_all(
+            [
+                Release(release_id=3, code="4.0", date=date(2025, 1, 1)),
+                Release(
+                    release_id=1010000003,
+                    code="4.2",
+                    date=date(2026, 3, 1),
+                ),
+                Release(release_id=5, code="4.2.1", date=date(2026, 6, 1)),
+                # MODA -- past-the-end scenario (the DORA/issue-#221 shape).
+                # Non-ghost 1.0.0 covers [4.0, 4.2); ghost 1.1.0 covers
+                # [4.2, ∞). Request 4.2 against 1.0.0 must succeed.
+                ModuleVersion(
+                    module_vid=1,
+                    module_id=1,
+                    code="MODA",
+                    version_number="1.0.0",
+                    start_release_id=3,
+                    end_release_id=1010000003,
+                    from_reference_date=date(2025, 1, 31),
+                    to_reference_date=date(2026, 3, 30),
+                ),
+                ModuleVersion(
+                    module_vid=2,
+                    module_id=1,
+                    code="MODA",
+                    version_number="1.1.0",
+                    start_release_id=1010000003,
+                    end_release_id=None,
+                    from_reference_date=date(2026, 3, 31),
+                    to_reference_date=date(2026, 3, 31),
+                ),
+                # MODC -- no ghost anywhere. Non-ghost 1.0.0 covers
+                # [4.2, 4.2.1). Request 4.2.1 must still raise
+                # "past the end" (no ghost of MODC covers it), and 4.0
+                # must still raise "predates".
+                ModuleVersion(
+                    module_vid=5,
+                    module_id=3,
+                    code="MODC",
+                    version_number="1.0.0",
+                    start_release_id=1010000003,
+                    end_release_id=5,
+                    from_reference_date=date(2026, 3, 31),
+                    to_reference_date=date(2026, 5, 30),
+                ),
+                # MODD -- ghost of a DIFFERENT module (id=1) must not
+                # relax MODD's window. MODD 1.0.0 covers [4.0, 4.2);
+                # 4.2 must still be rejected.
+                ModuleVersion(
+                    module_vid=6,
+                    module_id=4,
+                    code="MODD",
+                    version_number="1.0.0",
+                    start_release_id=3,
+                    end_release_id=1010000003,
+                    from_reference_date=date(2025, 1, 31),
+                    to_reference_date=date(2026, 3, 30),
+                ),
+                # MODE -- open-ended ghost (start_release_id=None,
+                # end_release_id=None). Should cover every release of
+                # its module. Non-ghost MODE 1.0.0 covers [4.0, 4.2);
+                # 4.2.1 must succeed thanks to the open-ended ghost.
+                ModuleVersion(
+                    module_vid=7,
+                    module_id=5,
+                    code="MODE",
+                    version_number="1.0.0",
+                    start_release_id=3,
+                    end_release_id=1010000003,
+                    from_reference_date=date(2025, 1, 31),
+                    to_reference_date=date(2026, 3, 30),
+                ),
+                ModuleVersion(
+                    module_vid=8,
+                    module_id=5,
+                    code="MODE",
+                    version_number="1.1.0",
+                    start_release_id=None,
+                    end_release_id=None,
+                    from_reference_date=date(2026, 3, 31),
+                    to_reference_date=date(2026, 3, 31),
+                ),
+                # MODF -- ghost between two non-ghosts. Non-ghost 1.0.0
+                # covers [4.0, 4.2); ghost 1.1.0 covers [4.2, 4.2.1);
+                # non-ghost 1.2.0 covers [4.2.1, ∞). Effective end of
+                # 1.0.0 extends past the ghost to 1.2.0's start (4.2.1):
+                # 4.2 is accepted (inside chain), 4.2.1 is rejected
+                # (past the next non-ghost's start).
+                ModuleVersion(
+                    module_vid=9,
+                    module_id=6,
+                    code="MODF",
+                    version_number="1.0.0",
+                    start_release_id=3,
+                    end_release_id=1010000003,
+                    from_reference_date=date(2025, 1, 31),
+                    to_reference_date=date(2026, 3, 30),
+                ),
+                ModuleVersion(
+                    module_vid=10,
+                    module_id=6,
+                    code="MODF",
+                    version_number="1.1.0",
+                    start_release_id=1010000003,
+                    end_release_id=5,
+                    from_reference_date=date(2026, 3, 31),
+                    to_reference_date=date(2026, 3, 31),
+                ),
+                ModuleVersion(
+                    module_vid=11,
+                    module_id=6,
+                    code="MODF",
+                    version_number="1.2.0",
+                    start_release_id=5,
+                    end_release_id=None,
+                    from_reference_date=date(2026, 6, 1),
+                    to_reference_date=None,
+                ),
+            ]
+        )
+        memory_session.flush()
+        return ASTGeneratorService(memory_session)
+
+    def test_past_end_allowed_when_ghost_covers_release(self, svc):
+        # Reproduction of issue #221: MODA 1.0.0 ends at 4.2, but ghost
+        # MODA 1.1.0 covers 4.2 onwards, so 4.2 must be accepted.
+        mv, rel = svc._resolve_release("MODA", "1.0.0", "4.2")
+        assert rel.code == "4.2"
+        assert mv.version_number == "1.0.0"
+
+    def test_past_end_still_raised_when_no_ghost(self, svc):
+        with pytest.raises(ValueError, match="past the end"):
+            svc._resolve_release("MODC", "1.0.0", "4.2.1")
+
+    def test_predates_still_raised_when_no_ghost(self, svc):
+        # Predates branch is never relaxed by a ghost: ghost-fallback in
+        # ``_latest_prior_non_collapsed_vids`` picks strictly backward,
+        # so a ghost of the same module cannot legitimately produce this
+        # scenario. Kept as regression against accidental relaxation.
+        with pytest.raises(ValueError, match="predates module version"):
+            svc._resolve_release("MODC", "1.0.0", "4.0")
+
+    def test_ghost_of_another_module_does_not_relax(self, svc):
+        # MODD has no ghost of its own; MODA's ghost covers 4.2 but must
+        # not leak across modules.
+        with pytest.raises(ValueError, match="past the end"):
+            svc._resolve_release("MODD", "1.0.0", "4.2")
+
+    def test_open_ended_ghost_covers_every_release(self, svc):
+        # MODE ghost has start/end release ids both NULL -- covers all
+        # releases of its module, so 4.2.1 is accepted against 1.0.0.
+        mv, rel = svc._resolve_release("MODE", "1.0.0", "4.2.1")
+        assert rel.code == "4.2.1"
+        assert mv.version_number == "1.0.0"
+
+    def test_extension_stops_at_next_non_ghost_start(self, svc):
+        # MODF 1.0.0 ends at 4.2; ghost 1.1.0 covers [4.2, 4.2.1);
+        # non-ghost 1.2.0 starts at 4.2.1. 4.2 sits inside the ghost's
+        # region so is accepted (extension bridges the ghost), but 4.2.1
+        # is the next non-ghost's start -- extension stops there.
+        mv, rel = svc._resolve_release("MODF", "1.0.0", "4.2")
+        assert rel.code == "4.2"
+        assert mv.version_number == "1.0.0"
+        with pytest.raises(ValueError, match="past the end"):
+            svc._resolve_release("MODF", "1.0.0", "4.2.1")

--- a/tests/integration/services/test_scope_release_axis.py
+++ b/tests/integration/services/test_scope_release_axis.py
@@ -502,6 +502,7 @@ class TestResolveExplicitReleaseGhostFallback:
                     date=date(2026, 3, 1),
                 ),
                 Release(release_id=5, code="4.2.1", date=date(2026, 6, 1)),
+                Release(release_id=7, code="4.3", date=date(2026, 9, 1)),
                 # MODA -- past-the-end scenario (the DORA/issue-#221 shape).
                 # Non-ghost 1.0.0 covers [4.0, 4.2); ghost 1.1.0 covers
                 # [4.2, ∞). Request 4.2 against 1.0.0 must succeed.
@@ -612,6 +613,30 @@ class TestResolveExplicitReleaseGhostFallback:
                     from_reference_date=date(2026, 6, 1),
                     to_reference_date=None,
                 ),
+                # MODG -- bounded-ghost tail. Non-ghost 1.0.0 covers
+                # [4.0, 4.2); ghost 1.1.0 covers [4.2, 4.2.1); no sibling
+                # after. Extension goes up to the ghost's end (4.2.1) --
+                # NOT past it. Releases beyond 4.2.1 must still raise.
+                ModuleVersion(
+                    module_vid=12,
+                    module_id=7,
+                    code="MODG",
+                    version_number="1.0.0",
+                    start_release_id=3,
+                    end_release_id=1010000003,
+                    from_reference_date=date(2025, 1, 31),
+                    to_reference_date=date(2026, 3, 30),
+                ),
+                ModuleVersion(
+                    module_vid=13,
+                    module_id=7,
+                    code="MODG",
+                    version_number="1.1.0",
+                    start_release_id=1010000003,
+                    end_release_id=5,
+                    from_reference_date=date(2026, 3, 31),
+                    to_reference_date=date(2026, 3, 31),
+                ),
             ]
         )
         memory_session.flush()
@@ -648,6 +673,19 @@ class TestResolveExplicitReleaseGhostFallback:
         mv, rel = svc._resolve_release("MODE", "1.0.0", "4.2.1")
         assert rel.code == "4.2.1"
         assert mv.version_number == "1.0.0"
+
+    def test_extension_stops_at_bounded_ghost_end_when_no_sibling(self, svc):
+        # MODG 1.0.0 ends at 4.2; ghost 1.1.0 covers [4.2, 4.2.1) and
+        # nothing follows. The extension must stop at the ghost's own
+        # end (4.2.1). Releases inside the ghost pass; anything past its
+        # end must still raise "past the end".
+        mv, rel = svc._resolve_release("MODG", "1.0.0", "4.2")
+        assert rel.code == "4.2"
+        assert mv.version_number == "1.0.0"
+        with pytest.raises(ValueError, match="past the end"):
+            svc._resolve_release("MODG", "1.0.0", "4.2.1")
+        with pytest.raises(ValueError, match="past the end"):
+            svc._resolve_release("MODG", "1.0.0", "4.3")
 
     def test_extension_stops_at_next_non_ghost_start(self, svc):
         # MODF 1.0.0 ends at 4.2; ghost 1.1.0 covers [4.2, 4.2.1);


### PR DESCRIPTION
Body:
  ## Summary
  - `ast_generator._resolve_explicit_release` now consults `_effective_end_release_id`, which virtually extends the received `ModuleVersion`'s end past any adjacent chain of ghost siblings
  (same module, `FromReferenceDate == ToReferenceDate`) to the start of the next non-ghost sibling, or to `None` when only ghosts follow.
  - Aligns the strict window check with the ghost fallback in `dpm_xl.model_queries._resolve_with_ghost_fallback`, which already substitutes a ghost with its latest prior non-ghost. Without
  this fix, a validation issued with an explicit release just past the non-ghost fallback's end (e.g. DORA v1.1.0 ending at 4.2 with ghost v1.2.0 covering 4.2+) failed with `Release X is
  past the end of module version`. 
  - Predates branch is deliberately unchanged: `_latest_prior_non_collapsed_vids` picks strictly backward, so a legitimate ghost fallback can never produce that scenario.
  
  ## Test plan
  - [x] `pytest tests/integration/services/test_scope_release_axis.py` (18 passed — includes 6 new tests exercising: DORA-shape past-end, no-ghost negative, ghost of a different module,
  open-ended ghost, and extension terminating at the next non-ghost's `start_release_id`).
  - [x] `ruff format`, `ruff check`, `mypy src/` all clean.
  - [x] End-to-end reproduction on the DORA local DB: `ast_generator.script("DORA", "1.1.0", release="4.2")` now succeeds; the pre-fix `Release 4.2 is past the end of module version DORA
  1.1.0` no longer fires.

  Fixes #221
