### PR TITLE
fix: emit alternative_dependencies as disjoint groups

### DIFF
--- a/src/dpmcore/services/ast_generator.py
+++ b/src/dpmcore/services/ast_generator.py
@@ -1221,7 +1221,7 @@ class ASTGeneratorService:
             )
 
         # Restrict alternatives to the script's genuine dependency modules
-        # so the pairs can never name a module absent from
+        # so the groups can never name a module absent from
         # ``dependency_modules`` (#202 dangling references).
         alt_deps = self._scope_calc.detect_alternative_dependencies(
             scope_results=all_scope_results,

--- a/src/dpmcore/services/scope_calculator.py
+++ b/src/dpmcore/services/scope_calculator.py
@@ -441,7 +441,7 @@ class ScopeCalculatorService:
         release_code: Optional[str] = None,
         valid_module_uris: Optional[Set[str]] = None,
     ) -> List[List[str]]:
-        """Detect pairs of external modules that are alternatives.
+        """Detect disjoint groups of interchangeable external modules.
 
         Two external modules are alternatives only when they are
         interchangeable dependencies of the *same* operation (#202):
@@ -450,6 +450,10 @@ class ScopeCalculatorService:
         scope. Each ``ScopeResult`` is one operation, so candidate pairs
         are collected per scope result — being the sole external of two
         *different* operations does not make two modules alternatives.
+
+        Interchangeable pairs are then collapsed into disjoint groups so
+        that when three or more modules are mutually interchangeable they
+        surface as one group rather than every overlapping pair (#242).
 
         Args:
             scope_results: One entry per operation.
@@ -462,7 +466,9 @@ class ScopeCalculatorService:
                 never name a module absent from ``dependency_modules``
                 (#202 dangling references).
 
-        Returns a list of ``[uri_a, uri_b]`` pairs (sorted).
+        Returns a list of disjoint groups; each group is a sorted list
+        of two or more interchangeable module URIs, and no module appears
+        in more than one group.
         """
         # Validate the release inputs (rejects an unknown code, or both
         # arguments at once). The resolved id is not threaded further:
@@ -495,7 +501,11 @@ class ScopeCalculatorService:
                 if pair[0] in valid_module_uris
                 and pair[1] in valid_module_uris
             ]
-        return uri_pairs
+        # Interchangeable pairs overlap when 3+ modules are mutually
+        # interchangeable (A-B, A-C, B-C). Collapse them into the disjoint
+        # groups the consumer expects: one connected component == one
+        # dependency slot fillable by any module in it (#242).
+        return self._group_alternative_pairs(uri_pairs)
 
     @staticmethod
     def _collect_external_vid_sets(
@@ -550,6 +560,38 @@ class ScopeCalculatorService:
                     for v2 in sorted_vids[i + 1 :]:
                         co_occurring.add((v1, v2))
         return co_occurring
+
+    @staticmethod
+    def _group_alternative_pairs(
+        uri_pairs: List[List[str]],
+    ) -> List[List[str]]:
+        """Collapse overlapping interchangeable pairs into disjoint groups.
+
+        Nodes are module URIs, edges are interchangeable pairs; each
+        connected component becomes one group. Guarantees the returned
+        groups share no module (disjoint), which is the shape the
+        consuming engine's dependency report expects (#242).
+        """
+        adjacency: Dict[str, Set[str]] = {}
+        for a, b in uri_pairs:
+            adjacency.setdefault(a, set()).add(b)
+            adjacency.setdefault(b, set()).add(a)
+
+        seen: Set[str] = set()
+        groups: List[List[str]] = []
+        for start in sorted(adjacency):
+            if start in seen:
+                continue
+            stack, component = [start], set()
+            while stack:
+                node = stack.pop()
+                if node in seen:
+                    continue
+                seen.add(node)
+                component.add(node)
+                stack.extend(adjacency[node] - seen)
+            groups.append(sorted(component))
+        return sorted(groups)
 
     def _map_pairs_to_uris(
         self,

--- a/tests/unit/services/test_scope_calculator.py
+++ b/tests/unit/services/test_scope_calculator.py
@@ -372,6 +372,89 @@ class TestDetectAlternativeDependencies:
         )
         assert result == []
 
+    @staticmethod
+    def _assert_disjoint(result):
+        """No module URI appears in more than one group."""
+        seen: set = set()
+        for group in result:
+            assert not (seen & set(group)), "groups overlap"
+            seen |= set(group)
+
+    def test_three_interchangeable_modules_form_one_group(self):
+        """3+ interchangeable modules collapse to one disjoint group (#242).
+
+        A, B and C are each the sole external of the same operation and
+        never co-occur, so they are mutually interchangeable. This must
+        surface as the single group ``[[A, B, C]]``, not the overlapping
+        pairs ``[[A, B], [A, C], [B, C]]``.
+        """
+        svc, SR = self._make_svc(
+            {10: "http://uri/a", 20: "http://uri/b", 30: "http://uri/c"},
+        )
+        sr = SR(
+            scopes=[
+                _scope([1, 10]),
+                _scope([1, 20]),
+                _scope([1, 30]),
+            ],
+        )
+        result = svc.detect_alternative_dependencies(
+            scope_results=[sr], primary_module_vid=1
+        )
+        assert result == [
+            sorted(["http://uri/a", "http://uri/b", "http://uri/c"])
+        ]
+        self._assert_disjoint(result)
+
+    def test_disjoint_alternative_groups(self):
+        """Independent interchangeable sets stay as separate groups (#242)."""
+        svc, SR = self._make_svc(
+            {
+                10: "http://uri/a",
+                20: "http://uri/b",
+                30: "http://uri/c",
+                40: "http://uri/d",
+            },
+        )
+        # Two operations, each with its own pair of interchangeables; the
+        # two pairs never share an operation, so they must not merge.
+        sr1 = SR(scopes=[_scope([1, 10]), _scope([1, 20])])
+        sr2 = SR(scopes=[_scope([1, 30]), _scope([1, 40])])
+        result = svc.detect_alternative_dependencies(
+            scope_results=[sr1, sr2], primary_module_vid=1
+        )
+        assert result == [
+            sorted(["http://uri/a", "http://uri/b"]),
+            sorted(["http://uri/c", "http://uri/d"]),
+        ]
+        self._assert_disjoint(result)
+
+    def test_non_transitive_merges_into_one_group(self):
+        """Non-transitive alternatives merge via connected components (#242).
+
+        A-B and B-C are interchangeable, but A and C co-occur (so they are
+        conjunctive, not alternatives). Connected components keep the
+        result disjoint by merging all three into one group.
+        """
+        svc, SR = self._make_svc(
+            {10: "http://uri/a", 20: "http://uri/b", 30: "http://uri/c"},
+        )
+        sr = SR(
+            scopes=[
+                _scope([1, 10]),
+                _scope([1, 20]),
+                _scope([1, 30]),
+                _scope([1, 10, 30]),  # A and C required together.
+            ],
+        )
+        result = svc.detect_alternative_dependencies(
+            scope_results=[sr], primary_module_vid=1
+        )
+        assert result == [
+            sorted(["http://uri/a", "http://uri/b", "http://uri/c"])
+        ]
+        self._assert_disjoint(result)
+
 
 # ------------------------------------------------------------------ #
 # detect_cross_module_dependencies (Fix 2)


### PR DESCRIPTION
## Summary

Fixes #242.

This change collapses the surviving interchangeable pairs into connected components, so mutually  interchangeable modules surface as a single disjoint group, e.g. `[[A, B, C]]`. A single pair still  yields one two-module group, so scripts with at most two interchangeable modules are unchanged. The  `valid_module_uris` dangling-reference guard from #202 is untouched.

Where the relation is not transitive (A and B are alternatives, B and C are alternatives, but A and C  co-occur), connected components keep the result disjoint by merging the three into one group.

## Checklist

  - [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
  - [x] Tests pass (`pytest`)
  - [x] Documentation updated (if applicable) 
 
  ## Impact / Risk

 - Breaking changes? Elements of `alternative_dependencies` in the generated script may now contain more  than two module URIs, where previously each element was always a two-module pair. The field type (a list  of lists of module URIs) and all API/CLI/REST signatures are unchanged.
 - Database schema or migration concerns?
 - Notes for release/changelog? `alternative_dependencies` now groups three or more interchangeable modules into a single disjoint group instead of overlapping pairs.