### PR TITLE
fix: use real ORM attribute names in MLGeneration constructors

### DIFF
--- a/src/dpmcore/dpm_xl/ast/ml_generation.py
+++ b/src/dpmcore/dpm_xl/ast/ml_generation.py
@@ -201,7 +201,7 @@ class MLGeneration(ASTTemplate):
         argument = getattr(node, "argument", None)
         argument_id: int | None = None
         if argument:
-            parent_operator_id = parent_node.OperatorID
+            parent_operator_id = parent_node.operator_id
             argument_info = self.df_arguments[
                 (self.df_arguments["Name"] == argument)
                 & (self.df_arguments["OperatorID"] == parent_operator_id)
@@ -210,14 +210,14 @@ class MLGeneration(ASTTemplate):
                 argument_id = int(argument_info[0])
 
         operand_node = OperationNode(
-            OperatorID=operator_id,
-            OperationVID=self.op_version_id,
+            operator_id=operator_id,
+            operation_vid=self.op_version_id,
             parent=parent_node,
-            Scalar=scalar,
-            UseIntervalArithmetics=interval,
-            FallbackValue=fallback_value,
-            IsLeaf=is_leaf,
-            ArgumentID=argument_id,
+            scalar=scalar,
+            use_interval_arithmetics=interval,
+            fallback_value=fallback_value,
+            is_leaf=is_leaf,
+            argument_id=argument_id,
         )
 
         self.session.add(operand_node)
@@ -346,16 +346,16 @@ class MLGeneration(ASTTemplate):
             op_ref: OperandReference
             if component in ("r", "c", "s"):
                 op_ref = OperandReference(
-                    op_node=comp_node, OperandReference=component
+                    operation_node=comp_node, operand_reference=component
                 )
             else:
                 property_id = ItemCategoryQuery.get_property_id_from_code(
                     code=component, session=self.session_queries
                 )[0]
                 op_ref = OperandReference(
-                    op_node=comp_node,
-                    OperandReference="property",
-                    PropertyID=property_id,
+                    operation_node=comp_node,
+                    operand_reference="property",
+                    property_id=property_id,
                 )
 
             self.session.add(op_ref)
@@ -413,16 +413,16 @@ class MLGeneration(ASTTemplate):
         op_ref: OperandReference
         if property_ref_period_mangement(component):
             op_ref = OperandReference(
-                op_node=operand_node, OperandReference="refPeriod"
+                operation_node=operand_node, operand_reference="refPeriod"
             )
         else:
             property_id = ItemCategoryQuery.get_property_id_from_code(
                 code=component, session=self.session_queries
             )[0]
             op_ref = OperandReference(
-                op_node=operand_node,
-                OperandReference=ast_element.source_reference,
-                PropertyID=property_id,
+                operation_node=operand_node,
+                operand_reference=ast_element.source_reference,
+                property_id=property_id,
             )
         self.session.add(op_ref)
 
@@ -447,16 +447,16 @@ class MLGeneration(ASTTemplate):
         op_ref: OperandReference
         if property_ref_period_mangement(component):
             op_ref = OperandReference(
-                op_node=operand_node, OperandReference="refPeriod"
+                operation_node=operand_node, operand_reference="refPeriod"
             )
         else:
             property_id = ItemCategoryQuery.get_property_id_from_code(
                 code=component, session=self.session_queries
             )[0]
             op_ref = OperandReference(
-                op_node=operand_node,
-                OperandReference=ast_element.source_reference,
-                PropertyID=property_id,
+                operation_node=operand_node,
+                operand_reference=ast_element.source_reference,
+                property_id=property_id,
             )
         self.session.add(op_ref)
 
@@ -517,16 +517,16 @@ class MLGeneration(ASTTemplate):
         op_ref: OperandReference
         if property_ref_period_mangement(node.component):
             op_ref = OperandReference(
-                op_node=component_node, OperandReference="refPeriod"
+                operation_node=component_node, operand_reference="refPeriod"
             )
         else:
             property_id = ItemCategoryQuery.get_property_id_from_code(
                 code=node.component, session=self.session_queries
             )[0]
             op_ref = OperandReference(
-                op_node=component_node,
-                OperandReference=element.source_reference,
-                PropertyID=property_id,
+                operation_node=component_node,
+                operand_reference=element.source_reference,
+                property_id=property_id,
             )
         self.session.add(op_ref)
 
@@ -556,9 +556,9 @@ class MLGeneration(ASTTemplate):
         old_name_node = self.create_operation_node(old_name, is_leaf=True)
 
         old_operand_ref = OperandReference(
-            op_node=old_name_node,
-            OperandReference=old_name.source_reference,
-            PropertyID=old_property_id,
+            operation_node=old_name_node,
+            operand_reference=old_name.source_reference,
+            property_id=old_property_id,
         )
 
         self.session.add(old_operand_ref)
@@ -571,9 +571,9 @@ class MLGeneration(ASTTemplate):
         new_name_node = self.create_operation_node(new_name, is_leaf=True)
 
         new_operand_ref = OperandReference(
-            op_node=new_name_node,
-            OperandReference=new_name.source_reference,
-            PropertyID=old_property_id,
+            operation_node=new_name_node,
+            operand_reference=new_name.source_reference,
+            property_id=old_property_id,
         )
         self.session.add(new_operand_ref)
 
@@ -628,9 +628,9 @@ class MLGeneration(ASTTemplate):
                 raise SemanticError("1-3", variable=node.variable_code)
 
         operand_ref = OperandReference(
-            op_node=operand_node,
-            OperandReference=operand_reference,
-            VariableID=variable_id,
+            operation_node=operand_node,
+            operand_reference=operand_reference,
+            variable_id=variable_id,
         )
 
         self.session.add(operand_ref)
@@ -651,9 +651,9 @@ class MLGeneration(ASTTemplate):
         else:
             raise SemanticError("1-3", variable=node_value)
         operand_ref = OperandReference(
-            op_node=op_node,
-            OperandReference=node.source_reference,
-            VariableID=variable_id,
+            operation_node=op_node,
+            operand_reference=node.source_reference,
+            variable_id=variable_id,
         )
 
         self.session.add(operand_ref)
@@ -678,23 +678,23 @@ class MLGeneration(ASTTemplate):
 
         for e in data_xyz:
             operand_ref = OperandReference(
-                op_node=op_node,
+                operation_node=op_node,
                 x=e["x"] if significant_rows else None,
                 y=e["y"] if significant_cols else None,
                 z=e["z"] if significant_sheets else None,
-                OperandReference=node.source_reference,
-                VariableID=e["variable_id"],
+                operand_reference=node.source_reference,
+                variable_id=e["variable_id"],
             )
 
             self.session.add(operand_ref)
 
             operand_ref_loc = OperandReferenceLocation(
-                op_reference=operand_ref,
-                CellID=e["cell_id"],
-                Table=table,
-                Row=e["row_code"],
+                operand_reference=operand_ref,
+                cell_id=e["cell_id"],
+                table=table,
+                row=e["row_code"],
                 column=e["column_code"],
-                Sheet=e["sheet_code"],
+                sheet=e["sheet_code"],
             )
 
             self.session.add(operand_ref_loc)
@@ -725,9 +725,9 @@ class MLGeneration(ASTTemplate):
                 f"Property with code {node.dimension_code!r} not found"
             )
         operand_ref = OperandReference(
-            op_node=op_node,
-            OperandReference=node.source_reference,
-            PropertyID=property_row.item_id,
+            operation_node=op_node,
+            operand_reference=node.source_reference,
+            property_id=property_row.item_id,
         )
         self.session.add(operand_ref)
 
@@ -743,9 +743,9 @@ class MLGeneration(ASTTemplate):
                 signature=child.item, session=self.session_queries
             )[0]
             operand_ref = OperandReference(
-                op_node=op_node,
-                OperandReference=node.source_reference,
-                ItemID=item_id,
+                operation_node=op_node,
+                operand_reference=node.source_reference,
+                item_id=item_id,
             )
             self.session.add(operand_ref)
 
@@ -756,9 +756,9 @@ class MLGeneration(ASTTemplate):
             signature=node.item, session=self.session_queries
         )[0]
         operand_ref = OperandReference(
-            op_node=op_node,
-            OperandReference=node.source_reference,
-            ItemID=item_id,
+            operation_node=op_node,
+            operand_reference=node.source_reference,
+            item_id=item_id,
         )
         self.session.add(operand_ref)
 
@@ -769,7 +769,7 @@ class MLGeneration(ASTTemplate):
         op_version_id = self._get_op_version_id(node.operation_code)
 
         operand_ref = OperandReference(
-            op_node=op_node, OperandReference=op_version_id
+            operation_node=op_node, operand_reference=op_version_id
         )
         self.session.add(operand_ref)
 

--- a/tests/unit/ast/test_ml_generation.py
+++ b/tests/unit/ast/test_ml_generation.py
@@ -4,6 +4,7 @@ MR !74 set operators emit operation nodes instead of NotImplementedError.
 
 from unittest.mock import MagicMock
 
+import pandas as pd
 import pytest
 
 from dpmcore.dpm_xl.ast.ml_generation import MLGeneration
@@ -17,6 +18,12 @@ from dpmcore.dpm_xl.ast.nodes import (
     SubstrOp,
     SymdiffOp,
     UnionSetOp,
+    VarID,
+)
+from dpmcore.orm.operations import (
+    OperandReference,
+    OperandReferenceLocation,
+    OperationNode,
 )
 
 
@@ -156,3 +163,92 @@ def test_visit_empty_set_creates_leaf_without_operand_refs(ml_generation):
     assert ml_generation.create_operation_node.call_count == 1
     # No ``OperandReference`` rows added for children that don't exist.
     assert ml_generation.session.add.call_count == 0
+
+
+def test_create_operation_node_builds_operation_node_with_real_attributes(
+    ml_generation,
+):
+    ml_generation.session = MagicMock()
+    ml_generation.op_version_id = 99
+    ml_generation.df_operators = pd.DataFrame(
+        columns=["Symbol", "OperatorID", "Name"]
+    )
+    ml_generation.df_arguments = pd.DataFrame(
+        columns=["Name", "OperatorID", "ArgumentID"]
+    )
+    node = Constant(type_="Integer", value=1)
+    node.scalar = "1"
+
+    result = MLGeneration.create_operation_node(
+        ml_generation, node, is_leaf=True
+    )
+
+    assert isinstance(result, OperationNode)
+    assert result.operation_vid == 99
+    assert result.scalar == "1"
+    assert result.is_leaf is True
+
+
+def test_create_operation_node_resolves_argument_id_from_parent_operator_id(
+    ml_generation,
+):
+    ml_generation.session = MagicMock()
+    ml_generation.op_version_id = 99
+    ml_generation.df_operators = pd.DataFrame(
+        columns=["Symbol", "OperatorID", "Name"]
+    )
+    ml_generation.df_arguments = pd.DataFrame(
+        {"Name": ["left"], "OperatorID": [7], "ArgumentID": [11]}
+    )
+    node = Constant(type_="Integer", value=1)
+    node.argument = "left"
+    node.parent = OperationNode(operator_id=7)
+
+    result = MLGeneration.create_operation_node(ml_generation, node)
+
+    assert result.argument_id == 11
+
+
+def test_visit_var_id_builds_operand_reference_and_location_with_real_attributes(
+    ml_generation,
+):
+    ml_generation.session = MagicMock()
+    ml_generation.data = None
+    ml_generation.is_scripting = False
+    ml_generation.create_operation_node = MagicMock(
+        return_value=OperationNode()
+    )
+    ml_generation.extract_operand_data = MagicMock(
+        return_value=[
+            {
+                "x": None,
+                "y": None,
+                "z": None,
+                "variable_id": 42,
+                "cell_id": 7,
+                "row_code": "r1",
+                "column_code": "c1",
+                "sheet_code": "s1",
+            }
+        ]
+    )
+    node = VarID(
+        table="T1",
+        rows=None,
+        cols=None,
+        sheets=None,
+        interval=None,
+        default=None,
+    )
+
+    ml_generation.visit_VarID(node)
+
+    added = [call.args[0] for call in ml_generation.session.add.call_args_list]
+    op_ref = next(o for o in added if isinstance(o, OperandReference))
+    op_ref_loc = next(
+        o for o in added if isinstance(o, OperandReferenceLocation)
+    )
+    assert op_ref.variable_id == 42
+    assert op_ref.operand_reference == "variable"
+    assert op_ref_loc.cell_id == 7
+    assert op_ref_loc.table == "T1"


### PR DESCRIPTION
Closes #223 

## Summary

`MLGeneration` built `OperationNode`, `OperandReference`, and `OperandReferenceLocation` using DB column names instead of the ORM's actual Python attributes, raising `TypeError`/`AttributeError` on every expression passing through ML generation

## Checklist

- [X] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [X] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [X] Documentation updated (if applicable)

## Impact / Risk

- Breaking changes? (public API / CLI / REST endpoints / Django models)
- Database schema or migration concerns?
- Notes for release/changelog?

## Notes

<!-- Follow-ups, TODOs, or anything reviewers should know. -->
