### PR TITLE
fix(dpm-xl): tighten default-value semantic checks around isnull

### DIFF
--- a/src/dpmcore/dpm_xl/semantic_analyzer.py
+++ b/src/dpmcore/dpm_xl/semantic_analyzer.py
@@ -211,21 +211,8 @@ class InputAnalyzer(ASTTemplate, ABC):
         self, node: UnaryOp
     ) -> Operand:
         op = cast(str, node.op)
-        # ``isnull(x)`` on a selection with a non-null default is tautologically
-        # false (the default guarantees the operand is never null). Warn so the
-        # user notices the modelling mistake instead of relying on ``not(...)``
-        # around a constant. ``default:null`` is materialised as a ``Constant``
-        # with ``type_ == "Null"`` (see visitDefault in the AST constructor).
         if op == ISNULL:
-            default = getattr(node.operand, "default", None)
-            if (
-                default is not None
-                and getattr(default, "type", None) != "Null"
-            ):
-                add_semantic_warning(
-                    "isnull(...) on a selection with a non-null default is "
-                    "always false"
-                )
+            self.__warn_if_isnull_has_non_null_default(node)
         operand_symbol = self.visit(node.operand)
         if op in UNARY_OP_MAPPING:
             result = UNARY_OP_MAPPING[op].validate_types(operand_symbol)
@@ -297,6 +284,49 @@ class InputAnalyzer(ASTTemplate, ABC):
             raise errors.SemanticError(
                 "3-6", expected_type=type_, default_type=default_type
             )
+
+    @staticmethod
+    def __warn_if_isnull_has_non_null_default(node: UnaryOp) -> None:
+        """Emit a warning if ``isnull(x)``'s operand has a non-null default.
+
+        Such a call is tautologically false — the default guarantees the
+        operand is never null. Parentheses around the operand parse to a
+        ``ParExpr`` wrapper that carries no ``default`` attribute, so the
+        check would miss ``isnull((x))``; unwrap those first. Only VarID
+        and ParameterRef carry ``default:``; every other operand shape is
+        silently ignored. ``default:null`` materialises as
+        ``Constant(type_="Null")`` (see visitDefault in the AST
+        constructor) and stays warning-free.
+        """
+        inner: Any = node.operand
+        while isinstance(inner, ParExpr):
+            inner = inner.expression
+        default = getattr(inner, "default", None)
+        if default is None or getattr(default, "type", None) == "Null":
+            return
+        selection = InputAnalyzer.__isnull_operand_repr(inner)
+        add_semantic_warning(
+            f"isnull({selection}) is always false: operand has a "
+            f"non-null default (default:{getattr(default, 'value', '?')})"
+        )
+
+    @staticmethod
+    def __isnull_operand_repr(node: Any) -> str:
+        """Render the operand of an ``isnull(...)`` warning message.
+
+        Uses the same formatting as ``generate_operand_expression`` for
+        VarID (``{ tXXX, rY, cZ }``); falls back to the AST class name
+        for anything else, since the warning only fires when a default
+        was found (which limits us to VarID/ParameterRef in practice).
+        """
+        if isinstance(node, VarID):
+            from dpmcore.dpm_xl.utils.operands_mapping import (
+                generate_operand_expression,
+            )
+
+            return generate_operand_expression(node)
+        name = getattr(node, "name", None) or getattr(node, "label", None)
+        return str(name) if name else type(node).__name__
 
     def visit_VarID(  # type: ignore[override]
         self, node: VarID

--- a/src/dpmcore/dpm_xl/semantic_analyzer.py
+++ b/src/dpmcore/dpm_xl/semantic_analyzer.py
@@ -69,6 +69,7 @@ from dpmcore.dpm_xl.types.scalar import (
     Null,
     ScalarFactory,
     ScalarType,
+    String,
 )
 from dpmcore.dpm_xl.utils.data_handlers import filter_all_data
 from dpmcore.dpm_xl.utils.operands_mapping import set_operand_label
@@ -90,6 +91,7 @@ from dpmcore.dpm_xl.utils.tokens import (
     FILTER,
     GET,
     IF,
+    ISNULL,
     RENAME,
     STANDARD,
     SUB,
@@ -208,8 +210,23 @@ class InputAnalyzer(ASTTemplate, ABC):
     def visit_UnaryOp(  # type: ignore[override]
         self, node: UnaryOp
     ) -> Operand:
-        operand_symbol = self.visit(node.operand)
         op = cast(str, node.op)
+        # ``isnull(x)`` on a selection with a non-null default is tautologically
+        # false (the default guarantees the operand is never null). Warn so the
+        # user notices the modelling mistake instead of relying on ``not(...)``
+        # around a constant. ``default:null`` is materialised as a ``Constant``
+        # with ``type_ == "Null"`` (see visitDefault in the AST constructor).
+        if op == ISNULL:
+            default = getattr(node.operand, "default", None)
+            if (
+                default is not None
+                and getattr(default, "type", None) != "Null"
+            ):
+                add_semantic_warning(
+                    "isnull(...) on a selection with a non-null default is "
+                    "always false"
+                )
+        operand_symbol = self.visit(node.operand)
         if op in UNARY_OP_MAPPING:
             result = UNARY_OP_MAPPING[op].validate_types(operand_symbol)
         else:
@@ -266,6 +283,16 @@ class InputAnalyzer(ASTTemplate, ABC):
         # default on a Number cell (String → Number is an Explicit cast).
         # Null already promotes to every type; a Mixed cell has unknown type
         # (no dict entry, empty ``cell_implicities``) and accepts any default.
+        # String is the sink of the implicit-promotion table (every scalar
+        # promotes to String), which would let e.g. ``default:0`` land on a
+        # String cell — reject that explicitly; only String and Null defaults
+        # are meaningful on a String cell.
+        if isinstance(type_, String) and not isinstance(
+            default_type, (String, Null)
+        ):
+            raise errors.SemanticError(
+                "3-6", expected_type=type_, default_type=default_type
+            )
         if cell_implicities and not type_.is_included(default_implicities):
             raise errors.SemanticError(
                 "3-6", expected_type=type_, default_type=default_type

--- a/tests/unit/semantic/test_default_value_type_check.py
+++ b/tests/unit/semantic/test_default_value_type_check.py
@@ -37,35 +37,58 @@ class TestCheckDefaultValue:
             default_value, expected_type
         )
 
-    def test_integer_default_for_string_is_valid(self):
-        """Integer default for String operand should be valid (Integer can be promoted to String)."""
+    def test_integer_default_for_string_raises_error(self):
+        """Integer default for String operand should raise SemanticError 3-6.
+
+        Issue #254: Integer→String is a formatting cast, not a meaningful
+        default for a String cell — the user almost certainly meant
+        ``default:"0"`` or ``default:null``.
+        """
         default_value = self._create_constant("Integer", 0)
         expected_type = String()
 
-        # Should not raise any exception
-        InputAnalyzer._InputAnalyzer__check_default_value(
-            default_value, expected_type
-        )
+        with pytest.raises(SemanticError) as exc_info:
+            InputAnalyzer._InputAnalyzer__check_default_value(
+                default_value, expected_type
+            )
 
-    def test_number_default_for_string_is_valid(self):
-        """Number default for String operand should be valid (Number can be promoted to String)."""
+        assert "Invalid default type" in str(exc_info.value)
+        assert "Integer" in str(exc_info.value)
+        assert "String" in str(exc_info.value)
+
+    def test_number_default_for_string_raises_error(self):
+        """Number default for String operand should raise SemanticError 3-6.
+
+        Issue #254: see ``test_integer_default_for_string_raises_error``.
+        """
         default_value = self._create_constant("Number", 0.0)
         expected_type = String()
 
-        # Should not raise any exception
-        InputAnalyzer._InputAnalyzer__check_default_value(
-            default_value, expected_type
-        )
+        with pytest.raises(SemanticError) as exc_info:
+            InputAnalyzer._InputAnalyzer__check_default_value(
+                default_value, expected_type
+            )
 
-    def test_boolean_default_for_string_is_valid(self):
-        """Boolean default for String operand should be valid (Boolean can be promoted to String)."""
+        assert "Invalid default type" in str(exc_info.value)
+        assert "Number" in str(exc_info.value)
+        assert "String" in str(exc_info.value)
+
+    def test_boolean_default_for_string_raises_error(self):
+        """Boolean default for String operand should raise SemanticError 3-6.
+
+        Issue #254: see ``test_integer_default_for_string_raises_error``.
+        """
         default_value = self._create_constant("Boolean", True)
         expected_type = String()
 
-        # Should not raise any exception
-        InputAnalyzer._InputAnalyzer__check_default_value(
-            default_value, expected_type
-        )
+        with pytest.raises(SemanticError) as exc_info:
+            InputAnalyzer._InputAnalyzer__check_default_value(
+                default_value, expected_type
+            )
+
+        assert "Invalid default type" in str(exc_info.value)
+        assert "Boolean" in str(exc_info.value)
+        assert "String" in str(exc_info.value)
 
     def test_boolean_default_for_boolean_is_valid(self):
         """Boolean default for Boolean operand should be valid."""
@@ -191,15 +214,22 @@ class TestCheckDefaultValue:
         assert "Integer" in str(exc_info.value)
         assert "TimeInterval" in str(exc_info.value)
 
-    def test_item_default_for_string_is_valid(self):
-        """Item default for String operand should be valid (Item can be promoted to String)."""
+    def test_item_default_for_string_raises_error(self):
+        """Item default for String operand should raise SemanticError 3-6.
+
+        Issue #254: see ``test_integer_default_for_string_raises_error``.
+        """
         default_value = self._create_constant("Item", "[x1]")
         expected_type = String()
 
-        # Should not raise any exception
-        InputAnalyzer._InputAnalyzer__check_default_value(
-            default_value, expected_type
-        )
+        with pytest.raises(SemanticError) as exc_info:
+            InputAnalyzer._InputAnalyzer__check_default_value(
+                default_value, expected_type
+            )
+
+        assert "Invalid default type" in str(exc_info.value)
+        assert "Item" in str(exc_info.value)
+        assert "String" in str(exc_info.value)
 
     def test_none_default_value_is_valid(self):
         """None default value should be valid (no check performed)."""

--- a/tests/unit/semantic/test_isnull_default_warning.py
+++ b/tests/unit/semantic/test_isnull_default_warning.py
@@ -1,0 +1,105 @@
+"""Tests for the isnull warning on non-null defaults (issue #254).
+
+``isnull(x)`` on a selection with a non-null ``default:`` is
+tautologically ``false`` — the default guarantees the operand is never
+null. The semantic analyzer emits a warning so the user notices the
+modelling mistake instead of silently relying on ``not(...)`` around a
+constant.
+"""
+
+import contextlib
+
+from dpmcore.dpm_xl.ast.nodes import Constant, UnaryOp, VarID
+from dpmcore.dpm_xl.semantic_analyzer import InputAnalyzer
+from dpmcore.dpm_xl.warning_collector import collect_warnings
+
+
+def _run_visit(node: UnaryOp) -> list[str]:
+    """Run ``visit_UnaryOp`` and return collected semantic warnings.
+
+    ``visit_UnaryOp`` will try to visit the VarID operand against the DB;
+    without a session that raises. The isnull warning fires *before* the
+    operand is visited, so the downstream error is suppressed here and
+    only the collected warnings are inspected.
+    """
+    analyzer = InputAnalyzer(expression="dummy")
+    with collect_warnings() as wc:
+        with contextlib.suppress(Exception):
+            analyzer.visit_UnaryOp(node)
+        return wc.get_warnings()
+
+
+def test_isnull_warns_when_operand_has_integer_default():
+    """``isnull({..., default:0})`` should emit a warning."""
+    operand = VarID(
+        table="tC_34.06",
+        rows=["r0010"],
+        cols=["c0010"],
+        sheets=None,
+        interval=None,
+        default=Constant(type_="Integer", value=0),
+    )
+    node = UnaryOp(op="isnull", operand=operand)
+
+    warnings = _run_visit(node)
+
+    assert any("isnull" in w and "always false" in w for w in warnings), (
+        f"expected an isnull-tautology warning, got {warnings!r}"
+    )
+
+
+def test_isnull_does_not_warn_when_operand_has_null_default():
+    """``isnull({..., default:null})`` is a legitimate pattern — no warning."""
+    operand = VarID(
+        table="tC_34.06",
+        rows=["r0010"],
+        cols=["c0010"],
+        sheets=None,
+        interval=None,
+        default=Constant(type_="Null", value=None),
+    )
+    node = UnaryOp(op="isnull", operand=operand)
+
+    warnings = _run_visit(node)
+
+    assert not any("always false" in w for w in warnings), (
+        f"unexpected isnull warning, got {warnings!r}"
+    )
+
+
+def test_isnull_does_not_warn_when_operand_has_no_default():
+    """``isnull({..., no default})`` — no warning."""
+    operand = VarID(
+        table="tC_34.06",
+        rows=["r0010"],
+        cols=["c0010"],
+        sheets=None,
+        interval=None,
+        default=None,
+    )
+    node = UnaryOp(op="isnull", operand=operand)
+
+    warnings = _run_visit(node)
+
+    assert not any("always false" in w for w in warnings), (
+        f"unexpected isnull warning, got {warnings!r}"
+    )
+
+
+def test_non_isnull_unary_op_never_warns():
+    """The tautology warning is specific to isnull; other unary ops don't fire it."""
+    operand = VarID(
+        table="tC_34.06",
+        rows=["r0010"],
+        cols=["c0010"],
+        sheets=None,
+        interval=None,
+        default=Constant(type_="Integer", value=0),
+    )
+    node = UnaryOp(op="not", operand=operand)
+
+    warnings = _run_visit(node)
+
+    assert not any("always false" in w for w in warnings), (
+        f"unexpected warning on non-isnull op, got {warnings!r}"
+    )

--- a/tests/unit/semantic/test_isnull_default_warning.py
+++ b/tests/unit/semantic/test_isnull_default_warning.py
@@ -9,9 +9,20 @@ constant.
 
 import contextlib
 
-from dpmcore.dpm_xl.ast.nodes import Constant, UnaryOp, VarID
+from dpmcore.dpm_xl.ast.nodes import Constant, ParExpr, UnaryOp, VarID
 from dpmcore.dpm_xl.semantic_analyzer import InputAnalyzer
 from dpmcore.dpm_xl.warning_collector import collect_warnings
+
+
+def _varid(table="C_34.06", cols=("c0010",), default=None):
+    return VarID(
+        table=table,
+        rows=None,
+        cols=list(cols) if cols else None,
+        sheets=None,
+        interval=None,
+        default=default,
+    )
 
 
 def _run_visit(node: UnaryOp) -> list[str]:
@@ -30,34 +41,81 @@ def _run_visit(node: UnaryOp) -> list[str]:
 
 
 def test_isnull_warns_when_operand_has_integer_default():
-    """``isnull({..., default:0})`` should emit a warning."""
-    operand = VarID(
-        table="tC_34.06",
-        rows=["r0010"],
-        cols=["c0010"],
-        sheets=None,
-        interval=None,
-        default=Constant(type_="Integer", value=0),
-    )
+    """``isnull({..., default:0})`` should emit a warning naming the selection."""
+    operand = _varid(default=Constant(type_="Integer", value=0))
     node = UnaryOp(op="isnull", operand=operand)
 
     warnings = _run_visit(node)
 
-    assert any("isnull" in w and "always false" in w for w in warnings), (
+    assert any("always false" in w for w in warnings), (
         f"expected an isnull-tautology warning, got {warnings!r}"
+    )
+    # The message must identify the selection so multiple isnull calls in
+    # the same expression yield distinct lines (andres-sole review on
+    # PR #255).
+    assert any("c0010" in w for w in warnings), (
+        f"warning should name the operand columns, got {warnings!r}"
+    )
+
+
+def test_isnull_warns_through_parentheses():
+    """``isnull((x))`` — parens around the operand must not defeat the check.
+
+    Regression: the AST wraps the operand in a ``ParExpr`` when the user
+    adds redundant parentheses; the naive ``node.operand.default`` lookup
+    misses the underlying VarID.
+    """
+    operand = _varid(default=Constant(type_="Integer", value=0))
+    paren = ParExpr(expression=operand)
+    node = UnaryOp(op="isnull", operand=paren)
+
+    warnings = _run_visit(node)
+
+    assert any("always false" in w and "c0010" in w for w in warnings), (
+        f"expected warning through ParExpr, got {warnings!r}"
+    )
+
+
+def test_isnull_warns_through_nested_parentheses():
+    """``isnull(((x)))`` — multiple ParExpr layers must all be unwrapped."""
+    operand = _varid(default=Constant(type_="Integer", value=0))
+    wrapped = ParExpr(
+        expression=ParExpr(expression=ParExpr(expression=operand))
+    )
+    node = UnaryOp(op="isnull", operand=wrapped)
+
+    warnings = _run_visit(node)
+
+    assert any("always false" in w for w in warnings), (
+        f"expected warning through nested ParExpr, got {warnings!r}"
+    )
+
+
+def test_isnull_warning_identifies_distinct_selections():
+    """Two isnull calls on different selections yield two distinct warnings.
+
+    Reported by andres-sole on PR #255: a shared boilerplate message
+    collapsed to two identical lines in
+    ``isnull({c0040}) and isnull({c0130})``. The message must include the
+    selection so the two lines differ.
+    """
+    a = _varid(cols=("c0040",), default=Constant(type_="Integer", value=0))
+    b = _varid(cols=("c0130",), default=Constant(type_="Integer", value=0))
+    wa = _run_visit(UnaryOp(op="isnull", operand=a))
+    wb = _run_visit(UnaryOp(op="isnull", operand=b))
+
+    combined = wa + wb
+    assert any("c0040" in w for w in combined)
+    assert any("c0130" in w for w in combined)
+    # The two messages must not be identical.
+    assert wa != wb, (
+        f"expected distinct warnings per selection, both were {wa!r}"
     )
 
 
 def test_isnull_does_not_warn_when_operand_has_null_default():
     """``isnull({..., default:null})`` is a legitimate pattern — no warning."""
-    operand = VarID(
-        table="tC_34.06",
-        rows=["r0010"],
-        cols=["c0010"],
-        sheets=None,
-        interval=None,
-        default=Constant(type_="Null", value=None),
-    )
+    operand = _varid(default=Constant(type_="Null", value=None))
     node = UnaryOp(op="isnull", operand=operand)
 
     warnings = _run_visit(node)
@@ -69,15 +127,7 @@ def test_isnull_does_not_warn_when_operand_has_null_default():
 
 def test_isnull_does_not_warn_when_operand_has_no_default():
     """``isnull({..., no default})`` — no warning."""
-    operand = VarID(
-        table="tC_34.06",
-        rows=["r0010"],
-        cols=["c0010"],
-        sheets=None,
-        interval=None,
-        default=None,
-    )
-    node = UnaryOp(op="isnull", operand=operand)
+    node = UnaryOp(op="isnull", operand=_varid(default=None))
 
     warnings = _run_visit(node)
 
@@ -88,14 +138,7 @@ def test_isnull_does_not_warn_when_operand_has_no_default():
 
 def test_non_isnull_unary_op_never_warns():
     """The tautology warning is specific to isnull; other unary ops don't fire it."""
-    operand = VarID(
-        table="tC_34.06",
-        rows=["r0010"],
-        cols=["c0010"],
-        sheets=None,
-        interval=None,
-        default=Constant(type_="Integer", value=0),
-    )
+    operand = _varid(default=Constant(type_="Integer", value=0))
     node = UnaryOp(op="not", operand=operand)
 
     warnings = _run_visit(node)


### PR DESCRIPTION
Two independent gaps in the semantic analyzer let a nonsensical
  expression like `not(isnull({tC_34.06, c0010, default:0}))` — with
  c0010 a String cell — pass validation silently.

  1. `__check_default_value` validated defaults against the cell type via
     `implicit_type_promotion_dict`, whose "everything → String" fallback
     accepted `default:0` on a String cell. Guard the String cell case
     explicitly: only String and Null defaults are meaningful there.

  2. `IsNull` inherited `_BaseUnary` with no operand inspection, so
     `isnull({..., default:<non-null>})` — tautologically false — passed
     without any warning. `visit_UnaryOp` now inspects the operand's AST
     default before visiting and emits a semantic warning.

  Closes #254

  ## Summary

  - Reject numeric/boolean/item defaults on String cells (SemanticError 3-6).
  - Warn on `isnull(x)` when `x`'s default is non-null.

  ## Checklist

  - [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
  - [x] Tests pass (`pytest tests/unit/semantic tests/unit/dpm_xl tests/unit/ast`)

  ## Impact / Risk

  - Breaking-ish: expressions currently passing with `default:<numeric>`
    on a String cell now raise SemanticError 3-6. This is the intended
    behaviour per issue #254.
  - No schema/migration concerns.