### PR TITLE
fix(dpm-xl): don't fail scope calc on non-filing-indicator preconditions

### DIFF
--- a/src/dpmcore/dpm_xl/model_queries.py
+++ b/src/dpmcore/dpm_xl/model_queries.py
@@ -1160,6 +1160,37 @@ class ModuleVersionQuery:
         )
 
     @staticmethod
+    def get_filing_indicator_codes(
+        session: "Session",
+        codes: Sequence[str],
+    ) -> set[str]:
+        """Return the subset of ``codes`` that are filing-indicator variables.
+
+        Only filing-indicator preconditions constrain an operation's module
+        scope. Precondition variables that are *not* filing indicators (for
+        example a business-model attribute compared against a set of values,
+        ``{vBM} in {'G-SIB', ...}``) are value conditions, not scoping
+        conditions, and must not force module resolution or fail scope
+        calculation. This helper lets scope calculation tell the two apart,
+        so a genuinely-missing filing indicator still errors while a value
+        condition is simply ignored.
+        """
+        if not codes:
+            return set()
+        rows = (
+            session.query(VariableVersion.code)
+            .join(
+                Variable,
+                VariableVersion.variable_id == Variable.variable_id,
+            )
+            .filter(VariableVersion.code.in_(list(codes)))
+            .filter(_is_filing_indicator())
+            .distinct()
+            .all()
+        )
+        return {row[0] for row in rows}
+
+    @staticmethod
     def get_module_version_by_vid(
         session: "Session",
         vid: int,

--- a/src/dpmcore/dpm_xl/model_queries.py
+++ b/src/dpmcore/dpm_xl/model_queries.py
@@ -13,6 +13,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    Collection,
     Hashable,
     Sequence,
 )
@@ -1162,7 +1163,7 @@ class ModuleVersionQuery:
     @staticmethod
     def get_filing_indicator_codes(
         session: "Session",
-        codes: Sequence[str],
+        codes: Collection[str],
     ) -> set[str]:
         """Return the subset of ``codes`` that are filing-indicator variables.
 

--- a/src/dpmcore/dpm_xl/utils/scopes_calculator.py
+++ b/src/dpmcore/dpm_xl/utils/scopes_calculator.py
@@ -436,6 +436,26 @@ class OperationScopeService:
                 ).difference(set(modules_preconditions))
 
             if missing_precondition_modules:
+                # Only filing-indicator preconditions constrain module scope.
+                # A precondition variable that is *not* a filing indicator
+                # (e.g. a business-model attribute used in a value condition,
+                # ``{vBM} in {'G-SIB', ...}``) has no module version by design
+                # and must not fail scope calculation. Keep as "missing" only
+                # those items that are genuinely filing indicators absent from
+                # the release's modules.
+                filing_indicator_items = (
+                    ModuleVersionQuery.get_filing_indicator_codes(
+                        session=session,
+                        codes=missing_precondition_modules,
+                    )
+                )
+                missing_precondition_modules = {
+                    code
+                    for code in missing_precondition_modules
+                    if code in filing_indicator_items
+                }
+
+            if missing_precondition_modules:
                 raise errors.SemanticError(
                     "1-14", precondition_items=missing_precondition_modules
                 )

--- a/src/dpmcore/dpm_xl/utils/scopes_calculator.py
+++ b/src/dpmcore/dpm_xl/utils/scopes_calculator.py
@@ -71,6 +71,27 @@ class OperationScopeService:
                 self._require_session()
             )
 
+        # Only filing-indicator preconditions constrain module scope. A
+        # precondition may also carry value conditions on non-filing-indicator
+        # items (e.g. a business-model attribute compared against a set of
+        # values, ``{vBM} in {'G-SIB', ...}``). Such items have no module
+        # version, so if left in ``precondition_items`` they would inflate the
+        # operand count (making every module fail the intra-module test and
+        # collapsing the scope to empty) and fail resolution with error 1-14.
+        # Drop them up front so only genuine filing indicators participate.
+        if precondition_items:
+            filing_indicator_items = (
+                ModuleVersionQuery.get_filing_indicator_codes(
+                    session=self._require_session(),
+                    codes=list(precondition_items),
+                )
+            )
+            precondition_items = [
+                item
+                for item in precondition_items
+                if item in filing_indicator_items
+            ]
+
         modules_info_dataframe = self.extract_module_info(
             tables_vids=tables_vids,
             precondition_items=precondition_items,
@@ -434,26 +455,6 @@ class OperationScopeService:
                 missing_precondition_modules = set(
                     precondition_items
                 ).difference(set(modules_preconditions))
-
-            if missing_precondition_modules:
-                # Only filing-indicator preconditions constrain module scope.
-                # A precondition variable that is *not* a filing indicator
-                # (e.g. a business-model attribute used in a value condition,
-                # ``{vBM} in {'G-SIB', ...}``) has no module version by design
-                # and must not fail scope calculation. Keep as "missing" only
-                # those items that are genuinely filing indicators absent from
-                # the release's modules.
-                filing_indicator_items = (
-                    ModuleVersionQuery.get_filing_indicator_codes(
-                        session=session,
-                        codes=missing_precondition_modules,
-                    )
-                )
-                missing_precondition_modules = {
-                    code
-                    for code in missing_precondition_modules
-                    if code in filing_indicator_items
-                }
 
             if missing_precondition_modules:
                 raise errors.SemanticError(

--- a/tests/integration/queries/test_precondition_filing_indicator.py
+++ b/tests/integration/queries/test_precondition_filing_indicator.py
@@ -11,10 +11,12 @@ import datetime
 
 import pytest
 
+from dpmcore import errors
 from dpmcore.dpm_xl.model_queries import (
     ModuleVersionQuery,
     VariableVersionQuery,
 )
+from dpmcore.dpm_xl.utils.scopes_calculator import OperationScopeService
 from dpmcore.orm.infrastructure import Release
 from dpmcore.orm.packaging import ModuleParameters, ModuleVersion
 from dpmcore.orm.variables import Variable, VariableVersion
@@ -29,6 +31,11 @@ def _seed(session):
     the type (``"filingindicator"`` and ``"Filing Indicator"``) to prove
     the normalised comparison matches both. A third ``"fact"`` variable
     shares a code but must never be returned.
+
+    Two more variables support the scope-filtering tests (issue #240):
+    ``BM`` is a business-model attribute (a non-filing-indicator value
+    condition) and ``C_99.00`` is a genuine filing indicator that no
+    module hosts.
     """
     session.add_all(
         [
@@ -38,6 +45,11 @@ def _seed(session):
             Variable(variable_id=1, type="filingindicator"),
             Variable(variable_id=2, type="Filing Indicator"),
             Variable(variable_id=3, type="fact"),
+            # Business-model attribute used in a value condition; NOT a
+            # filing indicator and hosted by no module by design.
+            Variable(variable_id=4, type="Business Model"),
+            # A genuine filing indicator that no module reports.
+            Variable(variable_id=5, type="filingindicator"),
             VariableVersion(
                 variable_vid=1,
                 variable_id=1,
@@ -57,6 +69,20 @@ def _seed(session):
                 variable_vid=3,
                 variable_id=3,
                 code="C_02.00",
+                start_release_id=1,
+                end_release_id=None,
+            ),
+            VariableVersion(
+                variable_vid=4,
+                variable_id=4,
+                code="BM",
+                start_release_id=1,
+                end_release_id=None,
+            ),
+            VariableVersion(
+                variable_vid=5,
+                variable_id=5,
+                code="C_99.00",
                 start_release_id=1,
                 end_release_id=None,
             ),
@@ -116,3 +142,109 @@ def test_check_precondition_finds_filing_indicator(memory_session):
 
     assert row is not None
     assert row.Code == "C_25.00"
+
+
+# --------------------------------------------------------------------- #
+# get_filing_indicator_codes — the helper backing the #240 scope fix.
+# --------------------------------------------------------------------- #
+
+
+def test_get_filing_indicator_codes_keeps_only_filing_indicators(
+    memory_session,
+):
+    _seed(memory_session)
+
+    result = ModuleVersionQuery.get_filing_indicator_codes(
+        memory_session, ["C_02.00", "C_25.00", "BM"]
+    )
+
+    # Both filing indicators are returned (regardless of type spelling);
+    # the business-model value-condition variable BM is excluded.
+    assert result == {"C_02.00", "C_25.00"}
+
+
+def test_get_filing_indicator_codes_ignores_unknown_code(memory_session):
+    _seed(memory_session)
+
+    # Neither BM (a known non-filing-indicator variable) nor a code that is
+    # not a variable at all counts as a filing indicator. Per issue #240 a
+    # value-condition item "need not even be a VariableVersion".
+    result = ModuleVersionQuery.get_filing_indicator_codes(
+        memory_session, ["BM", "DOES_NOT_EXIST"]
+    )
+
+    assert result == set()
+
+
+def test_get_filing_indicator_codes_empty_input_short_circuits(
+    memory_session,
+):
+    # Empty input returns an empty set without issuing a query.
+    assert (
+        ModuleVersionQuery.get_filing_indicator_codes(memory_session, [])
+        == set()
+    )
+
+
+# --------------------------------------------------------------------- #
+# calculate_operation_scope — a value condition must not fail scope calc,
+# while a genuinely-missing filing indicator still raises 1-14 (#240).
+# The up-front filter drops non-filing-indicator preconditions before they
+# reach module resolution.
+# --------------------------------------------------------------------- #
+
+
+def test_value_condition_precondition_does_not_fail_scope(memory_session):
+    _seed(memory_session)
+    svc = OperationScopeService(session=memory_session)
+
+    # C_02.00 (filing indicator) resolves to module COREP_OF; BM is a value
+    # condition with no module version and must simply be ignored.
+    scopes, _ = svc.calculate_operation_scope(
+        tables_vids=[],
+        precondition_items=["C_02.00", "BM"],
+        release_id=1,
+    )
+
+    # The filing indicator alone drives a single-module scope; BM neither
+    # raised 1-14 nor added a spurious module.
+    assert len(scopes) == 1
+    module_vids = {
+        comp.module_vid for comp in scopes[0].operation_scope_compositions
+    }
+    assert module_vids == {100}
+
+
+def test_only_value_condition_precondition_does_not_fail_scope(memory_session):
+    _seed(memory_session)
+    svc = OperationScopeService(session=memory_session)
+
+    # A precondition made up solely of a non-filing-indicator value
+    # condition is filtered to nothing, so scope calc resolves no module
+    # and simply returns no scopes instead of raising 1-14.
+    scopes, _ = svc.calculate_operation_scope(
+        tables_vids=[],
+        precondition_items=["BM"],
+        release_id=1,
+    )
+
+    assert scopes == []
+
+
+def test_missing_filing_indicator_still_raises_1_14(memory_session):
+    _seed(memory_session)
+    svc = OperationScopeService(session=memory_session)
+
+    # C_99.00 is a genuine filing indicator that no module hosts: it survives
+    # the filter and scope calculation must still fail with 1-14, while the BM
+    # value condition is dropped and never reported.
+    with pytest.raises(errors.SemanticError) as exc_info:
+        svc.calculate_operation_scope(
+            tables_vids=[],
+            precondition_items=["C_99.00", "BM"],
+            release_id=1,
+        )
+
+    assert exc_info.value.code == "1-14"
+    assert "C_99.00" in str(exc_info.value)
+    assert "BM" not in str(exc_info.value)

--- a/tests/unit/dpm_xl/test_scopes_lifecycle.py
+++ b/tests/unit/dpm_xl/test_scopes_lifecycle.py
@@ -34,6 +34,15 @@ def _patch_orm(monkeypatch):
         "info",
     }
 
+    # calculate_operation_scope now filters precondition_items down to
+    # filing indicators up front via ModuleVersionQuery. These lifecycle
+    # tests intend every precondition to be a filing indicator, so mock the
+    # classifier as an identity filter (returns the codes it is given).
+    model_queries_stub = MagicMock()
+    model_queries_stub.ModuleVersionQuery.get_filing_indicator_codes.side_effect = (
+        lambda session, codes: set(codes)
+    )
+
     stubs = {
         "dpmcore": pkg,
         "dpmcore.connection": MagicMock(),
@@ -45,7 +54,7 @@ def _patch_orm(monkeypatch):
         "dpmcore.orm.variables": MagicMock(),
         "dpmcore.errors": MagicMock(),
         "dpmcore.dpm_xl": dpm_xl,
-        "dpmcore.dpm_xl.model_queries": MagicMock(),
+        "dpmcore.dpm_xl.model_queries": model_queries_stub,
         "dpmcore.dpm_xl.utils": MagicMock(),
         "dpmcore.dpm_xl.utils.tokens": tokens_stub,
     }


### PR DESCRIPTION
## Summary

Narrows the "missing precondition modules" set to genuine filing indicators before raising `1-14`. A genuinely-missing filing indicator still errors; non-filing-indicator value conditions are ignored for  module scoping.

Closes #240 

## Checklist

- [X] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [X] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [ ] Documentation updated (if applicable)
