### PR TITLE
fix(dpm-xl): serialize match as BinOp with op "match"

### DIFF
--- a/src/dpmcore/dpm_xl/utils/serialization.py
+++ b/src/dpmcore/dpm_xl/utils/serialization.py
@@ -37,15 +37,12 @@ class ASTToJSONVisitor(NodeVisitor):
         return result
 
     def visit_BinOp(self, node: Any) -> NodeDict:
-        """Visit BinOp nodes."""
-        # Handle match operations as MatchCharactersOp
-        if node.op == "match":
-            return {
-                "class_name": "MatchCharactersOp",
-                "operand": self.visit(node.left),
-                "pattern": self.visit(node.right),
-            }
+        """Visit BinOp nodes.
 
+        ``match`` is a regular binary operator on the wire: the engine
+        consumes it as a ``BinOp`` with ``op == "match"`` (operand on the
+        left, pattern on the right), not as a dedicated node class.
+        """
         return {
             "class_name": "BinOp",
             "op": node.op,

--- a/tests/unit/ast/test_match_expression.py
+++ b/tests/unit/ast/test_match_expression.py
@@ -1,0 +1,42 @@
+"""Serialization tests for the ``match`` string operator.
+
+The engine consumes ``match`` as a plain ``BinOp`` with ``op == "match"``
+(operand on the left, pattern on the right). It must NOT be emitted as a
+dedicated ``MatchCharactersOp`` node -- that class name is not part of the
+engine's accepted AST vocabulary and fails schema validation.
+"""
+
+from dpmcore.dpm_xl.utils.serialization import ASTToJSONVisitor, serialize_ast
+from dpmcore.services.syntax import SyntaxService
+
+MATCH_EXPR = 'match({tC_27.00, c021}, "[A-Z0-9]{18}[0-9]{2}")'
+
+
+def test_match_serializes_as_binop():
+    ast = SyntaxService().parse(MATCH_EXPR)
+    node = ASTToJSONVisitor().visit(ast)["children"][0]
+
+    assert node["class_name"] == "BinOp"
+    assert node["op"] == "match"
+    # Operand on the left, regex pattern on the right.
+    assert node["left"]["class_name"] == "VarID"
+    assert node["right"]["class_name"] == "Constant"
+    assert node["right"]["value"] == "[A-Z0-9]{18}[0-9]{2}"
+
+
+def test_match_does_not_emit_match_characters_op():
+    """Guard against re-introducing the rejected ``MatchCharactersOp`` name."""
+    payload = serialize_ast(SyntaxService().parse(MATCH_EXPR))
+
+    def class_names(node):
+        if isinstance(node, dict):
+            cn = node.get("class_name")
+            if isinstance(cn, str):
+                yield cn
+            for value in node.values():
+                yield from class_names(value)
+        elif isinstance(node, list):
+            for item in node:
+                yield from class_names(item)
+
+    assert "MatchCharactersOp" not in set(class_names(payload))


### PR DESCRIPTION
## Summary

`ast_generator.script()` serialized the DPM-XL `match` operator as an AST node with `class_name: "MatchCharactersOp"`. The engine no longer recognises that node type — it consumes `match` as a plain `BinOp` with `op: "match"` — so any generated script containing a `match(...)` validation failed the engine's AST schema validation and the whole script was rejected.

This drops the `match` special-case in the serializer so it serializes as a standard `BinOp` (`op: "match"`, operand on the left, regex pattern on the right), matching how `in` is already handled.

Fixes #247 

## Checklist

- [X] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [X] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [ ] Documentation updated (if applicable)

## Impact / Risk

- Breaking changes? (public API / CLI / REST endpoints / Django models)
- Database schema or migration concerns?
- Notes for release/changelog?

