### PR TITLE
fix(scripts): declare cross-validation operands in dependency_modules

### DIFF
--- a/src/dpmcore/services/ast_generator.py
+++ b/src/dpmcore/services/ast_generator.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import re
 import zlib
+from dataclasses import dataclass, field
 from datetime import date as date_cls
 from typing import (
     TYPE_CHECKING,
@@ -42,6 +43,19 @@ _TABLE_CODE_NORMALIZER = re.compile(r"^([A-Z]+)_(\d+)_(\d+)$")
 _DEFAULT_FROM_DATE = "2001-01-01"
 _DEFAULT_NAMESPACE = "default_module"
 _DATA_FIELDS_TO_STRIP = ("data_type", "cell_code", "table_code", "table_vid")
+
+
+@dataclass(frozen=True)
+class _OperandRefs:
+    """What a single operation's operands reference.
+
+    ``tables`` are the table codes of its ``VarID`` nodes; ``variables``
+    maps every operand datapoint id to its scalar type code, across all
+    modules the operation spans (home module included).
+    """
+
+    tables: set[str] = field(default_factory=set)
+    variables: Dict[str, str] = field(default_factory=dict)
 
 
 def _normalize_variable_code(code: str) -> str:
@@ -179,7 +193,12 @@ class ASTGeneratorService:
             operations: Dict[str, Dict[str, Any]] = {}
             failed_operations: Dict[str, str] = {}
             scope_pairs: List[
-                Tuple[Tuple[str, str], "ScopeResult", Dict[str, str]]
+                Tuple[
+                    Tuple[str, str],
+                    "ScopeResult",
+                    Dict[str, str],
+                    _OperandRefs,
+                ]
             ] = []
             referenced_table_codes: set[str] = set()
             referenced_parameters: Dict[str, ParameterInfo] = {}
@@ -198,10 +217,14 @@ class ASTGeneratorService:
 
                 ast = self._semantic.ast
                 ast_dict = serialize_ast(ast)
-                self._clean_ast_data_entries(ast_dict)
-                referenced_table_codes.update(
-                    self._extract_referenced_tables(ast_dict)
+                # Operand refs come off the *raw* serialisation: cleaning
+                # strips the ``data_type`` each datapoint is typed by.
+                op_refs = _OperandRefs(
+                    tables=self._extract_referenced_tables(ast_dict),
+                    variables=self._extract_operand_datapoints(ast_dict),
                 )
+                self._clean_ast_data_entries(ast_dict)
+                referenced_table_codes.update(op_refs.tables)
                 self._accumulate_parameters(
                     referenced_parameters, result.parameters
                 )
@@ -238,7 +261,7 @@ class ASTGeneratorService:
                         "failed_operations": failed_operations,
                     }
                 ts = self._extract_time_shifts(ast)
-                scope_pairs.append((item, sr, ts))
+                scope_pairs.append((item, sr, ts, op_refs))
 
             primary_tables_full = self._scope_calc._get_module_tables(
                 primary_module_vid, release_id=release_id
@@ -1050,8 +1073,8 @@ class ASTGeneratorService:
         for entry in data:
             if not isinstance(entry, dict):
                 continue
-            for field in _DATA_FIELDS_TO_STRIP:
-                entry.pop(field, None)
+            for name in _DATA_FIELDS_TO_STRIP:
+                entry.pop(name, None)
 
     @staticmethod
     def _extract_referenced_tables(ast_dict: Any) -> set[str]:
@@ -1074,6 +1097,55 @@ class ASTGeneratorService:
 
         _walk(ast_dict)
         return codes
+
+    @staticmethod
+    def _extract_operand_datapoints(ast_dict: Any) -> Dict[str, str]:
+        """Walk a serialised AST and return ``{datapoint: data_type}``.
+
+        Every ``VarID`` node carries one ``data`` entry per data point its
+        cell reference resolves to, each holding the datapoint id (the
+        variable id) and its scalar type code. Must run *before*
+        :meth:`_clean_ast_data_entries`, which strips ``data_type``.
+
+        A datapoint with no type resolves to ``""`` — the same fallback
+        :meth:`ScopeCalculatorService._get_module_tables` uses when a
+        property carries no data type.
+        """
+        datapoints: Dict[str, str] = {}
+
+        def _walk(node: Any) -> None:
+            if isinstance(node, dict):
+                ASTGeneratorService._collect_varid_datapoints(node, datapoints)
+                children: Iterable[Any] = node.values()
+            elif isinstance(node, list):
+                children = node
+            else:
+                return
+            for child in children:
+                if isinstance(child, (dict, list)):
+                    _walk(child)
+
+        _walk(ast_dict)
+        return datapoints
+
+    @staticmethod
+    def _collect_varid_datapoints(
+        node: Dict[str, Any],
+        into: Dict[str, str],
+    ) -> None:
+        """Record one ``VarID`` node's datapoints and types into *into*."""
+        if node.get("class_name") != "VarID":
+            return
+        data = node.get("data")
+        if not isinstance(data, list):
+            return
+        for entry in data:
+            if not isinstance(entry, dict):
+                continue
+            dp = entry.get("datapoint")
+            if dp is None:
+                continue
+            into[str(dp)] = entry.get("data_type") or ""
 
     def _accumulate_parameters(
         self,
@@ -1175,7 +1247,12 @@ class ASTGeneratorService:
     def _build_dependency_info(
         self,
         scope_pairs: List[
-            Tuple[Tuple[str, str], "ScopeResult", Dict[str, str]]
+            Tuple[
+                Tuple[str, str],
+                "ScopeResult",
+                Dict[str, str],
+                _OperandRefs,
+            ]
         ],
         primary_module_vid: Optional[int],
         release_id: Optional[int],
@@ -1199,7 +1276,7 @@ class ASTGeneratorService:
         all_dep_modules: Dict[str, Any] = {}
         all_scope_results: List["ScopeResult"] = []
 
-        for item, sr, ts in scope_pairs:
+        for item, sr, ts, refs in scope_pairs:
             all_scope_results.append(sr)
             op_code = item[1]
             current = self._scope_calc.detect_cross_module_dependencies(
@@ -1209,6 +1286,8 @@ class ASTGeneratorService:
                 release_id=release_id,
                 time_shifts=ts,
                 compute_alternative_deps=False,
+                referenced_variables=refs.variables,
+                referenced_tables=refs.tables,
             )
             all_intra.extend(current.get("intra_instance_validations", []))
             self._merge_cross_deps(
@@ -1284,19 +1363,26 @@ class ASTGeneratorService:
     ) -> None:
         """Merge *new* dependency_modules into *existing*.
 
-        Avoids table duplicates within each module URI.
+        Avoids table duplicates within each module URI. Two operations
+        can reference different cells of the same dependency table, and
+        each declares only the datapoints it uses (#250), so a repeated
+        table unions its ``variables`` rather than keeping the first.
         """
         for uri, data in new.items():
             if uri not in existing:
                 existing[uri] = data
-            else:
-                for tbl, tbl_data in data.get("tables", {}).items():
-                    existing[uri].setdefault("tables", {}).setdefault(
-                        tbl, tbl_data
-                    )
-                existing[uri].setdefault("variables", {}).update(
-                    data.get("variables", {})
-                )
+                continue
+            tables = existing[uri].setdefault("tables", {})
+            for tbl, tbl_data in data.get("tables", {}).items():
+                if tbl not in tables:
+                    tables[tbl] = tbl_data
+                    continue
+                merged_vars = dict(tables[tbl].get("variables", {}))
+                merged_vars.update(tbl_data.get("variables", {}))
+                tables[tbl] = {**tables[tbl], "variables": merged_vars}
+            existing[uri].setdefault("variables", {}).update(
+                data.get("variables", {})
+            )
 
     @staticmethod
     def _to_ref_period(internal: str) -> str:

--- a/src/dpmcore/services/scope_calculator.py
+++ b/src/dpmcore/services/scope_calculator.py
@@ -411,6 +411,17 @@ class ScopeCalculatorService:
         if not tables_dict:
             return None
 
+        # The timeshift is a module-level property carried by the dependency
+        # module's tables. Compute it BEFORE narrowing: narrowing drops any
+        # table not referenced by the cross-rules, and a dropped table takes
+        # its timeshift with it — a module whose only timeshifted table is
+        # not referenced would otherwise fall back to ref_period T.
+        ref_period = "T"
+        for tbl_code in tables_dict:
+            rp = ts.get(tbl_code)
+            if rp and rp != "T":
+                ref_period = rp
+
         # #250: declare only the tables and datapoints the cross-rules
         # actually reference — a whole dependency module is 100+ tables and
         # 10k+ variables, where native EBA scripts declare a handful.
@@ -419,12 +430,6 @@ class ScopeCalculatorService:
         )
         if narrowed:
             tables_dict = narrowed
-
-        ref_period = "T"
-        for tbl_code in tables_dict:
-            rp = ts.get(tbl_code)
-            if rp and rp != "T":
-                ref_period = rp
 
         module_entry: Dict[str, Any] = {
             "URI": uri,

--- a/src/dpmcore/services/scope_calculator.py
+++ b/src/dpmcore/services/scope_calculator.py
@@ -237,6 +237,8 @@ class ScopeCalculatorService:
         time_shifts: Optional[Dict[str, str]] = None,
         compute_alternative_deps: bool = True,
         release_code: Optional[str] = None,
+        referenced_variables: Optional[Dict[str, str]] = None,
+        referenced_tables: Optional[Set[str]] = None,
     ) -> Dict[str, Any]:
         """Build dependency information for a scope result.
 
@@ -256,6 +258,15 @@ class ScopeCalculatorService:
             release_code: Optional release code; resolved to
                 ``release_id`` via :class:`Release.code`. Mutually
                 exclusive with ``release_id``.
+            referenced_variables: Optional ``{datapoint: type_code}`` of
+                every operand datapoint the operation references, across
+                all modules it spans — home module included. Declared in
+                each dependency module's ``variables`` map (#251).
+            referenced_tables: Optional table codes the operation
+                references. Together with ``referenced_variables`` this
+                narrows each dependency module's declaration to the
+                subset the operation uses (#250); omit both to declare
+                the dependency modules whole.
 
         Returns a dict with:
         - ``intra_instance_validations``
@@ -343,6 +354,8 @@ class ScopeCalculatorService:
                 release_id=release_id,
                 ts=ts,
                 operation_code=operation_code,
+                referenced_variables=referenced_variables,
+                referenced_tables=referenced_tables,
             )
             if entry is None:
                 continue
@@ -375,6 +388,8 @@ class ScopeCalculatorService:
         release_id: Optional[int],
         ts: Dict[str, str],
         operation_code: Optional[str],
+        referenced_variables: Optional[Dict[str, str]] = None,
+        referenced_tables: Optional[Set[str]] = None,
     ) -> Optional[Tuple[Dict[str, Any], str, Dict[str, Any]]]:
         """Build a single (cross_dep, uri, dependency_module) triple.
 
@@ -395,6 +410,15 @@ class ScopeCalculatorService:
         }
         if not tables_dict:
             return None
+
+        # #250: declare only the tables and datapoints the cross-rules
+        # actually reference — a whole dependency module is 100+ tables and
+        # 10k+ variables, where native EBA scripts declare a handful.
+        narrowed = self._narrow_dependency_tables(
+            tables_dict, referenced_tables, referenced_variables
+        )
+        if narrowed:
+            tables_dict = narrowed
 
         ref_period = "T"
         for tbl_code in tables_dict:
@@ -419,15 +443,63 @@ class ScopeCalculatorService:
             "from_reference_date": (str(from_date) if from_date else ""),
             "to_reference_date": (str(to_date) if to_date else ""),
         }
+        variables: Dict[str, str] = {
+            k: v
+            for tbl in tables_dict.values()
+            for k, v in tbl.get("variables", {}).items()
+        }
+        # #251: the engine resolves *every* operand of a cross-instance
+        # validation against this map — including operands owned by the
+        # home module. A referenced datapoint missing here leaves the
+        # engine unable to build that operand: a bare single-cell home
+        # operand fails with "Scalar can't be created for this data" and
+        # an aggregated one silently computes 0. The dependency module's
+        # own definition of a datapoint wins over the referencing AST's.
+        for var_id, type_code in sorted((referenced_variables or {}).items()):
+            variables.setdefault(var_id, type_code)
         dep_module = {
             "tables": tables_dict,
-            "variables": {
-                k: v
-                for tbl in tables_dict.values()
-                for k, v in tbl.get("variables", {}).items()
-            },
+            "variables": variables,
         }
         return cross_dep, uri, dep_module
+
+    @staticmethod
+    def _narrow_dependency_tables(
+        tables_dict: Dict[str, Any],
+        referenced_tables: Optional[Set[str]],
+        referenced_variables: Optional[Dict[str, str]],
+    ) -> Dict[str, Any]:
+        """Restrict a dependency module to its referenced tables/datapoints.
+
+        Returns ``{}`` when the caller supplied no reference information,
+        or when narrowing would leave nothing declarable. The caller then
+        keeps the unnarrowed module: over-declaring is wrong, but dropping
+        a genuine cross-instance dependency outright is worse.
+        """
+        if referenced_tables is None and referenced_variables is None:
+            return {}
+
+        narrowed: Dict[str, Any] = {}
+        for tcode, tdata in tables_dict.items():
+            if (
+                referenced_tables is not None
+                and tcode not in referenced_tables
+            ):
+                continue
+            variables = tdata.get("variables", {})
+            if referenced_variables is not None:
+                variables = {
+                    var_id: type_code
+                    for var_id, type_code in variables.items()
+                    if var_id in referenced_variables
+                }
+            # An empty variables map violates the engine schema's
+            # ``minProperties: 1``, so a table narrowed down to nothing is
+            # dropped rather than declared empty.
+            if not variables:
+                continue
+            narrowed[tcode] = {**tdata, "variables": variables}
+        return narrowed
 
     # ------------------------------------------------------------------ #
     # Alternative dependency detection (Fix 3)

--- a/tests/integration/services/test_cross_module_classification.py
+++ b/tests/integration/services/test_cross_module_classification.py
@@ -85,3 +85,100 @@ def test_primary_hosting_no_tables_is_not_intra(fixture_session):
     assert result["intra"] == []
     assert result["cross"] == 0
     assert result["tables"] == []
+
+
+def _operand_datapoints(node) -> set[str]:
+    """Every ``VarID`` datapoint id in a serialised operation AST."""
+    found: set[str] = set()
+    if isinstance(node, dict):
+        if node.get("class_name") == "VarID":
+            for entry in node.get("data") or []:
+                if isinstance(entry, dict) and entry.get("datapoint"):
+                    found.add(str(entry["datapoint"]))
+        for value in node.values():
+            if isinstance(value, (dict, list)):
+                found |= _operand_datapoints(value)
+    elif isinstance(node, list):
+        for item in node:
+            if isinstance(item, (dict, list)):
+                found |= _operand_datapoints(item)
+    return found
+
+
+def test_cross_validation_operands_declared_in_dependency(fixture_session):
+    """Regression for #251: every operand datapoint of a cross-instance
+    validation — home-module ones included — is declared in the
+    ``variables`` map of each module the validation depends on.
+    """
+    code = "v22973_m"
+    expression = _latest_expression(fixture_session, code)
+    result = ASTGeneratorService(fixture_session).script(
+        expressions=[(expression, code)],
+        module_code="IF_CLASS2",
+        module_version="1.4.0",
+    )
+    assert result["success"], result["error"]
+    module = next(iter(result["enriched_ast"].values()))
+    dep_modules = module["dependency_modules"]
+    assert dep_modules, "v22973_m must be cross-instance for IF_CLASS2"
+
+    operands = _operand_datapoints(module["operations"][code]["ast"])
+    assert operands, "the validation must reference at least one datapoint"
+    home_variables = set(module["variables"])
+    assert operands & home_variables, (
+        "v22973_m has home-module operands: they are what #251 was about"
+    )
+
+    for uri, dep in dep_modules.items():
+        missing = operands - set(dep["variables"])
+        assert not missing, f"{uri} omits operand datapoints {sorted(missing)}"
+
+
+def test_dependency_declares_only_referenced_subset(fixture_session):
+    """Regression for #250: a dependency module is declared as the subset
+    the cross-rules reference, not as the whole module.
+    """
+    code = "v22973_m"
+    expression = _latest_expression(fixture_session, code)
+    result = ASTGeneratorService(fixture_session).script(
+        expressions=[(expression, code)],
+        module_code="IF_CLASS2",
+        module_version="1.4.0",
+    )
+    assert result["success"], result["error"]
+    module = next(iter(result["enriched_ast"].values()))
+    dep_modules = module["dependency_modules"]
+    assert dep_modules, "v22973_m must be cross-instance for IF_CLASS2"
+
+    referenced_tables = set(
+        _referenced_tables(module["operations"][code]["ast"])
+    )
+    operands = _operand_datapoints(module["operations"][code]["ast"])
+    for uri, dep in dep_modules.items():
+        assert set(dep["tables"]) <= referenced_tables, (
+            f"{uri} declares tables no operation references: "
+            f"{sorted(set(dep['tables']) - referenced_tables)}"
+        )
+        for tcode, table in dep["tables"].items():
+            assert table["variables"], f"{uri}/{tcode} declares no variables"
+            extra = set(table["variables"]) - operands
+            assert not extra, (
+                f"{uri}/{tcode} declares unreferenced datapoints "
+                f"{sorted(extra)[:10]}"
+            )
+
+
+def _referenced_tables(node) -> set[str]:
+    """Every ``VarID`` table code in a serialised operation AST."""
+    found: set[str] = set()
+    if isinstance(node, dict):
+        if node.get("class_name") == "VarID" and node.get("table"):
+            found.add(node["table"])
+        for value in node.values():
+            if isinstance(value, (dict, list)):
+                found |= _referenced_tables(value)
+    elif isinstance(node, list):
+        for item in node:
+            if isinstance(item, (dict, list)):
+                found |= _referenced_tables(item)
+    return found

--- a/tests/unit/services/test_ast_generator.py
+++ b/tests/unit/services/test_ast_generator.py
@@ -199,6 +199,69 @@ class TestExtractReferencedTables:
 
 
 # ------------------------------------------------------------------ #
+# _extract_operand_datapoints (#251)
+# ------------------------------------------------------------------ #
+
+
+class TestExtractOperandDatapoints:
+    def test_collects_datapoints_with_types_across_modules(self):
+        """Both sides of a cross-module rule are collected (#251)."""
+        _, Cls, _ = _bare_svc()
+        ast = {
+            "class_name": "BinOp",
+            "op": "<=",
+            "left": {
+                "class_name": "VarID",
+                "table": "C_01.00",
+                "data": [{"datapoint": 32673, "data_type": "m"}],
+            },
+            "right": {
+                "class_name": "VarID",
+                "table": "F_01.03",
+                "data": [{"datapoint": 56987, "data_type": "m"}],
+            },
+        }
+        assert Cls._extract_operand_datapoints(ast) == {
+            "32673": "m",
+            "56987": "m",
+        }
+
+    def test_collects_every_datapoint_of_a_multi_cell_operand(self):
+        _, Cls, _ = _bare_svc()
+        ast = {
+            "class_name": "VarID",
+            "table": "C_04.00",
+            "data": [
+                {"datapoint": 1, "data_type": "i"},
+                {"datapoint": 2, "data_type": "e"},
+            ],
+        }
+        assert Cls._extract_operand_datapoints(ast) == {"1": "i", "2": "e"}
+
+    def test_missing_type_falls_back_to_empty_string(self):
+        _, Cls, _ = _bare_svc()
+        ast = {"class_name": "VarID", "data": [{"datapoint": 9}]}
+        assert Cls._extract_operand_datapoints(ast) == {"9": ""}
+
+    def test_entries_without_datapoint_are_skipped(self):
+        _, Cls, _ = _bare_svc()
+        ast = {
+            "class_name": "VarID",
+            "data": [{"data_type": "m"}, {"datapoint": None}, "junk"],
+        }
+        assert Cls._extract_operand_datapoints(ast) == {}
+
+    def test_ignores_non_varid_nodes(self):
+        _, Cls, _ = _bare_svc()
+        ast = {
+            "class_name": "Constant",
+            "value": 0,
+            "data": [{"datapoint": 5}],
+        }
+        assert Cls._extract_operand_datapoints(ast) == {}
+
+
+# ------------------------------------------------------------------ #
 # _build_module_info / _build_release_info / _build_dates
 # ------------------------------------------------------------------ #
 
@@ -693,11 +756,11 @@ class TestBuildDependencyInfo:
         )
 
     def test_none_when_primary_missing(self):
-        svc, _, _ = _bare_svc()
+        svc, _, mod = _bare_svc()
         svc._scope_calc = _scope_calc_mock()
         assert (
             svc._build_dependency_info(
-                scope_pairs=[(("e",), MagicMock(), {})],
+                scope_pairs=[(("e",), MagicMock(), {}, mod._OperandRefs())],
                 primary_module_vid=None,
                 release_id=None,
             )
@@ -715,7 +778,7 @@ class TestBuildDependencyInfo:
         )
 
     def test_aggregates_and_dedupes_intra(self):
-        svc, _, _ = _bare_svc()
+        svc, _, mod = _bare_svc()
         svc._scope_calc = _scope_calc_mock(
             detect_return={
                 "intra_instance_validations": ["v1"],
@@ -724,8 +787,8 @@ class TestBuildDependencyInfo:
             }
         )
         scope_pairs = [
-            (("e1", "v1"), MagicMock(), {}),
-            (("e2", "v1"), MagicMock(), {}),
+            (("e1", "v1"), MagicMock(), {}, mod._OperandRefs()),
+            (("e2", "v1"), MagicMock(), {}, mod._OperandRefs()),
         ]
         out = svc._build_dependency_info(
             scope_pairs=scope_pairs,
@@ -751,27 +814,38 @@ class TestMergeDepModules:
         )
         assert "http://a" in existing
 
-    def test_existing_uri_merges_tables_without_overwriting(self):
+    def test_existing_uri_unions_repeated_table_variables(self):
+        """Two operations referencing different cells of the same
+        dependency table must both end up declared (#250).
+        """
         _, Cls, _ = _bare_svc()
         existing = {
             "http://a": {
-                "tables": {"T1": {"variables": {}, "open_keys": {}}},
+                "tables": {
+                    "T1": {"variables": {"v1": "x"}, "open_keys": {"qA": "e"}}
+                },
                 "variables": {"v1": "x"},
             }
         }
         new = {
             "http://a": {
                 "tables": {
-                    "T1": {"variables": {"NEW": "y"}, "open_keys": {}},
-                    "T2": {"variables": {}, "open_keys": {}},
+                    "T1": {"variables": {"v2": "y"}, "open_keys": {"qA": "e"}},
+                    "T2": {"variables": {"v3": "z"}, "open_keys": {}},
                 },
-                "variables": {"v2": "y"},
+                "variables": {"v2": "y", "v3": "z"},
             }
         }
         Cls._merge_dep_modules(existing, new)
-        assert existing["http://a"]["tables"]["T1"]["variables"] == {}
+        t1 = existing["http://a"]["tables"]["T1"]
+        assert t1["variables"] == {"v1": "x", "v2": "y"}
+        assert t1["open_keys"] == {"qA": "e"}
         assert "T2" in existing["http://a"]["tables"]
-        assert existing["http://a"]["variables"] == {"v1": "x", "v2": "y"}
+        assert existing["http://a"]["variables"] == {
+            "v1": "x",
+            "v2": "y",
+            "v3": "z",
+        }
 
 
 # ------------------------------------------------------------------ #

--- a/tests/unit/services/test_scope_calculator.py
+++ b/tests/unit/services/test_scope_calculator.py
@@ -699,6 +699,156 @@ class TestDetectCrossModuleDependencies:
         assert "T_01" in dm["http://uri/mod_20"]["tables"]
         assert dm["http://uri/mod_20"]["variables"] == {"v1": "x"}
 
+    def test_referenced_home_variables_declared(self):
+        """Regression for #251: a cross-validation's home-module operand
+        datapoints must appear in the dependency module's ``variables``
+        map, or the engine cannot build the home operand.
+        """
+        svc, SR = self._make_svc()
+        svc._get_module_tables = lambda vid, release_id=None: {
+            "F_01.03": {
+                "variables": {"56987": "m"},
+                "open_keys": {},
+            }
+        }
+
+        mv = MagicMock()
+        mv.module_vid = 20
+        mv.version_number = "1.0"
+        mv.from_reference_date = None
+        mv.to_reference_date = None
+
+        q = svc.session.query.return_value
+        q.filter.return_value.all.return_value = [mv]
+
+        sr = SR(
+            scopes=[_scope([10, 20])],
+            is_cross_module=True,
+        )
+        info = svc.detect_cross_module_dependencies(
+            scope_result=sr,
+            primary_module_vid=10,
+            # {tC_01.00,...} <= {tF_01.03,...}: 32673 is the home operand.
+            referenced_variables={"32673": "m", "56987": "m"},
+        )
+        dep = info["dependency_modules"]["http://uri/mod_20"]
+        assert dep["variables"] == {"32673": "m", "56987": "m"}
+        # tables stay dependency-side only.
+        assert set(dep["tables"]) == {"F_01.03"}
+
+    def test_declares_only_referenced_tables_and_datapoints(self):
+        """Regression for #250: a dependency module is declared as the
+        subset the cross-rules reference, not whole.
+        """
+        svc, SR = self._make_svc()
+        svc._get_module_tables = lambda vid, release_id=None: {
+            "F_22.02": {
+                "variables": {"1": "m", "2": "m", "3": "m"},
+                "open_keys": {"qAS": "e"},
+            },
+            # Referenced by no cross-rule: must not be declared.
+            "F_99.00": {"variables": {"9": "m"}, "open_keys": {}},
+        }
+
+        mv = MagicMock()
+        mv.module_vid = 20
+        mv.version_number = "1.0"
+        mv.from_reference_date = None
+        mv.to_reference_date = None
+
+        q = svc.session.query.return_value
+        q.filter.return_value.all.return_value = [mv]
+
+        info = svc.detect_cross_module_dependencies(
+            scope_result=SR(scopes=[_scope([10, 20])], is_cross_module=True),
+            primary_module_vid=10,
+            referenced_tables={"G_01.00", "F_22.02"},
+            referenced_variables={"1": "m", "500": "m"},
+        )
+        dep = info["dependency_modules"]["http://uri/mod_20"]
+        assert set(dep["tables"]) == {"F_22.02"}
+        assert dep["tables"]["F_22.02"]["variables"] == {"1": "m"}
+        # open_keys survive the narrowing (#122).
+        assert dep["tables"]["F_22.02"]["open_keys"] == {"qAS": "e"}
+        # 500 is the home operand grafted in by #251.
+        assert dep["variables"] == {"1": "m", "500": "m"}
+
+    def test_whole_module_declared_when_no_refs_supplied(self):
+        """Callers passing no reference info keep the unnarrowed module."""
+        svc, SR = self._make_svc()
+        svc._get_module_tables = lambda vid, release_id=None: {
+            "F_22.02": {"variables": {"1": "m"}, "open_keys": {}},
+            "F_99.00": {"variables": {"9": "m"}, "open_keys": {}},
+        }
+
+        mv = MagicMock()
+        mv.module_vid = 20
+        mv.version_number = "1.0"
+        mv.from_reference_date = None
+        mv.to_reference_date = None
+
+        q = svc.session.query.return_value
+        q.filter.return_value.all.return_value = [mv]
+
+        info = svc.detect_cross_module_dependencies(
+            scope_result=SR(scopes=[_scope([10, 20])], is_cross_module=True),
+            primary_module_vid=10,
+        )
+        dep = info["dependency_modules"]["http://uri/mod_20"]
+        assert set(dep["tables"]) == {"F_22.02", "F_99.00"}
+
+    def test_dependency_kept_whole_when_narrowing_empties_it(self):
+        """Narrowing must never drop a genuine cross-instance dependency:
+        if nothing matches, the module is declared unnarrowed.
+        """
+        svc, SR = self._make_svc()
+        svc._get_module_tables = lambda vid, release_id=None: {
+            "F_22.02": {"variables": {"1": "m"}, "open_keys": {}},
+        }
+
+        mv = MagicMock()
+        mv.module_vid = 20
+        mv.version_number = "1.0"
+        mv.from_reference_date = None
+        mv.to_reference_date = None
+
+        q = svc.session.query.return_value
+        q.filter.return_value.all.return_value = [mv]
+
+        info = svc.detect_cross_module_dependencies(
+            scope_result=SR(scopes=[_scope([10, 20])], is_cross_module=True),
+            primary_module_vid=10,
+            referenced_tables={"Z_00.00"},
+            referenced_variables={"777": "m"},
+        )
+        dep = info["dependency_modules"]["http://uri/mod_20"]
+        assert set(dep["tables"]) == {"F_22.02"}
+        assert dep["variables"] == {"1": "m", "777": "m"}
+
+    def test_module_definition_wins_over_referenced_type(self):
+        """A datapoint the dependency module defines keeps that type."""
+        svc, SR = self._make_svc()
+        svc._get_module_tables = lambda vid, release_id=None: {
+            "F_01.03": {"variables": {"56987": "m"}, "open_keys": {}}
+        }
+
+        mv = MagicMock()
+        mv.module_vid = 20
+        mv.version_number = "1.0"
+        mv.from_reference_date = None
+        mv.to_reference_date = None
+
+        q = svc.session.query.return_value
+        q.filter.return_value.all.return_value = [mv]
+
+        info = svc.detect_cross_module_dependencies(
+            scope_result=SR(scopes=[_scope([10, 20])], is_cross_module=True),
+            primary_module_vid=10,
+            referenced_variables={"56987": ""},
+        )
+        dep = info["dependency_modules"]["http://uri/mod_20"]
+        assert dep["variables"] == {"56987": "m"}
+
     def test_dependency_table_open_keys_propagate(self):
         """Regression for #122: a dependency module's table entries must
         keep their ``open_keys`` so the engine can join on them.


### PR DESCRIPTION
The adam-engine resolves every operand of a cross-instance validation against dependency_modules[<dep>].variables, home-module operands included. The generator declared only the dependency module's own variables, so a home operand could not be built: a bare single cell failed with "Scalar can't be created for this data" and an aggregated one silently computed 0 (#251).

Collect every operand datapoint (and its type) per operation from the raw serialised AST — before _clean_ast_data_entries strips data_type — and graft them into each dependency module's variables map. The dependency module's own definition of a datapoint still wins.

While declaring the referenced subset, drop the over-declaration: a dependency module was emitted whole (122 tables / 13k variables where native EBA scripts declare a handful), so restrict its tables to the ones the cross-rules reference and each table's variables to the referenced datapoints, keeping open_keys intact (#250). If narrowing would leave nothing declarable the module is kept whole rather than dropped — over-declaring is wrong, losing a genuine cross-instance dependency is worse.

_merge_dep_modules now unions a repeated table's variables instead of keeping the first entry: with narrowing, two operations touching different cells of the same dependency table each declare only their own datapoints and both must survive the merge.

Closes #251
Closes #250

## Summary

<!-- Short description of the change and why it's needed. -->

## Checklist

- [ ] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [ ] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [ ] Documentation updated (if applicable)

## Impact / Risk

- Breaking changes? (public API / CLI / REST endpoints / Django models)
- Database schema or migration concerns?
- Notes for release/changelog?

## Notes

<!-- Follow-ups, TODOs, or anything reviewers should know. -->
