### PR TITLE
feat(semantic): add baseCurrency as an implicit open-key

### DIFF
--- a/src/dpmcore/dpm_xl/ast/operands.py
+++ b/src/dpmcore/dpm_xl/ast/operands.py
@@ -66,9 +66,11 @@ operand_elements = ["table", "rows", "cols", "sheets", "default", "interval"]
 # These are special dimensions that arise from the reporting context itself
 # - refPeriod: The reference period of the report (date type "d")
 # - entityID: The identifier of the reporting entity (string type "s")
+# - baseCurrency: The reporting currency of the entity (string type "s")
 IMPLICIT_OPEN_KEYS = {
     "refPeriod": "d",  # date type
     "entityID": "s",  # string type
+    "baseCurrency": "s",  # string type
 }
 
 

--- a/src/dpmcore/dpm_xl/semantic_analyzer.py
+++ b/src/dpmcore/dpm_xl/semantic_analyzer.py
@@ -134,6 +134,9 @@ class InputAnalyzer(ASTTemplate, ABC):
             "entityID": ScalarFactory().database_types_mapping(
                 "s"
             )(),  # string type
+            "baseCurrency": ScalarFactory().database_types_mapping(
+                "s"
+            )(),  # string type
         }
 
     # Start of visiting nodes.

--- a/tests/unit/ast/test_implicit_open_keys.py
+++ b/tests/unit/ast/test_implicit_open_keys.py
@@ -1,0 +1,62 @@
+"""Unit tests for the implicit open-keys catalogue.
+
+``IMPLICIT_OPEN_KEYS`` (in ``dpm_xl/ast/operands.py``) and the mirror
+``global_variables`` map in ``dpm_xl/semantic_analyzer.py`` declare the
+dimensions that arise from the reporting context itself and therefore do
+not need to be looked up per-table via ``KeyComposition``.
+
+Every entry here is consumed by ``check_dimensions``/
+``check_getop_components`` in ``ast/operands.py`` to synthesize an
+``open_keys`` DataFrame row with ``property_id = -1`` and the declared
+scalar type. Regressions on these entries silently reject perfectly
+valid DPM-XL expressions used by the published ECB EGDQ checks (see
+``EGDQ_0510a`` etc. for ``baseCurrency``).
+"""
+
+from dpmcore.dpm_xl.ast.operands import IMPLICIT_OPEN_KEYS
+from dpmcore.dpm_xl.semantic_analyzer import InputAnalyzer
+
+
+def test_ref_period_is_implicit_open_key():
+    """``refPeriod`` — the reference period of the report — stays declared
+    as an implicit open key of date type ``"d"``.
+    """
+    assert IMPLICIT_OPEN_KEYS.get("refPeriod") == "d"
+
+
+def test_entity_id_is_implicit_open_key():
+    """``entityID`` — the reporting entity's identifier — stays declared
+    as an implicit open key of string type ``"s"``.
+    """
+    assert IMPLICIT_OPEN_KEYS.get("entityID") == "s"
+
+
+def test_base_currency_is_implicit_open_key():
+    """``baseCurrency`` — the reporting currency of the entity — is
+    declared as an implicit open key of string type ``"s"``.
+
+    Regression against #232: the ECB EGDQ checks (rows highlighted yellow
+    in the "DPM-XL publication" sheet Gregorio Guidi shared on
+    2026-07-16) filter operational-risk rows by ``baseCurrency = 'EUR'``;
+    that syntax must be accepted by the semantic analyser without
+    requiring a per-module ``KeyComposition`` declaration.
+    """
+    assert IMPLICIT_OPEN_KEYS.get("baseCurrency") == "s"
+
+
+def test_semantic_global_variables_mirror_implicit_open_keys():
+    """The semantic analyser exposes the same set of implicit open keys
+    via its ``global_variables`` map, so the two catalogues stay in sync.
+    Any entry added to :data:`IMPLICIT_OPEN_KEYS` must also appear here,
+    otherwise implicit keys would parse fine in ``check_dimensions``
+    (via ``operands.py``) but be treated as undeclared in
+    ``visit_Dimension`` (via ``semantic_analyzer.py``).
+    """
+    analyser = InputAnalyzer(expression="")
+    assert set(IMPLICIT_OPEN_KEYS.keys()).issubset(
+        set(analyser.global_variables.keys())
+    ), (
+        "IMPLICIT_OPEN_KEYS keys not covered by "
+        "InputAnalyzer.global_variables: "
+        f"{set(IMPLICIT_OPEN_KEYS) - set(analyser.global_variables)}"
+    )


### PR DESCRIPTION
## Summary
  - Adds `baseCurrency` (string type) to `IMPLICIT_OPEN_KEYS` in `dpm_xl/ast/operands.py`, alongside `refPeriod` and `entityID`, so DPM-XL expressions can reference it via `[where baseCurrency = 'EUR']` / `[get baseCurrency]` without a
  per-module `KeyComposition` declaration.
  - Mirrors the entry in `InputAnalyzer.global_variables` (`dpm_xl/semantic_analyzer.py`) so `visit_Dimension` resolves the scalar type correctly.
  - New test file `tests/unit/ast/test_implicit_open_keys.py` pins the three catalogue entries and adds a sync check between the two catalogues, guarding against silent drift.
  - Affected EGDQ checks (4 unique VR codes): EGDQ_0510a, EGDQ_0510b, EGDQ_0510c, EGDQ_0510d.

  ## Test plan 
  - [x] `poetry run pytest tests/unit/ast/test_implicit_open_keys.py` — 4/4 green.
  - [x] `poetry run ruff format` + `ruff check` clean on the touched files.
  - [x] `poetry run mypy` clean on the touched files.
  - [x] End-to-end smoke: `SemanticService.validate("{tC_17.01.a, r0921, c0010}[where baseCurrency = 'EUR']")` → `is_valid=True` against the local taxonomy.

  Fixes #232
