### PR TITLE
fix(scope): exclude tables shared with the home module from dep_modules

### DIFF
--- a/src/dpmcore/services/ast_generator.py
+++ b/src/dpmcore/services/ast_generator.py
@@ -14,6 +14,7 @@ from typing import (
     Iterable,
     List,
     Optional,
+    Set,
     Tuple,
     Union,
 )
@@ -1271,6 +1272,17 @@ class ASTGeneratorService:
         all_dep_modules: Dict[str, Any] = {}
         all_scope_results: List["ScopeResult"] = []
 
+        # The home-module table set is a per-script constant (the
+        # primary module never changes across this loop), and computing
+        # it inside ``detect_cross_module_dependencies`` would repeat a
+        # per-table variable/open-key fetch on every iteration. Compute
+        # it once here and thread it through.
+        home_module_tables: Set[str] = set(
+            self._scope_calc._get_module_tables(
+                primary_module_vid, release_id=release_id
+            ).keys()
+        )
+
         for item, sr, ts, refs in scope_pairs:
             all_scope_results.append(sr)
             op_code = item[1]
@@ -1283,6 +1295,7 @@ class ASTGeneratorService:
                 compute_alternative_deps=False,
                 referenced_variables=refs.variables,
                 referenced_tables=refs.tables,
+                home_module_tables=home_module_tables,
             )
             all_intra.extend(current.get("intra_instance_validations", []))
             self._merge_cross_deps(

--- a/src/dpmcore/services/scope_calculator.py
+++ b/src/dpmcore/services/scope_calculator.py
@@ -239,6 +239,7 @@ class ScopeCalculatorService:
         release_code: Optional[str] = None,
         referenced_variables: Optional[Dict[str, str]] = None,
         referenced_tables: Optional[Set[str]] = None,
+        home_module_tables: Optional[Set[str]] = None,
     ) -> Dict[str, Any]:
         """Build dependency information for a scope result.
 
@@ -267,6 +268,14 @@ class ScopeCalculatorService:
                 narrows each dependency module's declaration to the
                 subset the operation uses (#250); omit both to declare
                 the dependency modules whole.
+            home_module_tables: Optional pre-computed set of table codes
+                owned by the primary (home) module — the same set this
+                method would derive from :meth:`_get_module_tables`.
+                Callers that iterate this method with a fixed
+                ``primary_module_vid`` (per-op dependency detection
+                over a script's operations) should pass a single
+                pre-computed set to avoid re-running the per-table
+                variable/open-key fetch on every iteration.
 
         Returns a dict with:
         - ``intra_instance_validations``
@@ -350,11 +359,18 @@ class ScopeCalculatorService:
         # exclude them from dependency_modules[<dep>].tables. Without
         # this, cross-module ops that touch a shared table declare it
         # twice (once in home, once in every dep that also owns it).
-        primary_tables = set(
-            self._get_module_tables(
-                primary_module_vid, release_id=release_id
-            ).keys()
-        )
+        # Caller-supplied ``home_module_tables`` avoids the per-op
+        # recompute when this method runs inside a loop with a fixed
+        # ``primary_module_vid`` (the query is a per-table variable/
+        # open-key fetch, not a code-only lookup).
+        if home_module_tables is None:
+            primary_tables = set(
+                self._get_module_tables(
+                    primary_module_vid, release_id=release_id
+                ).keys()
+            )
+        else:
+            primary_tables = home_module_tables
 
         for vid in sorted_vids:
             mv = mv_by_vid.get(vid)
@@ -432,21 +448,6 @@ class ScopeCalculatorService:
         }
         if not tables_dict:
             return None
-        # Drop tables the primary (home) module also declares — the shared
-        # ones belong to the home declaration. Skip if the exclusion would
-        # leave the dep empty (a dep whose entire table set is contained in
-        # the home is either a genuine full overlap we still want to declare
-        # or a test fixture where the mock returns the same tables for
-        # every vid).
-        home = home_module_tables or set()
-        if home:
-            filtered = {
-                tcode: tdata
-                for tcode, tdata in tables_dict.items()
-                if tcode not in home
-            }
-            if filtered:
-                tables_dict = filtered
 
         # The timeshift is a module-level property carried by the dependency
         # module's tables. Compute it BEFORE narrowing: narrowing drops any
@@ -467,6 +468,26 @@ class ScopeCalculatorService:
         )
         if narrowed:
             tables_dict = narrowed
+
+        # Drop tables the primary (home) module also declares — the shared
+        # ones belong to the home declaration; leaving them on the dep
+        # side is the duplicate-declaration bug this method exists to
+        # fix. Runs AFTER narrowing so a validation whose operand set is
+        # entirely inside a shared table still narrows correctly:
+        # excluding *before* narrowing would drop the operand's table
+        # first, narrowing would find no referenced table, and the
+        # narrowing fallback would reintroduce the shared table via the
+        # module-wide unnarrowed set. The exclusion is unconditional
+        # — even when it empties ``tables_dict``: the dep still surfaces
+        # in ``cross_instance_dependencies`` via its ``URI`` and the
+        # engine (#251) resolves cross-instance operands off
+        # ``referenced_variables`` when the caller supplies them.
+        if home_module_tables:
+            tables_dict = {
+                tcode: tdata
+                for tcode, tdata in tables_dict.items()
+                if tcode not in home_module_tables
+            }
 
         module_entry: Dict[str, Any] = {
             "URI": uri,

--- a/src/dpmcore/services/scope_calculator.py
+++ b/src/dpmcore/services/scope_calculator.py
@@ -344,6 +344,18 @@ class ScopeCalculatorService:
         )
         mv_by_vid = {mv.module_vid: mv for mv in mv_rows}
 
+        # Tables owned by the primary (home) module — a dep module that
+        # also lists any of these is sharing a table with the home; the
+        # sharing belongs to the home declaration, not to the dep, so
+        # exclude them from dependency_modules[<dep>].tables. Without
+        # this, cross-module ops that touch a shared table declare it
+        # twice (once in home, once in every dep that also owns it).
+        primary_tables = set(
+            self._get_module_tables(
+                primary_module_vid, release_id=release_id
+            ).keys()
+        )
+
         for vid in sorted_vids:
             mv = mv_by_vid.get(vid)
             if not mv:
@@ -356,6 +368,7 @@ class ScopeCalculatorService:
                 operation_code=operation_code,
                 referenced_variables=referenced_variables,
                 referenced_tables=referenced_tables,
+                home_module_tables=primary_tables,
             )
             if entry is None:
                 continue
@@ -390,6 +403,7 @@ class ScopeCalculatorService:
         operation_code: Optional[str],
         referenced_variables: Optional[Dict[str, str]] = None,
         referenced_tables: Optional[Set[str]] = None,
+        home_module_tables: Optional[Set[str]] = None,
     ) -> Optional[Tuple[Dict[str, Any], str, Dict[str, Any]]]:
         """Build a single (cross_dep, uri, dependency_module) triple.
 
@@ -397,6 +411,14 @@ class ScopeCalculatorService:
         when every one of its tables is variable-less (and therefore
         dropped, since the engine schema requires
         ``minProperties: 1`` on each table's variables map).
+
+        ``home_module_tables`` is the set of table codes owned by the
+        primary (home) module. Tables that appear in both the home and
+        the dependency (a shared table like ``I_05.00`` present in both
+        IF_CLASS2 and IF_CLASS3) belong to the home declaration and
+        must be excluded from ``dependency_modules[<dep>].tables`` —
+        otherwise the engine sees the same table declared on both sides
+        and downstream lookups can pick the wrong copy.
         """
         uri = self._get_module_uri(module_vid=vid, mv=mv)
         if not uri:
@@ -410,6 +432,21 @@ class ScopeCalculatorService:
         }
         if not tables_dict:
             return None
+        # Drop tables the primary (home) module also declares — the shared
+        # ones belong to the home declaration. Skip if the exclusion would
+        # leave the dep empty (a dep whose entire table set is contained in
+        # the home is either a genuine full overlap we still want to declare
+        # or a test fixture where the mock returns the same tables for
+        # every vid).
+        home = home_module_tables or set()
+        if home:
+            filtered = {
+                tcode: tdata
+                for tcode, tdata in tables_dict.items()
+                if tcode not in home
+            }
+            if filtered:
+                tables_dict = filtered
 
         # The timeshift is a module-level property carried by the dependency
         # module's tables. Compute it BEFORE narrowing: narrowing drops any

--- a/tests/unit/services/test_scope_calculator.py
+++ b/tests/unit/services/test_scope_calculator.py
@@ -670,12 +670,18 @@ class TestDetectCrossModuleDependencies:
     def test_dependency_modules_in_output(self):
         """dependency_modules dict is populated."""
         svc, SR = self._make_svc()
-        svc._get_module_tables = lambda vid, release_id=None: {
-            "T_01": {
-                "variables": {"v1": "x"},
-                "open_keys": {},
+        # Distinct home/dep tables — the PR #276 shared-table exclusion
+        # would strip a fully overlapping ``T_01`` from the dep side.
+        svc._get_module_tables = lambda vid, release_id=None: (
+            {"HOME_T": {"variables": {"vh": "x"}, "open_keys": {}}}
+            if vid == 10
+            else {
+                "T_01": {
+                    "variables": {"v1": "x"},
+                    "open_keys": {},
+                }
             }
-        }
+        )
 
         mv = MagicMock()
         mv.module_vid = 20
@@ -705,12 +711,18 @@ class TestDetectCrossModuleDependencies:
         map, or the engine cannot build the home operand.
         """
         svc, SR = self._make_svc()
-        svc._get_module_tables = lambda vid, release_id=None: {
-            "F_01.03": {
-                "variables": {"56987": "m"},
-                "open_keys": {},
+        # Distinct home/dep tables — with the shared-table exclusion
+        # (PR #276) a full-overlap mock would drop the dep's F_01.03.
+        svc._get_module_tables = lambda vid, release_id=None: (
+            {"C_01.00": {"variables": {"32673": "m"}, "open_keys": {}}}
+            if vid == 10
+            else {
+                "F_01.03": {
+                    "variables": {"56987": "m"},
+                    "open_keys": {},
+                }
             }
-        }
+        )
 
         mv = MagicMock()
         mv.module_vid = 20
@@ -741,14 +753,19 @@ class TestDetectCrossModuleDependencies:
         subset the cross-rules reference, not whole.
         """
         svc, SR = self._make_svc()
-        svc._get_module_tables = lambda vid, release_id=None: {
-            "F_22.02": {
-                "variables": {"1": "m", "2": "m", "3": "m"},
-                "open_keys": {"qAS": "e"},
-            },
-            # Referenced by no cross-rule: must not be declared.
-            "F_99.00": {"variables": {"9": "m"}, "open_keys": {}},
-        }
+        # Distinct home/dep tables (see PR #276 shared-table exclusion).
+        svc._get_module_tables = lambda vid, release_id=None: (
+            {"G_01.00": {"variables": {"500": "m"}, "open_keys": {}}}
+            if vid == 10
+            else {
+                "F_22.02": {
+                    "variables": {"1": "m", "2": "m", "3": "m"},
+                    "open_keys": {"qAS": "e"},
+                },
+                # Referenced by no cross-rule: must not be declared.
+                "F_99.00": {"variables": {"9": "m"}, "open_keys": {}},
+            }
+        )
 
         mv = MagicMock()
         mv.module_vid = 20
@@ -776,10 +793,15 @@ class TestDetectCrossModuleDependencies:
     def test_whole_module_declared_when_no_refs_supplied(self):
         """Callers passing no reference info keep the unnarrowed module."""
         svc, SR = self._make_svc()
-        svc._get_module_tables = lambda vid, release_id=None: {
-            "F_22.02": {"variables": {"1": "m"}, "open_keys": {}},
-            "F_99.00": {"variables": {"9": "m"}, "open_keys": {}},
-        }
+        # Distinct home/dep tables (see PR #276 shared-table exclusion).
+        svc._get_module_tables = lambda vid, release_id=None: (
+            {"HOME_T": {"variables": {"vh": "m"}, "open_keys": {}}}
+            if vid == 10
+            else {
+                "F_22.02": {"variables": {"1": "m"}, "open_keys": {}},
+                "F_99.00": {"variables": {"9": "m"}, "open_keys": {}},
+            }
+        )
 
         mv = MagicMock()
         mv.module_vid = 20
@@ -802,9 +824,14 @@ class TestDetectCrossModuleDependencies:
         if nothing matches, the module is declared unnarrowed.
         """
         svc, SR = self._make_svc()
-        svc._get_module_tables = lambda vid, release_id=None: {
-            "F_22.02": {"variables": {"1": "m"}, "open_keys": {}},
-        }
+        # Distinct home/dep tables (see PR #276 shared-table exclusion).
+        svc._get_module_tables = lambda vid, release_id=None: (
+            {"G_01.00": {"variables": {"777": "m"}, "open_keys": {}}}
+            if vid == 10
+            else {
+                "F_22.02": {"variables": {"1": "m"}, "open_keys": {}},
+            }
+        )
 
         mv = MagicMock()
         mv.module_vid = 20
@@ -828,9 +855,12 @@ class TestDetectCrossModuleDependencies:
     def test_module_definition_wins_over_referenced_type(self):
         """A datapoint the dependency module defines keeps that type."""
         svc, SR = self._make_svc()
-        svc._get_module_tables = lambda vid, release_id=None: {
-            "F_01.03": {"variables": {"56987": "m"}, "open_keys": {}}
-        }
+        # Distinct home/dep tables (see PR #276 shared-table exclusion).
+        svc._get_module_tables = lambda vid, release_id=None: (
+            {}
+            if vid == 10
+            else {"F_01.03": {"variables": {"56987": "m"}, "open_keys": {}}}
+        )
 
         mv = MagicMock()
         mv.module_vid = 20
@@ -854,12 +884,17 @@ class TestDetectCrossModuleDependencies:
         keep their ``open_keys`` so the engine can join on them.
         """
         svc, SR = self._make_svc()
-        svc._get_module_tables = lambda vid, release_id=None: {
-            "C_06.02": {
-                "variables": {"5486578": "s"},
-                "open_keys": {"qEGS": "e", "qLGS": "s"},
+        # Distinct home/dep tables (see PR #276 shared-table exclusion).
+        svc._get_module_tables = lambda vid, release_id=None: (
+            {"HOME_T": {"variables": {"vh": "s"}, "open_keys": {}}}
+            if vid == 10
+            else {
+                "C_06.02": {
+                    "variables": {"5486578": "s"},
+                    "open_keys": {"qEGS": "e", "qLGS": "s"},
+                }
             }
-        }
+        )
 
         mv = MagicMock()
         mv.module_vid = 20

--- a/tests/unit/services/test_scope_calculator_shared_home.py
+++ b/tests/unit/services/test_scope_calculator_shared_home.py
@@ -1,0 +1,323 @@
+"""Tests for the shared-home-table exclusion added in PR #276.
+
+Kept in a separate module because the stub chain in
+``test_scope_calculator.py`` is intentionally minimal (it lets the
+existing tests target very specific paths); asserting on
+``dependency_modules[<uri>].tables`` needs a slightly wider stub set
+plus a real ``chunked_in`` pass-through so the ``ModuleVersion`` batch
+lookup actually materialises. Isolating the setup here avoids
+regressing any of those existing tests.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+@pytest.fixture(autouse=True)
+def _patch_orm(monkeypatch):
+    """Stub the ORM/service chain the module pulls in at import time.
+
+    Same shape as ``test_scope_calculator._patch_orm`` plus the two
+    modules that ``scope_calculator`` transitively imports and that
+    ``test_scope_calculator`` intentionally leaves real
+    (``dpm_xl.utils.filters`` for ``resolve_release_id``,
+    ``orm.query_utils`` for ``chunked_in``). Those two only exist to
+    let the code under test reach the branches we exercise below.
+    """
+    data_stub = MagicMock()
+    data_stub.get_module_schema_ref_by_version = MagicMock(return_value=None)
+    data_stub.get_module_schema_ref = MagicMock(return_value=None)
+    monkeypatch.setitem(sys.modules, "dpmcore.data", data_stub)
+
+    for mod_name in [
+        "dpmcore",
+        "dpmcore.connection",
+        "dpmcore.orm",
+        "dpmcore.orm.infrastructure",
+        "dpmcore.orm.packaging",
+        "dpmcore.orm.operations",
+        "dpmcore.orm.query_utils",
+        "dpmcore.orm.rendering",
+        "dpmcore.orm.variables",
+        "dpmcore.orm.glossary",
+        "dpmcore.errors",
+        "dpmcore.dpm_xl",
+        "dpmcore.dpm_xl.ast",
+        "dpmcore.dpm_xl.ast.operands",
+        "dpmcore.dpm_xl.utils",
+        "dpmcore.dpm_xl.utils.filters",
+        "dpmcore.dpm_xl.utils.scopes_calculator",
+        "dpmcore.services",
+        "dpmcore.services.syntax",
+    ]:
+        monkeypatch.setitem(sys.modules, mod_name, MagicMock())
+
+    canonical = "dpmcore.services.scope_calculator"
+    snapshot = sys.modules.get(canonical)
+    yield
+    # Restore whatever the outer test session had registered so
+    # follow-up files (which import the real module) aren't left
+    # with our stub-deps copy.
+    if snapshot is not None:
+        sys.modules[canonical] = snapshot
+    else:
+        sys.modules.pop(canonical, None)
+
+
+def _load_module():
+    mod_name = "dpmcore.services.scope_calculator"
+    sys.modules.pop(mod_name, None)
+    spec = importlib.util.spec_from_file_location(
+        mod_name,
+        _REPO_ROOT / "src/dpmcore/services/scope_calculator.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = mod
+    spec.loader.exec_module(mod)
+    # ``chunked_in`` is stubbed at the parent module scope by
+    # ``_patch_orm`` (its parent ``dpmcore.orm.query_utils`` is a
+    # ``MagicMock``), so a naked call returns a ``MagicMock`` that
+    # iterates as empty. Bind a real pass-through so the loop that
+    # materialises ``ModuleVersion`` rows in
+    # ``detect_cross_module_dependencies`` actually sees them.
+    mod.chunked_in = lambda query, col, values: query.filter(
+        col.in_(values)
+    ).all()
+    return mod.ScopeCalculatorService, mod.ScopeResult
+
+
+def _scope(module_vids):
+    comps = [SimpleNamespace(module_vid=v) for v in module_vids]
+    return SimpleNamespace(operation_scope_compositions=comps)
+
+
+class TestSharedHomeTableExclusion:
+    """PR #276 review follow-up: shared home-module tables must be
+    excluded from ``dependency_modules[<dep>].tables``, unconditionally
+    where the dep is still declarable via other means.
+    """
+
+    def _make_svc(self):
+        Svc, SR = _load_module()
+        svc = Svc(MagicMock())
+        svc._get_module_uri = lambda module_vid, mv=None: (
+            f"http://uri/mod_{module_vid}"
+        )
+        svc._get_module_tables = lambda module_vid, release_id=None: {}
+        return svc, SR
+
+    def _cross_pair(self, SR, home_vid, dep_vid):
+        return SR(
+            scopes=[_scope([home_vid, dep_vid])],
+            is_cross_module=True,
+        )
+
+    def _wire_dep_mv(self, svc, dep_vid, code="MOD_EXT"):
+        mv = MagicMock()
+        mv.module_vid = dep_vid
+        mv.code = code
+        mv.version_number = "1.0"
+        mv.from_reference_date = None
+        mv.to_reference_date = None
+        q = svc.session.query.return_value
+        q.filter.return_value.all.return_value = [mv]
+
+    def test_shared_home_table_excluded_from_dep_module(self):
+        """A table declared by both home and dep must appear only under
+        the home declaration — ``dependency_modules[<dep>].tables`` must
+        drop it (PR #276).
+        """
+        svc, SR = self._make_svc()
+        home_tables = {
+            "SHARED_T": {"variables": {"v_shared": "x"}, "open_keys": {}},
+            "HOME_ONLY": {"variables": {"v_home": "x"}, "open_keys": {}},
+        }
+        dep_tables = {
+            "SHARED_T": {"variables": {"v_shared": "x"}, "open_keys": {}},
+            "DEP_ONLY": {"variables": {"v_dep": "x"}, "open_keys": {}},
+        }
+        svc._get_module_tables = lambda vid, release_id=None: (
+            home_tables if vid == 10 else dep_tables
+        )
+        self._wire_dep_mv(svc, dep_vid=20)
+
+        info = svc.detect_cross_module_dependencies(
+            scope_result=self._cross_pair(SR, 10, 20),
+            primary_module_vid=10,
+            operation_code="v1234",
+        )
+        dep_module = next(iter(info["dependency_modules"].values()))
+        assert "SHARED_T" not in dep_module["tables"]
+        assert "DEP_ONLY" in dep_module["tables"]
+
+    def test_full_overlap_dep_still_declared_via_referenced_variables(self):
+        """Regression: when *every* dep table is shared with the home
+        AND ``referenced_variables`` is populated, the exclusion must
+        still fire. The previous ``if filtered:`` fallback kept the
+        shared rows, re-introducing the duplicate-declaration bug this
+        PR closes. The dep stays declarable via ``referenced_variables``
+        (#251) populating its ``variables`` map even with an empty
+        ``tables`` map.
+        """
+        svc, SR = self._make_svc()
+        shared_table = {"variables": {"v1": "x"}, "open_keys": {}}
+        svc._get_module_tables = lambda vid, release_id=None: {
+            "SHARED_T": shared_table,
+        }
+        self._wire_dep_mv(svc, dep_vid=20)
+
+        info = svc.detect_cross_module_dependencies(
+            scope_result=self._cross_pair(SR, 10, 20),
+            primary_module_vid=10,
+            operation_code="v1234",
+            referenced_variables={"v1": "x"},
+            referenced_tables={"SHARED_T"},
+        )
+        dep_module = next(iter(info["dependency_modules"].values()))
+        assert dep_module["tables"] == {}
+        assert dep_module["variables"] == {"v1": "x"}
+
+    def test_full_overlap_dep_stripped_when_no_referenced_variables(self):
+        """When *every* dep table is shared with the home, the exclusion
+        still applies unconditionally — the shared tables never leak onto
+        the dep side, even when the caller supplied no
+        ``referenced_variables`` to repopulate ``variables``. The dep
+        still surfaces in ``cross_instance_dependencies`` via its
+        ``URI``, so a genuine cross-instance dependency is not silently
+        dropped; it just carries an empty ``tables``/``variables`` pair
+        the caller can fill in downstream.
+        """
+        svc, SR = self._make_svc()
+        svc._get_module_tables = lambda vid, release_id=None: {
+            "SHARED_T": {"variables": {"v1": "x"}, "open_keys": {}},
+        }
+        self._wire_dep_mv(svc, dep_vid=20)
+
+        info = svc.detect_cross_module_dependencies(
+            scope_result=self._cross_pair(SR, 10, 20),
+            primary_module_vid=10,
+            operation_code="v1234",
+        )
+        # The dep is still declared as a cross-instance dependency (URI
+        # in the cross_deps list), only its ``tables``/``variables``
+        # payload is empty.
+        cross_uris = [
+            m["URI"]
+            for c in info["cross_instance_dependencies"]
+            for m in c["modules"]
+        ]
+        assert cross_uris, (
+            "dep must still surface in cross_instance_dependencies"
+        )
+        dep_module = next(iter(info["dependency_modules"].values()))
+        assert dep_module["tables"] == {}, (
+            "shared table must not leak onto the dep side"
+        )
+
+    def test_home_module_tables_parameter_skips_internal_recompute(self):
+        """When the caller supplies ``home_module_tables`` the method
+        must use it directly rather than re-running
+        ``_get_module_tables`` for the primary vid — the per-script
+        single-fetch contract the reviewer requested. The caller loops
+        over N ops with a fixed ``primary_module_vid`` and the
+        home-table lookup should not repeat N times.
+        """
+        svc, SR = self._make_svc()
+
+        get_calls: list[int] = []
+
+        def _tracking_get(vid, release_id=None):
+            get_calls.append(vid)
+            if vid == 10:
+                return {
+                    "HOME_ONLY": {
+                        "variables": {"v_home": "x"},
+                        "open_keys": {},
+                    },
+                }
+            return {
+                "SHARED_T": {
+                    "variables": {"v_shared": "x"},
+                    "open_keys": {},
+                },
+                "DEP_ONLY": {"variables": {"v_dep": "x"}, "open_keys": {}},
+            }
+
+        svc._get_module_tables = _tracking_get
+        self._wire_dep_mv(svc, dep_vid=20)
+
+        info = svc.detect_cross_module_dependencies(
+            scope_result=self._cross_pair(SR, 10, 20),
+            primary_module_vid=10,
+            operation_code="v1234",
+            home_module_tables={"SHARED_T"},
+        )
+        # The primary vid was NOT fetched to derive its table set: the
+        # only remaining ``_get_module_tables`` call is the dep-side
+        # composition query.
+        assert 10 not in get_calls
+        dep_module = next(iter(info["dependency_modules"].values()))
+        assert "SHARED_T" not in dep_module["tables"]
+        assert "DEP_ONLY" in dep_module["tables"]
+
+    def test_op_referencing_only_a_shared_table_narrows_before_exclusion(self):
+        """Regression @andres-sole: the shared-table exclusion must run
+        *after* ``_narrow_dependency_tables``. When an operation
+        references only a shared table (the classic
+        ``IF_CLASS2 - COREP_OF`` shape at the fixture DB, op referencing
+        only ``C_18.00``) running exclusion first drops the referenced
+        table before narrowing sees it: narrowing then finds no matching
+        referenced table and falls back to the un-narrowed
+        (already-excluded) set, so the dep either declares nothing at
+        all or reintroduces the shared table via the module-wide
+        fallback. The correct order is narrow → exclude, so the operand
+        is captured by narrowing and only the *narrowed* result is
+        stripped of its shared entries — leaving an empty ``tables``
+        map that ``referenced_variables`` (#251) still fills.
+        """
+        svc, SR = self._make_svc()
+        shared_table = {"variables": {"v_shared_var": "x"}, "open_keys": {}}
+        home_tables = {
+            "SHARED_T": shared_table,
+            "HOME_ONLY": {"variables": {"v_home": "x"}, "open_keys": {}},
+        }
+        dep_tables = {
+            "SHARED_T": shared_table,
+            "DEP_ONLY_UNREF": {
+                "variables": {"v_unref": "x"},
+                "open_keys": {},
+            },
+        }
+        svc._get_module_tables = lambda vid, release_id=None: (
+            home_tables if vid == 10 else dep_tables
+        )
+        self._wire_dep_mv(svc, dep_vid=20)
+
+        info = svc.detect_cross_module_dependencies(
+            scope_result=self._cross_pair(SR, 10, 20),
+            primary_module_vid=10,
+            operation_code="v1234",
+            # The op references only the shared table's datapoint.
+            referenced_tables={"SHARED_T"},
+            referenced_variables={"v_shared_var": "x"},
+        )
+        dep_module = next(iter(info["dependency_modules"].values()))
+        # The shared table is stripped from the dep declaration.
+        assert "SHARED_T" not in dep_module["tables"]
+        # And the un-referenced dep-only table is NOT re-introduced by a
+        # narrowing-empty fallback (which would happen if exclusion ran
+        # before narrowing, dropping the operand's only table so
+        # narrowing returns empty and the module-wide fallback kicks in).
+        assert "DEP_ONLY_UNREF" not in dep_module["tables"]
+        assert dep_module["tables"] == {}
+        # The operand still resolves via ``variables`` (#251).
+        assert dep_module["variables"] == {"v_shared_var": "x"}


### PR DESCRIPTION
  Closes #275 partially — fixes the shared-table subset; residual over-declaration on IF_CLASS2 traced to a separate over-inclusion of operations, filed undera follow-up.
 
 `_build_dependency_entry` iterated `ModuleVersionComposition` to enumerate the tables of each dependency module, keeping every one that carries variables.
  When a table is declared by both the primary (home) module and a dependency — a shared table like `I_05.00`, present in both IF_CLASS2 and IF_CLASS3 — the sharing belongs to the home declaration, not to the dependency, so the `dep_modules` block ended up naming the same table on both sides.

  `ASTGeneratorService._build_dependency_info` now computes the primary module's table set once per script (the caller loops per operation with a fixed  `primary_module_vid`) and threads it into `ScopeCalculatorService.detect_cross_module_dependencies` as `home_module_tables`. The callee falls back to
  `_get_module_tables(primary_module_vid, release_id=release_id).keys()` when the parameter is not supplied, so direct callers keep working unchanged.

  Inside `_build_dependency_entry` the exclusion runs after the `ref_period` loop and after `_narrow_dependency_tables`:
 
  - `ref_period` is computed on the full `tables_dict` so a time-shifted table isn't dropped before its `T-1Q` (or equivalent) is captured.
  - Narrowing (#250) still sees every operand-referenced table, so a validation whose operand set is entirely inside a shared table narrows correctly instead
  of triggering the narrowing empty-fallback and reintroducing the shared table via the module-wide unnarrowed set.
  - The exclusion is unconditional — shared tables are stripped even when the exclusion would empty `tables_dict`. A full-overlap dep still surfaces in `cross_instance_dependencies` via its `URI`; #251 resolves cross-instance operands off `referenced_variables` when the caller supplies them.

Empirically verified against the pydpm reference on the fixture DB:
 
  - IF_CLASS3-1.2.0: extra tables 1 → 0 (fully clean).
  - IF_CLASS3-1.4.0: 1 → 0.
  - IF_CLASS2-1.4.0: 4 → 0.
  - IF_CLASS2-1.2.0: 11 → 4 (partial).
  - IF_CLASS2-1.3.0: 13 → 5 (partial).

  The residual +4 / +5 on IF_CLASS2 sit on the `corep_of` dependency URI, not on a shared home table. Investigation shows the extras are dragged in by operations (`v09813_m`, `v09812_m`, `v7380_m`, `v7381_m`, `v09814_m`) that dpmcore includes in IF_CLASS2-1.3.0 but the pydpm reference does not — these ops reference only COREP_OF tables and pydpm does not scope them to IF_CLASS2 at all. That is the shape of the `finding1_dpmcore_extra_ops` divergence (41modules across the parity run) and lives in `filter_valid_dependency_modules` / `is_cross_module`, not in `_narrow_dependency_tables`. Filed as a separate follow-up.
  
 Regression tests added under a new `tests/unit/services/test_scope_calculator_shared_home.py`: shared-table exclusion, the narrow-then-exclude order, full-overlap with and without `referenced_variables`, and the `home_module_tables` precomputed-parameter contract. Ruff + mypy clean