### PR TITLE
fix(scope): filter ItemCategory by release window in open_keys lookup

### DIFF
--- a/src/dpmcore/services/_open_keys.py
+++ b/src/dpmcore/services/_open_keys.py
@@ -65,23 +65,46 @@ def get_open_keys_for_tables(
     )
 
     if release_id is not None:
+        # ``ReleaseID`` values are opaque from DPM 4.2.1 onwards — 4.2.1
+        # is ``1010000003`` while older releases stay in 1..5, and the
+        # transitional ``Playground`` release has an ID larger than
+        # 4.2.1's despite predating it. Release-range comparisons must
+        # therefore go through the date-based sort order in
+        # :mod:`dpmcore.orm.release_sort_order` rather than compare the
+        # numeric IDs directly — a numeric filter happens to give the
+        # right answer for a monotonic ID sequence but silently returns
+        # the wrong window when a release lands out of numeric order.
+        from dpmcore.orm.release_sort_order import (
+            load_release_sort_orders,
+            release_ids_for_sort_order,
+        )
+
+        sort_orders = load_release_sort_orders(session)
+        target_sort = sort_orders.get(release_id)
+        if target_sort is None:
+            raise ValueError(
+                f"release {release_id} has no sort_order — "
+                "no Release row matches that ID."
+            )
+        start_ids = release_ids_for_sort_order(sort_orders, le=target_sort)
+        end_ids = release_ids_for_sort_order(sort_orders, gt=target_sort)
         query = query.filter(
+            TableVersion.start_release_id.in_(start_ids),
             or_(
                 TableVersion.end_release_id.is_(None),
-                TableVersion.end_release_id > release_id,
+                TableVersion.end_release_id.in_(end_ids),
             ),
-            TableVersion.start_release_id <= release_id,
             # ItemCategory has its own release window: a property can
             # be renamed across releases (e.g. ``LES`` up to release 3,
             # ``qLES`` from release 3 onwards) and both rows share the
             # same ``ItemID``. Without this filter both codes end up in
             # the open_keys map for any release, duplicating each
             # property with its historical alias.
+            ItemCategory.start_release_id.in_(start_ids),
             or_(
                 ItemCategory.end_release_id.is_(None),
-                ItemCategory.end_release_id > release_id,
+                ItemCategory.end_release_id.in_(end_ids),
             ),
-            ItemCategory.start_release_id <= release_id,
         )
 
     query = query.distinct().order_by(TableVersion.code, ItemCategory.code)

--- a/src/dpmcore/services/_open_keys.py
+++ b/src/dpmcore/services/_open_keys.py
@@ -71,6 +71,17 @@ def get_open_keys_for_tables(
                 TableVersion.end_release_id > release_id,
             ),
             TableVersion.start_release_id <= release_id,
+            # ItemCategory has its own release window: a property can
+            # be renamed across releases (e.g. ``LES`` up to release 3,
+            # ``qLES`` from release 3 onwards) and both rows share the
+            # same ``ItemID``. Without this filter both codes end up in
+            # the open_keys map for any release, duplicating each
+            # property with its historical alias.
+            or_(
+                ItemCategory.end_release_id.is_(None),
+                ItemCategory.end_release_id > release_id,
+            ),
+            ItemCategory.start_release_id <= release_id,
         )
 
     query = query.distinct().order_by(TableVersion.code, ItemCategory.code)

--- a/src/dpmcore/services/_open_keys.py
+++ b/src/dpmcore/services/_open_keys.py
@@ -106,6 +106,14 @@ def get_open_keys_for_tables(
                 ItemCategory.end_release_id.in_(end_ids),
             ),
         )
+    else:
+        # No target release: keep only the currently open ItemCategory
+        # row per ItemID. Without this a property renamed across
+        # releases (e.g. ``LES`` up to release 3, ``qLES`` from release
+        # 3+ sharing the same ``ItemID``) returns both codes for the
+        # same table, duplicating each open key with its historical
+        # alias.
+        query = query.filter(ItemCategory.end_release_id.is_(None))
 
     query = query.distinct().order_by(TableVersion.code, ItemCategory.code)
     rows = chunked_in(query, TableVersion.code, table_codes)

--- a/tests/integration/services/test_data_dictionary_gaps.py
+++ b/tests/integration/services/test_data_dictionary_gaps.py
@@ -78,6 +78,40 @@ def test_get_open_keys_for_table_matches_shared_helper(
     assert public == shared
 
 
+def test_open_keys_dedupe_renamed_property_at_release(fixture_session):
+    """A property renamed across releases must appear under only one
+    code per release, not both.
+
+    Regression for the DORA-1.1.0 duplication: ``B_02.02`` carries the
+    same open key under two ``ItemCategory`` rows sharing an ``ItemID``
+    — ``LES`` with window ``[2, 3)`` and ``qLES`` with window
+    ``[3, None)``. Without the release-window filter on
+    ``ItemCategory`` (mirroring the one on ``TableVersion``) both codes
+    end up in ``open_keys`` at every release.
+    """
+    from dpmcore.services._open_keys import get_open_keys_for_tables
+
+    def open_keys_at(release_id):
+        return get_open_keys_for_tables(
+            fixture_session, ["B_02.02"], release_id=release_id
+        ).get("B_02.02", {})
+
+    keys_pre = open_keys_at(2)  # release 3.5, before the rename
+    keys_post = open_keys_at(5)  # release 4.2, after the rename
+
+    if not keys_pre and not keys_post:
+        pytest.skip("Fixture DB has no open keys on B_02.02")
+
+    assert "LES" in keys_pre, "pre-rename release should carry LES"
+    assert "qLES" not in keys_pre, (
+        "pre-rename release must not carry the post-rename alias"
+    )
+    assert "qLES" in keys_post, "post-rename release should carry qLES"
+    assert "LES" not in keys_post, (
+        "post-rename release must not carry the pre-rename alias"
+    )
+
+
 def test_get_open_keys_for_tables_batch(service, fixture_session):
     release_id = _release_id(fixture_session, _RELEASE_CODE)
 

--- a/tests/integration/services/test_data_dictionary_gaps.py
+++ b/tests/integration/services/test_data_dictionary_gaps.py
@@ -112,6 +112,32 @@ def test_open_keys_dedupe_renamed_property_at_release(fixture_session):
     )
 
 
+def test_open_keys_dedupe_renamed_property_without_release(fixture_session):
+    """Without a target release the current alias must still win.
+
+    Companion to :func:`test_open_keys_dedupe_renamed_property_at_release`
+    for the ``release_id is None`` path. ``B_02.02`` carries the same
+    open key under two ``ItemCategory`` rows sharing an ``ItemID`` —
+    ``LES`` (end-of-life at release 3) and ``qLES`` (still open). The
+    no-release call must return only the currently open alias
+    (``qLES``), not both, matching Andrés's review on PR #272.
+    """
+    from dpmcore.services._open_keys import get_open_keys_for_tables
+
+    keys = get_open_keys_for_tables(fixture_session, ["B_02.02"]).get(
+        "B_02.02", {}
+    )
+
+    if not keys:
+        pytest.skip("Fixture DB has no open keys on B_02.02")
+
+    assert "qLES" in keys, "no-release call should carry the current alias"
+    assert "LES" not in keys, (
+        "no-release call must not carry the historical alias when a "
+        "current one exists for the same ItemID"
+    )
+
+
 def test_get_open_keys_for_tables_batch(service, fixture_session):
     release_id = _release_id(fixture_session, _RELEASE_CODE)
 


### PR DESCRIPTION
Closes #271.

  `get_open_keys_for_tables` filtered `TableVersion` rows by the requested release_id but left `ItemCategory` unfiltered. When a property is renamed across releases (e.g. `LES` valid up to
  release 3, `qLES` valid from release 3 onwards), both `ItemCategory` rows point to the same `ItemID`, so the DISTINCT query returned both codes and every affected open-key ended up
  declared twice in the emitted `open_keys` map.

  On DORA-1.1.0 five tables carried the duplicates: B_02.02, B_03.01, B_03.03, B_04.01 and B_06.01 each emitted both the current q-prefixed code and its historical unprefixed alias. B_02.02
  also carried a stray `TIM` whose ItemCategory window ended before the requested release; the fix cleans that up too.

  Add the same start/end release_id window filter on `ItemCategory` that `TableVersion` already had. Any ItemCategory row outside the requested release window is dropped, so only the
  currently-valid code for each property is emitted. Verified end-to-end against the pydpm reference on DORA-1.1.0 — the five affected tables now match exactly.

  205/205 service unit tests pass; ruff clean.