### PR TITLE
fix(ast-generator): root operator resolves to ParExpr when body wraps…

### DIFF
--- a/src/dpmcore/services/ast_generator.py
+++ b/src/dpmcore/services/ast_generator.py
@@ -729,12 +729,18 @@ class ASTGeneratorService:
     def _resolve_root_operator_id(ast: Any, session: "Session") -> int:
         """Resolve the OperatorID at the root of an expression AST.
 
-        Walks past structural wrappers (``Start``, ``ParExpr``,
-        ``WithExpression``, ``PersistentAssignment`` /
-        ``TemporaryAssignment``) down to the first node carrying an
-        ``op`` attribute, then looks up ``Operator.OperatorID`` by
-        ``Symbol`` via the same DataFrame
+        Walks past structural wrappers (``Start``, ``WithExpression``,
+        ``PersistentAssignment`` / ``TemporaryAssignment``) down to the
+        first node carrying an ``op`` attribute, then looks up
+        ``Operator.OperatorID`` by ``Symbol`` via the same DataFrame
         ``MLGeneration.create_operation_node`` uses.
+
+        ``ParExpr`` is treated as the operator itself (Symbol ``()``,
+        OperatorID 37 in the reference operator table), mirroring pydpm:
+        an expression whose body is wrapped in parentheses roots at the
+        paren operator, not at the operator inside. ``CondExpr`` and
+        ``ParExpr`` carry no ``op`` attribute but map to fixed synthetic
+        symbols.
 
         Raises ``RuntimeError`` if no operator is resolvable.
         """
@@ -750,9 +756,6 @@ class ASTGeneratorService:
                     break
                 node = children[0]
                 continue
-            if class_name == "ParExpr":
-                node = node.expression
-                continue
             if class_name == "WithExpression":
                 node = node.expression
                 continue
@@ -762,14 +765,20 @@ class ASTGeneratorService:
                 continue
             break
 
+        class_name = type(node).__name__
         op_symbol = getattr(node, "op", None)
-        if not op_symbol and type(node).__name__ == "CondExpr":
+        if not op_symbol and class_name == "CondExpr":
             # CondExpr carries no ``op`` attribute; its operator is fixed.
             op_symbol = "if-then-else"
+        elif not op_symbol and class_name == "ParExpr":
+            # ParExpr carries no ``op`` attribute either; the root of
+            # a body wrapped in parentheses is the paren operator, not
+            # the operator inside. pydpm serialises this as OperatorID 37.
+            op_symbol = "()"
         if not op_symbol:
             raise RuntimeError(
                 f"Cannot resolve root operator: AST root "
-                f"{type(node).__name__!r} has no 'op' attribute."
+                f"{class_name!r} has no 'op' attribute."
             )
 
         df = OperatorQuery.get_operators(session)

--- a/tests/unit/services/test_ast_generator.py
+++ b/tests/unit/services/test_ast_generator.py
@@ -637,6 +637,43 @@ class TestResolveRootOperatorId:
         )
         assert Cls._resolve_root_operator_id(with_expr, MagicMock()) == 30
 
+    def test_parexpr_root_resolves_to_paren_operator(self, monkeypatch):
+        # A ParExpr root has no 'op' attribute; when the whole expression
+        # body is wrapped in parentheses the operator IS the paren itself,
+        # not the operator inside — mirroring pydpm's OperatorID 37 for
+        # the "()" symbol. Regression guard for the previous walk that
+        # descended into ParExpr.expression and returned the inner op.
+        _, Cls, _ = _bare_svc()
+        ParExpr = type("ParExpr", (), {})
+        node = ParExpr()
+        node.op = None
+        inner = type("BinOp", (), {})()
+        inner.op = ">="  # would have been picked before the fix
+        node.expression = inner
+
+        WithExpression = type("WithExpression", (), {})
+        with_expr = WithExpression()
+        with_expr.expression = node
+
+        class FakeOperatorQuery:
+            @staticmethod
+            def get_operators(session):  # noqa: ARG004
+                import pandas as pd
+
+                return pd.DataFrame(
+                    [
+                        {"Symbol": "()", "OperatorID": 37},
+                        {"Symbol": ">=", "OperatorID": 15},
+                    ]
+                )
+
+        monkeypatch.setitem(
+            sys.modules,
+            "dpmcore.dpm_xl.model_queries",
+            SimpleNamespace(OperatorQuery=FakeOperatorQuery),
+        )
+        assert Cls._resolve_root_operator_id(with_expr, MagicMock()) == 37
+
     def test_unresolvable_root_raises(self, monkeypatch):
         _, Cls, _ = _bare_svc()
         # No 'op' attribute anywhere.


### PR DESCRIPTION
Closes #268 

`_resolve_root_operator_id` walked past `ParExpr` and returned the operator inside, but pydpm treats an expression whose body is parenthesised as rooting at the paren operator itself
  (OperatorID 37, symbol `()`). Ten operation codes across eight modules were emitting the wrong root_operator_id:

  - v7552_m / v7572_m / v7588_m (COREP_LCR_DA-3.1.0, 3.3.0): emitted 30 (`if-then-else`) instead of 37.
  - v10867_m (FINREP9-3.1.0, FINREP9-3.3.0, FINREP9DP-1.1.0, GSII-1.1.0, GSII-1.3.0): emitted 15 (`>=`) instead of 37.
  - v10861_m (COREP_LR-3.1.0, GSII-1.1.0): emitted 15 (`>=`) instead of 37.

  Stop walking past `ParExpr`; treat it as a fixed symbol `()` alongside `CondExpr`'s synthetic `if-then-else`. Nested / non-root ParExpr nodes are unaffected — this only concerns the root
  walk.

  Empirically verified: generating `GSII-1.3.0` after the fix, `v10867_m.root_operator_id` now returns 37 as expected. Regression test added under `TestResolveRootOperatorId`. 67/67 unit
  tests in `test_ast_generator.py` pass (excluding one pre-existing unrelated failure about `dpmcore.orm.release_sort_order`).
