### PR TITLE
Require explicit sheets axis declaration

### DIFF
--- a/src/dpmcore/dpm_xl/ast/operands.py
+++ b/src/dpmcore/dpm_xl/ast/operands.py
@@ -251,10 +251,11 @@ class OperandsChecking(ASTTemplate, ABC):
             and getattr(self.partial_selection, header) is not None
         ):
             return
-        # If ALL operands omit the header, the expression applies to every
-        # instance of that dimension ("apply to all" semantics) — valid.
-        # Only raise 1-20 when SOME operands specify the header and SOME don't.
-        if all(getattr(node, header) is None for node in self.operands[table]):
+        # Uniform omission is valid for rows/cols, but sheets
+        # has no broadcast semantics and must always be declared.
+        if header != "sheets" and all(
+            getattr(node, header) is None for node in self.operands[table]
+        ):
             return
         for node in self.operands[table]:
             if getattr(node, header) is None:

--- a/tests/integration/validation/test_semantic_release.py
+++ b/tests/integration/validation/test_semantic_release.py
@@ -467,7 +467,9 @@ def test_no_false_2_6_on_multi_release_headers(
     )
 
 
-def test_single_reference_omitting_closed_sheets_axis_rejected(fixture_session):
+def test_single_reference_omitting_closed_sheets_axis_rejected(
+    fixture_session,
+):
     """A lone reference omitting a closed sheets axis must be rejected."""
     expression = """
     if {tF_01.02, r0020, c0010, default:0} > 0

--- a/tests/integration/validation/test_semantic_release.py
+++ b/tests/integration/validation/test_semantic_release.py
@@ -465,3 +465,18 @@ def test_no_false_2_6_on_multi_release_headers(
         f"Expected valid at release {release_code!r}, got {result.error_code}: "
         f"{result.error_message}"
     )
+
+
+def test_single_reference_omitting_closed_sheets_axis_rejected(fixture_session):
+    """A lone reference omitting a closed sheets axis must be rejected."""
+    expression = """
+    if {tF_01.02, r0020, c0010, default:0} > 0
+    then {tC_07.00.b, r0110, c0210, default:0} > 0
+    endif
+    """
+    svc = SemanticService(fixture_session)
+    result = svc.validate(expression, release_id=1)
+    assert not result.is_valid, (
+        f"Expected invalid, got: {result.error_message}"
+    )
+    assert result.error_code == "1-20"

--- a/tests/unit/dpm_xl/test_check_header_present.py
+++ b/tests/unit/dpm_xl/test_check_header_present.py
@@ -94,6 +94,46 @@ class TestCheckHeaderPresentMixedSpecification:
         oc._check_header_present("SomeTable", "cols")  # must not raise
 
 
+class TestCheckHeaderPresentSheetsAlwaysExplicit:
+    """Unlike rows/cols, omitting sheets always raises, even uniformly."""
+
+    def test_single_operand_omits_sheets_raises(self):
+        nodes = [_varid("C_07.00.b", rows=["r0110"], cols=["c0210"])]
+        oc = _make_oc(nodes)
+        with pytest.raises(SemanticError) as exc_info:
+            oc._check_header_present("C_07.00.b", "sheets")
+        assert str(exc_info.value) == (
+            "Missing explicit sheets on the expression for table C_07.00.b"
+        )
+
+    def test_all_operands_omit_sheets_raises(self):
+        nodes = [
+            _varid("C_07.00.b", rows=["r0110"], cols=["c0210"]),
+            _varid("C_07.00.b", rows=["r0120"], cols=["c0210"]),
+        ]
+        oc = _make_oc(nodes)
+        with pytest.raises(SemanticError) as exc_info:
+            oc._check_header_present("C_07.00.b", "sheets")
+        assert str(exc_info.value) == (
+            "Missing explicit sheets on the expression for table C_07.00.b"
+        )
+
+    def test_all_operands_declare_sheets_no_raise(self):
+        nodes = [
+            _varid("C_07.00.b", rows=["r0110"], cols=["c0210"], sheets=["s0010"]),
+        ]
+        oc = _make_oc(nodes)
+        oc._check_header_present("C_07.00.b", "sheets")  # must not raise
+
+    def test_partial_selection_with_sheets_skips_check(self):
+        ps = _varid("C_07.00.b", sheets=["s0010"])
+        nodes = [
+            _varid("C_07.00.b", rows=["r0110"], cols=["c0210"]),
+        ]
+        oc = _make_oc(nodes, partial_selection=ps)
+        oc._check_header_present("C_07.00.b", "sheets")  # must not raise
+
+
 def test_range_filter_uses_between():
     """A range like r0090-0110 must translate to BETWEEN, not an exact match."""
     col = MagicMock()

--- a/tests/unit/dpm_xl/test_check_header_present.py
+++ b/tests/unit/dpm_xl/test_check_header_present.py
@@ -120,7 +120,9 @@ class TestCheckHeaderPresentSheetsAlwaysExplicit:
 
     def test_all_operands_declare_sheets_no_raise(self):
         nodes = [
-            _varid("C_07.00.b", rows=["r0110"], cols=["c0210"], sheets=["s0010"]),
+            _varid(
+                "C_07.00.b", rows=["r0110"], cols=["c0210"], sheets=["s0010"]
+            ),
         ]
         oc = _make_oc(nodes)
         oc._check_header_present("C_07.00.b", "sheets")  # must not raise


### PR DESCRIPTION
Closes #252 

## Summary

`_check_header_present` treated uniform omission of any axis (rows/cols/sheets) as valid "apply to all" semantics. That's correct for rows/cols, but the sheets (Z) axis has no such broadcast meaning, so `sheets` is now excluded from that shortcut and always requires an explicit declaration when the table's Z axis is closed.

## Checklist

- [X] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [X] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [X] Documentation updated (if applicable)

## Impact / Risk

- Breaking changes? (public API / CLI / REST endpoints / Django models)
- Database schema or migration concerns?
- Notes for release/changelog?

## Notes

<!-- Follow-ups, TODOs, or anything reviewers should know. -->
