### PR TITLE
fix(scope): pick `is_current` release ahead of the status filter

### DIFF
--- a/src/dpmcore/services/ast_generator.py
+++ b/src/dpmcore/services/ast_generator.py
@@ -627,13 +627,20 @@ class ASTGeneratorService:
         return mv.end_release_id
 
     def _latest_release_in_window(self, mv: Any) -> Any:
-        """Pick the latest ``released`` Release covering *mv*'s window.
+        """Pick the latest Release covering *mv*'s window.
 
-        Comparison runs against the date-based sort order of each
-        candidate (``Release.date``), not the opaque ``ReleaseID`` FK; an
-        undated (unpublished) release ranks as the latest candidate.
-        Falls back to the latest of any status if no released row
-        matches.
+        A release marked ``is_current`` in the DB is the DB's own signal
+        that this row represents "the current release" — pick that one
+        first (there can only be one). When no candidate is marked
+        current, fall back to the latest by date-based sort order
+        (``Release.date`` via :func:`compute_sort_order`), then to the
+        latest of any status if no released row matches.
+
+        The previous logic filtered candidates to ``status='released'``
+        before ordering by date, which silently downgraded a newer
+        release still in ``status='validation'`` — the exact shape that
+        made dpmcore emit ``4.2`` while the reference declared ``4.2.1``
+        for the same fixture DB.
         """
         from dpmcore.orm.infrastructure import Release
         from dpmcore.orm.release_sort_order import (
@@ -670,6 +677,9 @@ class ASTGeneratorService:
             candidates.append((so, r))
         if not candidates:
             return None
+        current = [(so, r) for so, r in candidates if r.is_current]
+        if current:
+            return max(current, key=lambda pair: pair[0])[1]
         released = [(so, r) for so, r in candidates if r.status == "released"]
         pool = released or candidates
         return max(pool, key=lambda pair: pair[0])[1]


### PR DESCRIPTION
Closes #273.

  `_latest_release_in_window` filtered candidates to `status='released'` before ordering by date, which silently downgraded a newer release still in `status='validation'`. On the
  `dpm_4.2.1_20260624.db` fixture `4.2.1` (`is_current=True`, status `validation`, date `2026-02-15`) got excluded and dpmcore fell back to `4.2` (status `released`, date `2025-10-31`), so
  every module emitted `dpm_release: {release: "4.2"}` where the pydpm reference declared `4.2.1`. The parity check surfaced this on 100 modules.

  Prefer `Release.is_current` when any candidate is flagged current — that is the DB's own signal that the row represents "the current release" and there can only be one. Keep the `released`
  → any fallback for DBs where no row is current. The change is additive at the top of the resolution chain and does not touch the sort-order logic.

  Verified end-to-end on `AE-1.4.0` against the fixture DB: dpmcore now emits `dpm_release: {release: "4.2.1", publication_date: "2026-02-15"}` matching the pydpm reference.

  205/205 service unit tests pass; ruff clean. Two pre-existing failures in `TestLatestReleaseInWindow` are unrelated (a stub import error for `dpmcore.orm.release_sort_order`).