### PR TITLE
feat(dpm-xl): accept the Fact Component in a where clause

### DIFF
--- a/specification/03-services.md
+++ b/specification/03-services.md
@@ -859,7 +859,7 @@ conversions (e.g., Integer + Decimal → Decimal).
 | Boolean | `AND`, `OR`, `NOT` |
 | Conditional | `IF-THEN-ELSE` |
 | Aggregate | `SUM`, `AVG`, `MIN`, `MAX`, `COUNT` |
-| Clause | `WHERE`, `FILTER`, `RENAME`, `SUB` |
+| Clause | `WHERE`, `GET`, `FILTER`, `RENAME`, `SUB` |
 | String | String manipulation operators |
 | Time | `TIMESHIFT` and temporal operators |
 
@@ -877,6 +877,21 @@ Component (abstract)
 
 Structure (component set with unique keys + single fact)
 ```
+
+Which components a clause operator may target:
+
+| Operator | DPM Key | Standard Key (`r`/`c`/`s`) | Fact (`f`) | Attribute |
+|----------|---------|----------------------------|------------|-----------|
+| `WHERE`  | yes     | no                         | yes        | yes       |
+| `GET`    | yes     | no                         | no         | yes       |
+| `RENAME` | yes     | no                         | no         | yes       |
+| `SUB`    | yes     | no                         | no         | no        |
+
+`WHERE` filters on the fact value and leaves the structure untouched, so it
+accepts the Fact Component; projecting onto it (`GET`), renaming it or
+substituting it stays invalid (`4-5-0-1`). `GET` re-types the result Fact
+Component to the data type of the selected component. Attribute Components
+are accepted structurally but no selection currently produces any.
 
 ### 10.6 Semantic Analyzer
 

--- a/specification/03-services.md
+++ b/specification/03-services.md
@@ -893,6 +893,11 @@ substituting it stays invalid (`4-5-0-1`). `GET` re-types the result Fact
 Component to the data type of the selected component. Attribute Components
 are accepted structurally but no selection currently produces any.
 
+Every Structure has exactly one Fact Component, so a `WHERE` condition
+naming only the Fact Component is applicable to any table selection —
+including selections on tables with no open keys, which contribute no DPM Key
+Components of their own.
+
 ### 10.6 Semantic Analyzer
 
 The `InputAnalyzer` walks the AST and:

--- a/src/dpmcore/dpm_xl/ast/ml_generation.py
+++ b/src/dpmcore/dpm_xl/ast/ml_generation.py
@@ -50,6 +50,7 @@ from dpmcore.dpm_xl.model_queries import (
     OperatorQuery,
     VariableVersionQuery,
 )
+from dpmcore.dpm_xl.utils import tokens
 from dpmcore.dpm_xl.utils.data_handlers import filter_all_data, generate_xyz
 from dpmcore.dpm_xl.utils.scopes_calculator import OperationScopeService
 from dpmcore.errors import SemanticError
@@ -727,6 +728,14 @@ class MLGeneration(ASTTemplate):
         self.create_operation_node(node, is_leaf=True)
 
     def visit_Dimension(self, node: Dimension) -> None:
+        # The Fact Component is not a Property, so there is no property to
+        # reference: store the component name on the node itself, the way
+        # literal arguments are stored.
+        if node.dimension_code == tokens.FACT:
+            node.scalar = tokens.FACT
+            self.create_operation_node(node, is_leaf=True)
+            return
+
         node.source_reference = "property"
         op_node = self.create_operation_node(node, is_leaf=True)
         property_row = ItemCategoryQuery.get_property_from_code(

--- a/src/dpmcore/dpm_xl/ast/module_dependencies.py
+++ b/src/dpmcore/dpm_xl/ast/module_dependencies.py
@@ -24,6 +24,7 @@ from dpmcore.dpm_xl.ast.nodes import (
     WhereClauseOp,
     WithExpression,
 )
+from dpmcore.dpm_xl.ast.operands import NON_KEY_COMPONENT_CODES
 from dpmcore.dpm_xl.ast.template import ASTTemplate
 from dpmcore.dpm_xl.ast.where_clause import WhereClauseChecker
 from dpmcore.dpm_xl.model_queries import (
@@ -195,6 +196,10 @@ class ModuleDependencies(ASTTemplate, ABC):
             self.full_operands[full_name] = final_list
 
     def visit_Dimension(self, node: Dimension) -> None:
+        # The Fact Component has no dictionary row, so it contributes no
+        # dependency and must not be looked up (see NON_KEY_COMPONENT_CODES).
+        if node.dimension_code in NON_KEY_COMPONENT_CODES:
+            return
         if node.dimension_code not in self.dimension_codes:
             self.dimension_codes.append(node.dimension_code)
             if not ItemCategoryQuery.get_property_from_code(

--- a/src/dpmcore/dpm_xl/ast/operands.py
+++ b/src/dpmcore/dpm_xl/ast/operands.py
@@ -42,6 +42,7 @@ from dpmcore.dpm_xl.model_queries import (
     ViewOpenKeysQuery,
 )
 from dpmcore.dpm_xl.types.scalar import Integer, Mixed, Number, ScalarFactory
+from dpmcore.dpm_xl.utils import tokens
 from dpmcore.dpm_xl.utils.data_handlers import filter_all_data
 from dpmcore.dpm_xl.utils.filters import filter_by_release
 from dpmcore.dpm_xl.utils.operands_mapping import (
@@ -72,6 +73,17 @@ IMPLICIT_OPEN_KEYS = {
     "entityID": "s",  # string type
     "baseCurrency": "s",  # string type
 }
+
+# Component names that a clause operator may legitimately mention but that are
+# *not* open keys, so they must never be looked up in the dictionary.
+# Currently only the Fact Component ("f"), which every Recordset carries and
+# whose data type is per-operand (resolved in
+# ``InputAnalyzer.visit_Dimension``). Deliberately kept apart from
+# ``IMPLICIT_OPEN_KEYS``: entries there are also injected as DPM key
+# components into every Recordset, which is exactly what the Fact must not
+# become. Whether a given clause operator accepts it is decided structurally,
+# by ``ClauseOperator.allow_fact`` in ``dpm_xl/operators/clause.py``.
+NON_KEY_COMPONENT_CODES = frozenset({tokens.FACT})
 
 
 _HEADERS_CACHE: Dict[
@@ -351,14 +363,19 @@ class OperandsChecking(ASTTemplate, ABC):
         if len(self.dimension_codes) == 0:
             return
 
-        # Separate implicit keys from database-backed keys
-        implicit_codes = [
-            code for code in self.dimension_codes if code in IMPLICIT_OPEN_KEYS
-        ]
-        database_codes = [
+        # The Fact Component is not an open key: it has no dictionary row, so
+        # looking it up would raise 1-5 before the clause operator ever gets a
+        # chance to accept it (``where``) or reject it (``get``/``rename``).
+        codes = [
             code
             for code in self.dimension_codes
-            if code not in IMPLICIT_OPEN_KEYS
+            if code not in NON_KEY_COMPONENT_CODES
+        ]
+
+        # Separate implicit keys from database-backed keys
+        implicit_codes = [code for code in codes if code in IMPLICIT_OPEN_KEYS]
+        database_codes = [
+            code for code in codes if code not in IMPLICIT_OPEN_KEYS
         ]
 
         # Query database only for non-implicit keys
@@ -427,16 +444,19 @@ class OperandsChecking(ASTTemplate, ABC):
         if len(self.getop_components) == 0:
             return
 
-        # Separate implicit keys from database-backed keys
-        implicit_codes = [
+        # ``[get f]`` stays invalid, but it is rejected structurally with
+        # 4-5-0-1 by ``ClauseOperator.validate``; skipping the lookup here only
+        # stops the misleading "open keys not found: ['f']" from pre-empting it.
+        codes = [
             code
             for code in self.getop_components
-            if code in IMPLICIT_OPEN_KEYS
+            if code not in NON_KEY_COMPONENT_CODES
         ]
+
+        # Separate implicit keys from database-backed keys
+        implicit_codes = [code for code in codes if code in IMPLICIT_OPEN_KEYS]
         database_codes = [
-            code
-            for code in self.getop_components
-            if code not in IMPLICIT_OPEN_KEYS
+            code for code in codes if code not in IMPLICIT_OPEN_KEYS
         ]
 
         # Query property_ids for GetOp components (same query as dimensions)

--- a/src/dpmcore/dpm_xl/ast/where_clause.py
+++ b/src/dpmcore/dpm_xl/ast/where_clause.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import TypeGuard
+
 from dpmcore.dpm_xl.ast.nodes import (
     AST,
     BinOp,
@@ -42,6 +44,18 @@ def _equality_value(node: AST) -> str | None:
     return None
 
 
+def _is_key_dimension(node: AST) -> TypeGuard[Dimension]:
+    """Whether ``node`` references a component a join can be keyed on.
+
+    Args:
+        node: One side of an ``=`` condition.
+
+    Returns:
+        ``True`` for a ``Dimension`` other than the Fact Component.
+    """
+    return isinstance(node, Dimension) and node.dimension_code != tokens.FACT
+
+
 def _equality_pin(node: BinOp) -> tuple[str, str] | None:
     """Return ``(dimension_code, value)`` for a ``dimension = value`` node.
 
@@ -49,17 +63,21 @@ def _equality_pin(node: BinOp) -> tuple[str, str] | None:
     when the equality is not between exactly one ``Dimension`` and one
     literal value (e.g. ``value = value`` or ``dimension = dimension``).
 
+    The Fact Component ("f") never yields a pin: pins exist only to spot an
+    inner join that can never match, and the join is over *Key Components*.
+    Two operands filtering on different fact values are perfectly joinable.
+
     Args:
         node: An ``=`` ``BinOp`` from a where condition.
 
     Returns:
         The pinned dimension code and value, or ``None``.
     """
-    if isinstance(node.left, Dimension):
+    if _is_key_dimension(node.left):
         value = _equality_value(node.right)
         if value is not None:
             return node.left.dimension_code, value
-    if isinstance(node.right, Dimension):
+    if _is_key_dimension(node.right):
         value = _equality_value(node.left)
         if value is not None:
             return node.right.dimension_code, value

--- a/src/dpmcore/dpm_xl/operators/clause.py
+++ b/src/dpmcore/dpm_xl/operators/clause.py
@@ -25,6 +25,12 @@ class ClauseOperator(Operator):
     check_new_names: ClassVar[bool] = False
     precondition: ClassVar[bool] = False
     propagate_attributes: ClassVar[bool] = True
+    # Whether the operator accepts the Fact Component ("f") as a target.
+    # Only ``where`` does: it filters on the fact value, leaving the structure
+    # untouched. Projecting onto (``get``), renaming or substituting the Fact
+    # Component stays invalid. Standard Key Components ("r", "c", "s") are
+    # never accepted by any clause operator.
+    allow_fact: ClassVar[bool] = False
 
     @classmethod
     def validate(
@@ -40,18 +46,20 @@ class ClauseOperator(Operator):
         if condition:
             cls._validate_condition(operand, condition)
 
-        if (
-            any(x in operand.get_standard_components() for x in key_names)
-            or tokens.FACT in key_names
-        ):
-            raise errors.SemanticError("4-5-0-1", recordset=operand.name)
+        cls._check_targets_allowed(operand, key_names)
 
         dpm_components = {
             **operand.get_dpm_components(),
             **operand.get_attributes(),
         }
 
-        not_found = [name for name in key_names if name not in dpm_components]
+        # The Fact Component is not in ``dpm_components`` by design; when the
+        # operator accepts it, the guard above has already vetted it.
+        not_found = [
+            name
+            for name in key_names
+            if name != tokens.FACT and name not in dpm_components
+        ]
         if not_found:
             raise errors.SemanticError(
                 "2-8", op=cls.op, dpm_keys=not_found, recordset=operand.name
@@ -111,6 +119,29 @@ class ClauseOperator(Operator):
         return cls.generate_result_structure(
             operand, key_names, condition, origin
         )
+
+    @classmethod
+    def _check_targets_allowed(
+        cls, operand: RecordSet, key_names: list[str]
+    ) -> None:
+        """Reject component targets this clause operator cannot act on.
+
+        Standard *Key Components* ("r", "c", "s") are out of bounds for every
+        clause operator. The Fact Component ("f") is accepted only by the
+        operators that declare ``allow_fact``.
+
+        Args:
+            operand: The recordset the clause applies to.
+            key_names: Component names targeted by the clause.
+
+        Raises:
+            SemanticError: ``4-5-0-1`` for a standard key, or for the Fact
+                Component on an operator that does not accept it.
+        """
+        if any(x in operand.get_standard_components() for x in key_names):
+            raise errors.SemanticError("4-5-0-1", recordset=operand.name)
+        if tokens.FACT in key_names and not cls.allow_fact:
+            raise errors.SemanticError("4-5-0-1", recordset=operand.name)
 
     @classmethod
     def _validate_condition(
@@ -206,6 +237,9 @@ class ClauseOperator(Operator):
 
 class Where(ClauseOperator):
     op: ClassVar[str | None] = tokens.WHERE
+    # A where condition may reference the Fact Component of the operand; the
+    # filter leaves the structure, and therefore the Fact, untouched.
+    allow_fact: ClassVar[bool] = True
 
     @classmethod
     def validate_condition_type(cls, condition: Scalar) -> None:
@@ -272,6 +306,11 @@ class Sub(ClauseOperator):
     ) -> RecordSet:
         if not isinstance(operand, RecordSet):
             raise errors.SemanticError("4-5-0-2", operator=cls.op)
+
+        # A sub clause substitutes DPM *Key Components* only. State that
+        # explicitly rather than letting a standard key or the Fact Component
+        # fall through to the "not on recordset" error below.
+        cls._check_targets_allowed(operand, [property_code])
 
         # Validate that the property_code exists in the operand's components
         dpm_components = operand.get_dpm_components()

--- a/src/dpmcore/dpm_xl/semantic_analyzer.py
+++ b/src/dpmcore/dpm_xl/semantic_analyzer.py
@@ -88,6 +88,7 @@ from dpmcore.dpm_xl.utils.tokens import (
     ANNUALISE,
     DATE,
     DPM,
+    FACT,
     FILTER,
     GET,
     IF,
@@ -126,6 +127,12 @@ class InputAnalyzer(ASTTemplate, ABC):
         self.preconditions: bool = False
 
         self.calculations_outputs: dict[str, Operand] = {}
+
+        # Operands of the clause operators currently being visited, innermost
+        # last. A ``Dimension`` naming the Fact Component ("f") has no
+        # dictionary entry and its data type is whatever the enclosing operand
+        # carries, so ``visit_Dimension`` reads the top of this stack.
+        self._clause_operands: list[RecordSet] = []
 
         # Implicit open keys that are always available without being declared
         # These are special dimensions that arise from the reporting context itself
@@ -566,6 +573,16 @@ class InputAnalyzer(ASTTemplate, ABC):
     def visit_Dimension(  # type: ignore[override]
         self, node: Dimension
     ) -> Scalar:
+        # The Fact Component is not an open key: it is a component of the
+        # clause operand itself, and takes that operand's data type.
+        if node.dimension_code == FACT:
+            if not self._clause_operands:
+                raise errors.SemanticError(
+                    "4-5-0-1", recordset=self._expression
+                )
+            fact_type = self._clause_operands[-1].get_fact_component().type
+            return Scalar(type_=fact_type, name=None, origin=FACT)
+
         # Check if this is an implicit open key (refPeriod, entityID)
         if node.dimension_code in self.global_variables:
             gtype = self.global_variables[node.dimension_code]
@@ -809,7 +826,18 @@ class InputAnalyzer(ASTTemplate, ABC):
         if len(node.key_components) == 0:
             raise errors.SemanticError("4-5-2-1", recordset=operand.name)
 
-        condition = self.visit(node.condition)
+        # ``ClauseOperator.validate`` rejects non-recordset operands anyway;
+        # raising the same error here keeps the Fact Component resolvable in
+        # ``visit_Dimension`` (which needs the operand's structure) without
+        # having to cope with an operand that has none.
+        if not isinstance(operand, RecordSet):
+            raise errors.SemanticError("4-5-0-2", operator=WHERE)
+
+        self._clause_operands.append(operand)
+        try:
+            condition = self.visit(node.condition)
+        finally:
+            self._clause_operands.pop()
         result = CLAUSE_OP_MAPPING[WHERE].validate(
             operand=operand,
             key_names=node.key_components,

--- a/tests/integration/validation/test_semantic_where_fact.py
+++ b/tests/integration/validation/test_semantic_where_fact.py
@@ -1,0 +1,95 @@
+"""Issue #266 — ``[where f …]`` against the real dictionary.
+
+Before the extension, a ``where`` condition naming the Fact Component died in
+the operands pre-check with ``1-5 "open keys not found: ['f']"``, because
+``f`` has no dictionary row and every condition identifier was resolved as an
+open key. It must now resolve structurally, against the Fact Component of the
+clause operand, while ``get``/``rename``/``sub`` keep rejecting it — with
+``4-5-0-1`` rather than the misleading ``1-5``.
+"""
+
+from dpmcore.services.semantic import SemanticService
+
+RELEASE = "4.2.1"
+
+# C_08.01.a r0020 c0260 is the operand of published check v6200_m: a
+# monetary cell whose selection carries an open key (``qEEA``).
+OPERAND = "{tC_08.01.a, r0020, c0260}"
+
+
+def test_where_on_fact_is_valid(fixture_session):
+    """A Fact-only where condition passes semantic validation."""
+    result = SemanticService(fixture_session).validate(
+        f"{OPERAND}[where f > 0] >= 0", release_code=RELEASE
+    )
+    assert result.is_valid, result.error_message
+
+
+def test_where_mixing_fact_and_open_key_is_valid(fixture_session):
+    """The Fact composes with the DPM key components it used to exclude."""
+    expression = (
+        f"sum({OPERAND}[where f > 0 and qEEA in {{[eba_qAE:qx2018]}}]) >= 0"
+    )
+    result = SemanticService(fixture_session).validate(
+        expression, release_code=RELEASE
+    )
+    assert result.is_valid, result.error_message
+
+
+def test_where_on_fact_then_get_on_a_key_is_valid(fixture_session):
+    """Chained clauses: the outer ``get`` still sees the filtered operand."""
+    result = SemanticService(fixture_session).validate(
+        f"{OPERAND}[where f > 0][get qEEA] >= 0", release_code=RELEASE
+    )
+    assert result.is_valid, result.error_message
+
+
+def test_disjoint_fact_filters_do_not_yield_2_2(fixture_session):
+    """Unlike a key, the Fact cannot make an inner join empty.
+
+    Guards against a false ``2-2`` from the contradictory-where check of
+    issue #121, which is keyed on *Key Components* only.
+    """
+    result = SemanticService(fixture_session).validate(
+        f"{OPERAND}[where f = 1] = {OPERAND}[where f = 2]",
+        release_code=RELEASE,
+    )
+    assert result.is_valid, result.error_message
+
+
+def test_non_boolean_fact_condition_yields_3_3(fixture_session):
+    """``f`` is typed from the operand, so a bare numeric fact is not a filter.
+
+    This is what makes ``[where f and …]`` meaningful only on Boolean-typed
+    selections: the condition must promote to Boolean.
+    """
+    result = SemanticService(fixture_session).validate(
+        f"{OPERAND}[where f] >= 0", release_code=RELEASE
+    )
+    assert not result.is_valid
+    assert result.error_code == "3-3"
+
+
+def test_get_on_fact_yields_4_5_0_1(fixture_session):
+    """Projecting onto the Fact stays invalid, with the structural error."""
+    result = SemanticService(fixture_session).validate(
+        f"{OPERAND}[get f] >= 0", release_code=RELEASE
+    )
+    assert not result.is_valid
+    assert result.error_code == "4-5-0-1"
+
+
+def test_rename_on_fact_yields_4_5_0_1(fixture_session):
+    result = SemanticService(fixture_session).validate(
+        f"{OPERAND}[rename f to qZZ] >= 0", release_code=RELEASE
+    )
+    assert not result.is_valid
+    assert result.error_code == "4-5-0-1"
+
+
+def test_sub_on_fact_yields_4_5_0_1(fixture_session):
+    result = SemanticService(fixture_session).validate(
+        f"{OPERAND}[sub f = 1] >= 0", release_code=RELEASE
+    )
+    assert not result.is_valid
+    assert result.error_code == "4-5-0-1"

--- a/tests/integration/validation/test_semantic_where_fact.py
+++ b/tests/integration/validation/test_semantic_where_fact.py
@@ -73,6 +73,55 @@ def test_where_on_fact_then_get_on_a_key_is_valid(fixture_session):
     assert result.is_valid, result.error_message
 
 
+def test_get_on_a_key_then_where_on_fact_is_valid(fixture_session):
+    """The reverse order: ``where`` sees the Fact the ``get`` installed.
+
+    ``ClauseOperator.generate_result_structure`` replaces the result Fact
+    Component with one carrying the selected component's type, so after
+    ``[get qEEA]`` the Fact is an Item and comparing it against an item of
+    ``qEEA``'s domain type-checks.
+
+    The numeric form is here because it is the one the review asked for,
+    but note it is *not* evidence of the re-typing on its own: comparison
+    against a number is permissive for Item operands generally — plain
+    ``[where qEEA > 0]`` is accepted too, and was before this change. The
+    assertion that actually pins the re-typing is the neighbouring
+    ``test_where_on_fact_after_get_uses_the_retyped_fact``.
+    """
+    service = SemanticService(fixture_session)
+    for expression in (
+        f"{OPERAND}[get qEEA][where f = [eba_qAE:qx2018]] >= 0",
+        f"{OPERAND}[get qEEA][where f > 0] >= 0",
+    ):
+        result = service.validate(expression, release_code=RELEASE)
+        assert result.is_valid, f"{expression}: {result.error_message}"
+
+
+def test_where_on_fact_after_get_uses_the_retyped_fact(fixture_session):
+    """The re-typed Fact is what ``f`` resolves to, not the original one.
+
+    A bare ``[where f]`` is a ``3-3`` either way, so the reported type is
+    the discriminator: ``Item`` — ``qEEA``'s type, installed by the
+    ``get`` — rather than the ``Number`` of the monetary cell the
+    selection started from. Type ``f`` from the pre-``get`` operand
+    instead and the first assertion flips to ``Number``.
+    """
+    service = SemanticService(fixture_session)
+
+    retyped = service.validate(
+        f"{OPERAND}[get qEEA][where f] >= 0", release_code=RELEASE
+    )
+    assert not retyped.is_valid
+    assert retyped.error_code == "3-3"
+    assert "type_op_1=Item" in retyped.error_message
+
+    original = service.validate(
+        f"{OPERAND}[where f] >= 0", release_code=RELEASE
+    )
+    assert original.error_code == "3-3"
+    assert "type_op_1=Number" in original.error_message
+
+
 def test_disjoint_fact_filters_do_not_yield_2_2(fixture_session):
     """Unlike a key, the Fact cannot make an inner join empty.
 

--- a/tests/integration/validation/test_semantic_where_fact.py
+++ b/tests/integration/validation/test_semantic_where_fact.py
@@ -16,11 +16,40 @@ RELEASE = "4.2.1"
 # monetary cell whose selection carries an open key (``qEEA``).
 OPERAND = "{tC_08.01.a, r0020, c0260}"
 
+# C_01.00 carries no open keys at all, so its selection contributes no DPM
+# Key Components. The Fact Component must resolve there just the same.
+NO_KEY_OPERAND = "{tC_01.00, r0010, c0010}"
+
 
 def test_where_on_fact_is_valid(fixture_session):
     """A Fact-only where condition passes semantic validation."""
     result = SemanticService(fixture_session).validate(
         f"{OPERAND}[where f > 0] >= 0", release_code=RELEASE
+    )
+    assert result.is_valid, result.error_message
+
+
+def test_where_on_fact_is_valid_without_open_keys(fixture_session):
+    """A selection with no DPM Key Components still carries a Fact.
+
+    Nothing in the ``where`` path asserts this on its own; it holds because
+    ``InputAnalyzer.visit_VarID`` always injects the global variables as key
+    components, which is what keeps a table selection a ``RecordSet`` — and
+    therefore ``get_fact_component()`` reachable — instead of the bare
+    ``Scalar`` it returns for a structure with no components. Narrow that
+    injection and this expression starts failing with ``4-5-0-2``.
+    """
+    result = SemanticService(fixture_session).validate(
+        f"{NO_KEY_OPERAND}[where f > 0] >= 0", release_code=RELEASE
+    )
+    assert result.is_valid, result.error_message
+
+
+def test_with_clause_where_on_fact_without_open_keys(fixture_session):
+    """Issue #266 item 6, verbatim: the ``with`` clause form of the above."""
+    result = SemanticService(fixture_session).validate(
+        "with {tC_01.00}: {r0010, c0010}[where f > 0] >= 0",
+        release_code=RELEASE,
     )
     assert result.is_valid, result.error_message
 

--- a/tests/unit/ast/test_ml_generation.py
+++ b/tests/unit/ast/test_ml_generation.py
@@ -11,6 +11,7 @@ from dpmcore.dpm_xl.ast.ml_generation import MLGeneration
 from dpmcore.dpm_xl.ast.nodes import (
     Constant,
     CountSetOp,
+    Dimension,
     IntersectSetOp,
     Set,
     SetdiffOp,
@@ -20,6 +21,7 @@ from dpmcore.dpm_xl.ast.nodes import (
     UnionSetOp,
     VarID,
 )
+from dpmcore.dpm_xl.utils.tokens import FACT
 from dpmcore.orm.operations import (
     OperandReference,
     OperandReferenceLocation,
@@ -252,3 +254,23 @@ def test_visit_var_id_builds_operand_reference_and_location_with_real_attributes
     assert op_ref.operand_reference == "variable"
     assert op_ref_loc.cell_id == 7
     assert op_ref_loc.table == "T1"
+
+
+def test_visit_dimension_on_the_fact_emits_a_leaf_without_operand_refs(
+    ml_generation,
+):
+    """The Fact Component is not a Property, so there is nothing to reference.
+
+    ``visit_Dimension`` normally resolves the code to a ``property_id`` and
+    adds an ``OperandReference``; the dictionary has no row for "f", so the
+    component name is stored on the node itself instead — the same mechanism
+    literal arguments use.
+    """
+    ml_generation.session = MagicMock()
+    node = Dimension(dimension_code=FACT)
+
+    ml_generation.visit_Dimension(node)
+
+    assert node.scalar == FACT
+    assert ml_generation.create_operation_node.call_count == 1
+    assert ml_generation.session.add.call_count == 0

--- a/tests/unit/ast/test_where_fact_component.py
+++ b/tests/unit/ast/test_where_fact_component.py
@@ -1,0 +1,169 @@
+"""Tests for the Fact Component ("f") as a ``where`` clause target (#266).
+
+The DPM-XL spec was extended so a ``where`` condition may reference the Fact
+Component of its operand, not just DPM *Key Components*. ``get``, ``rename``
+and ``sub`` keep rejecting it, and Standard *Key Components* ("r", "c", "s")
+stay out of bounds for every clause operator.
+
+These tests cover the parse/AST/serialization side and the pin-extraction
+side. The structural rules live in
+``tests/unit/dpm_xl/test_clause_fact_component.py``.
+"""
+
+import pytest
+
+from dpmcore.dpm_xl.ast.nodes import (
+    BinOp,
+    Constant,
+    Dimension,
+    GetOp,
+    RenameOp,
+    SubOp,
+    WhereClauseOp,
+)
+from dpmcore.dpm_xl.ast.operands import (
+    IMPLICIT_OPEN_KEYS,
+    NON_KEY_COMPONENT_CODES,
+)
+from dpmcore.dpm_xl.ast.where_clause import (
+    WhereClauseChecker,
+    collect_where_equality_pins,
+)
+from dpmcore.dpm_xl.utils import tokens
+from dpmcore.dpm_xl.utils.serialization import ASTToJSONVisitor
+from dpmcore.services.syntax import SyntaxService
+
+WHERE_FACT_EXPRESSIONS = [
+    "{tT, r010}[where f > 0]",
+    '{tT, r010}[where f = "x"]',
+    "{tT, r010}[where f]",
+    "{tT, r010}[where f in {[ns:code1], [ns:code2]}]",
+    "{tT, r010}[where f and CNT != entityID]",
+    "{tT, r010}[where f > 0][get CNT]",
+]
+
+# Rejected semantically, not syntactically: ``f`` lexes as an ordinary
+# PROPERTY_CODE, so these all parse.
+PARSEABLE_NON_WHERE_FACT_EXPRESSIONS = [
+    "{tT, r010}[get f]",
+    "{tT, r010}[rename f to CNT]",
+    '{tT, r010}[sub f = "x"]',
+]
+
+
+@pytest.mark.parametrize("expr", WHERE_FACT_EXPRESSIONS)
+def test_where_on_fact_is_valid_syntax(expr):
+    """A where condition referencing ``f`` parses."""
+    assert SyntaxService().is_valid(expr)
+
+
+@pytest.mark.parametrize("expr", PARSEABLE_NON_WHERE_FACT_EXPRESSIONS)
+def test_fact_in_other_clauses_still_parses(expr):
+    """``f`` in get/rename/sub is a semantic error, not a syntax error.
+
+    Pinning this keeps the rejection where it belongs: no grammar change was
+    needed for #266, and none should be introduced to reject these.
+    """
+    assert SyntaxService().is_valid(expr)
+
+
+def test_where_on_fact_builds_a_dimension_node():
+    """``f`` becomes a plain ``Dimension``, like any other component name."""
+    ast = SyntaxService().parse("{tT, r010}[where f > 0]")
+    where_op = ast.children[0]
+    assert isinstance(where_op, WhereClauseOp)
+    condition = where_op.condition
+    assert isinstance(condition, BinOp)
+    assert isinstance(condition.left, Dimension)
+    assert condition.left.dimension_code == tokens.FACT
+
+
+def test_where_clause_checker_collects_the_fact():
+    """The Fact counts towards ``key_components``.
+
+    ``visit_WhereClauseOp`` rejects a condition that names no component at
+    all (4-5-2-1); a Fact-only condition must not trip that check.
+    """
+    ast = SyntaxService().parse("{tT, r010}[where f > 0]")
+    checker = WhereClauseChecker()
+    checker.visit(ast.children[0].condition)
+    assert checker.key_components == [tokens.FACT]
+
+
+def test_get_and_rename_and_sub_keep_the_component_name_as_a_string():
+    """Only where conditions produce ``Dimension`` nodes."""
+    parse = SyntaxService().parse
+    get_op = parse("{tT, r010}[get f]").children[0]
+    rename_op = parse("{tT, r010}[rename f to CNT]").children[0]
+    sub_op = parse('{tT, r010}[sub f = "x"]').children[0]
+
+    assert isinstance(get_op, GetOp)
+    assert get_op.component == tokens.FACT
+    assert isinstance(rename_op, RenameOp)
+    assert rename_op.rename_nodes[0].old_name == tokens.FACT
+    assert isinstance(sub_op, SubOp)
+    assert sub_op.substitutions[0].property_code == tokens.FACT
+
+
+def test_fact_dimension_serializes_unchanged():
+    """The wire payload is identical to a key dimension's.
+
+    The engine's AST schema pins ``Dimension`` to exactly ``class_name`` +
+    ``dimension_code`` (``additionalProperties: false``), so a Fact reference
+    must travel as ``dimension_code: "f"`` and nothing more. Component names
+    are unique within a Recordset and the Fact is named "f" by definition, so
+    the engine can resolve it by name.
+    """
+    ast = SyntaxService().parse("{tT, r010}[where f > 0]")
+    serialized = ASTToJSONVisitor().visit(ast.children[0])
+
+    assert serialized["class_name"] == "WhereClauseOp"
+    assert serialized["condition"]["left"] == {
+        "class_name": "Dimension",
+        "dimension_code": "f",
+    }
+
+
+class TestFactIsNeverPinned:
+    """Pins exist to spot a dead inner join, which is keyed on *keys*.
+
+    Two operands filtering on different fact values join perfectly well, so
+    the Fact must never contribute a pin — otherwise
+    ``Binary.check_disjoint_where_constraints`` reports a false 2-2.
+    """
+
+    def test_fact_equality_yields_no_pin(self):
+        node = BinOp(Dimension(tokens.FACT), tokens.EQ, Constant("Integer", 5))
+        assert collect_where_equality_pins(node) == {}
+
+    def test_fact_on_the_right_yields_no_pin(self):
+        node = BinOp(Constant("Integer", 5), tokens.EQ, Dimension(tokens.FACT))
+        assert collect_where_equality_pins(node) == {}
+
+    def test_key_pin_survives_alongside_a_fact_equality(self):
+        node = BinOp(
+            BinOp(Dimension("qA"), tokens.EQ, Constant("String", "X")),
+            tokens.AND,
+            BinOp(Dimension(tokens.FACT), tokens.EQ, Constant("Integer", 5)),
+        )
+        assert collect_where_equality_pins(node) == {"qA": "X"}
+
+
+class TestNonKeyComponentCodes:
+    """The Fact must stay out of the open-key catalogues."""
+
+    def test_fact_is_declared_as_a_non_key_component(self):
+        assert tokens.FACT in NON_KEY_COMPONENT_CODES
+
+    def test_fact_is_not_an_implicit_open_key(self):
+        """Folding ``f`` into ``IMPLICIT_OPEN_KEYS`` would break it.
+
+        Entries there are injected as DPM *Key Components* into every
+        Recordset by ``InputAnalyzer.visit_VarID``, which is exactly what the
+        Fact Component must not become — it would then be renameable,
+        projectable via ``get``, and counted as a join key.
+        """
+        assert tokens.FACT not in IMPLICIT_OPEN_KEYS
+
+    def test_catalogues_are_disjoint(self):
+        assert not NON_KEY_COMPONENT_CODES & set(IMPLICIT_OPEN_KEYS)

--- a/tests/unit/dpm_xl/test_clause_fact_component.py
+++ b/tests/unit/dpm_xl/test_clause_fact_component.py
@@ -1,0 +1,194 @@
+"""Structural rules for the Fact Component in clause operators (#266).
+
+``where`` accepts the Fact Component ("f") as a condition target; ``get``,
+``rename`` and ``sub`` reject it, as do all four for Standard *Key
+Components* ("r", "c", "s"). These tests drive the operators directly, so no
+database is involved.
+"""
+
+import pytest
+
+import dpmcore.dpm_xl.semantic_analyzer  # noqa: F401 (resolves circular imports)
+from dpmcore.dpm_xl.ast.nodes import BinOp, Constant, Dimension
+from dpmcore.dpm_xl.ast.where_clause import collect_where_equality_pins
+from dpmcore.dpm_xl.operators.arithmetic import BinPlus
+from dpmcore.dpm_xl.operators.clause import Get, Rename, Sub, Where
+from dpmcore.dpm_xl.symbols import (
+    ConstantOperand,
+    FactComponent,
+    KeyComponent,
+    RecordSet,
+    Scalar,
+    Structure,
+)
+from dpmcore.dpm_xl.types.scalar import Boolean, Item, Number, String
+from dpmcore.dpm_xl.utils.tokens import DPM, EQ, FACT, STANDARD
+from dpmcore.errors import SemanticError
+
+
+def _make_rs(fact_type=None) -> RecordSet:
+    """Recordset with one standard key ("r"), one DPM key ("qA") and a fact."""
+    structure = Structure(
+        [
+            KeyComponent("r", Number(), STANDARD, "test"),
+            KeyComponent("qA", Item(), DPM, "test"),
+            FactComponent(fact_type or Number(), "test"),
+        ]
+    )
+    return RecordSet(structure, "ds", "ds")
+
+
+def _boolean_condition() -> Scalar:
+    return Scalar(type_=Boolean(), name="cond", origin="cond")
+
+
+class TestWhereAcceptsTheFact:
+    def test_fact_only_condition_is_accepted(self):
+        result = Where.validate(
+            operand=_make_rs(),
+            key_names=[FACT],
+            new_names=None,
+            condition=_boolean_condition(),
+        )
+        assert isinstance(result, RecordSet)
+
+    def test_structure_is_unchanged(self):
+        """A filter changes records, never components."""
+        operand = _make_rs()
+        before = dict(operand.structure.components)
+        result = Where.validate(
+            operand=operand,
+            key_names=[FACT],
+            new_names=None,
+            condition=_boolean_condition(),
+        )
+        assert set(result.structure.components) == set(before)
+        assert isinstance(result.get_fact_component(), FactComponent)
+
+    def test_fact_alongside_a_dpm_key_is_accepted(self):
+        result = Where.validate(
+            operand=_make_rs(),
+            key_names=[FACT, "qA"],
+            new_names=None,
+            condition=_boolean_condition(),
+        )
+        assert isinstance(result, RecordSet)
+
+    def test_unknown_component_still_raises_2_8(self):
+        """Allowing the Fact must not weaken resolution of real components."""
+        with pytest.raises(SemanticError) as exc:
+            Where.validate(
+                operand=_make_rs(),
+                key_names=[FACT, "qMissing"],
+                new_names=None,
+                condition=_boolean_condition(),
+            )
+        assert exc.value.code == "2-8"
+
+    def test_standard_key_still_raises_4_5_0_1(self):
+        with pytest.raises(SemanticError) as exc:
+            Where.validate(
+                operand=_make_rs(),
+                key_names=["r"],
+                new_names=None,
+                condition=_boolean_condition(),
+            )
+        assert exc.value.code == "4-5-0-1"
+
+
+class TestOtherClausesRejectTheFact:
+    def test_get_raises_4_5_0_1(self):
+        with pytest.raises(SemanticError) as exc:
+            Get.validate(operand=_make_rs(), key_names=[FACT])
+        assert exc.value.code == "4-5-0-1"
+
+    def test_rename_from_the_fact_raises_4_5_0_1(self):
+        with pytest.raises(SemanticError) as exc:
+            Rename.validate(
+                operand=_make_rs(), key_names=[FACT], new_names=["qB"]
+            )
+        assert exc.value.code == "4-5-0-1"
+
+    def test_rename_to_the_fact_still_raises_4_5_1_3(self):
+        with pytest.raises(SemanticError) as exc:
+            Rename.validate(
+                operand=_make_rs(), key_names=["qA"], new_names=[FACT]
+            )
+        assert exc.value.code == "4-5-1-3"
+
+    def test_sub_on_the_fact_raises_4_5_0_1(self):
+        """A sub clause substitutes DPM *Key Components* only."""
+        with pytest.raises(SemanticError) as exc:
+            Sub.validate(
+                operand=_make_rs(),
+                property_code=FACT,
+                value=ConstantOperand(
+                    type_=Number(), name=None, origin="1", value=1
+                ),
+            )
+        assert exc.value.code == "4-5-0-1"
+
+    def test_sub_on_a_standard_key_raises_4_5_0_1(self):
+        """Reachable via the backtick form (`` [sub `r` = ...] ``)."""
+        with pytest.raises(SemanticError) as exc:
+            Sub.validate(
+                operand=_make_rs(),
+                property_code="r",
+                value=ConstantOperand(
+                    type_=Number(), name=None, origin="1", value=1
+                ),
+            )
+        assert exc.value.code == "4-5-0-1"
+
+
+class TestGetRetypesTheFact:
+    """The result Fact Component takes the Data Type of the selected one."""
+
+    def test_fact_takes_the_selected_components_type(self):
+        operand = _make_rs(fact_type=Number())
+        result = Get.validate(operand=operand, key_names=["qA"])
+        assert isinstance(result.get_fact_component().type, Item)
+
+    def test_string_key_yields_a_string_fact(self):
+        structure = Structure(
+            [
+                KeyComponent("r", Number(), STANDARD, "test"),
+                KeyComponent("qA", String(), DPM, "test"),
+                FactComponent(Number(), "test"),
+            ]
+        )
+        result = Get.validate(
+            operand=RecordSet(structure, "ds", "ds"), key_names=["qA"]
+        )
+        assert isinstance(result.get_fact_component().type, String)
+
+
+class TestFactPinsDoNotKillTheJoin:
+    """Two operands filtering on different fact values must still join."""
+
+    def test_disjoint_fact_filters_do_not_raise_2_2(self):
+        """``{tA}[where f = 1] + {tB}[where f = 2]`` is a live operation.
+
+        The pins are derived the same way ``visit_WhereClauseOp`` derives
+        them, so this exercises the real path rather than a hand-written
+        constraint dict.
+        """
+        left, right = _make_rs(), _make_rs()
+        left.where_constraints = collect_where_equality_pins(
+            BinOp(Dimension(FACT), EQ, Constant("Integer", 1))
+        )
+        right.where_constraints = collect_where_equality_pins(
+            BinOp(Dimension(FACT), EQ, Constant("Integer", 2))
+        )
+        assert left.where_constraints == {}
+        BinPlus.validate_structures(left, right)  # must not raise
+
+    def test_shared_key_pin_conflict_still_raises_2_2(self):
+        """Regression guard: the key-based check keeps working."""
+        left = _make_rs()
+        right = _make_rs()
+        left.where_constraints = {"qA": "X"}
+        right.where_constraints = {"qA": "Y"}
+        with pytest.raises(SemanticError) as exc:
+            BinPlus.validate_structures(left, right)
+        assert exc.value.code == "2-2"

--- a/tests/unit/dpm_xl/test_clause_fact_component.py
+++ b/tests/unit/dpm_xl/test_clause_fact_component.py
@@ -8,7 +8,6 @@ database is involved.
 
 import pytest
 
-import dpmcore.dpm_xl.semantic_analyzer  # noqa: F401 (resolves circular imports)
 from dpmcore.dpm_xl.ast.nodes import BinOp, Constant, Dimension
 from dpmcore.dpm_xl.ast.where_clause import collect_where_equality_pins
 from dpmcore.dpm_xl.operators.arithmetic import BinPlus

--- a/tests/unit/semantic/test_where_fact_dimension.py
+++ b/tests/unit/semantic/test_where_fact_dimension.py
@@ -1,0 +1,110 @@
+"""Tests for Fact Component resolution in ``InputAnalyzer.visit_Dimension``.
+
+A ``Dimension`` naming the Fact Component ("f") is not looked up in the
+dictionary: its data type is whatever the enclosing clause operand carries.
+``visit_WhereClauseOp`` therefore pushes its operand onto a stack before
+visiting the condition, and ``visit_Dimension`` reads the top of that stack.
+"""
+
+import pytest
+
+from dpmcore.dpm_xl.ast.nodes import Constant, Dimension, WhereClauseOp
+from dpmcore.dpm_xl.semantic_analyzer import InputAnalyzer
+from dpmcore.dpm_xl.symbols import (
+    FactComponent,
+    KeyComponent,
+    RecordSet,
+    Structure,
+)
+from dpmcore.dpm_xl.types.scalar import Boolean, Item, Number, String
+from dpmcore.dpm_xl.utils.tokens import DPM, FACT
+from dpmcore.errors import SemanticError
+
+
+def _make_rs(fact_type) -> RecordSet:
+    structure = Structure(
+        [
+            KeyComponent("qA", Item(), DPM, "test"),
+            FactComponent(fact_type, "test"),
+        ]
+    )
+    return RecordSet(structure, "ds", "ds")
+
+
+@pytest.mark.parametrize("fact_type", [Number(), String(), Boolean()])
+def test_fact_dimension_takes_the_operands_fact_type(fact_type):
+    """The scalar returned mirrors the operand's Fact Component type.
+
+    This is what makes ``[where f]`` valid on a Boolean-typed selection and a
+    type error on a numeric one, and what type-checks ``[where f = "x"]``
+    against the right side.
+    """
+    analyser = InputAnalyzer(expression="")
+    analyser._clause_operands.append(_make_rs(fact_type))
+
+    result = analyser.visit_Dimension(Dimension(FACT))
+
+    assert type(result.type) is type(fact_type)
+    assert result.origin == FACT
+
+
+def test_innermost_operand_wins():
+    """Chained/nested clauses resolve against the operand they belong to."""
+    analyser = InputAnalyzer(expression="")
+    analyser._clause_operands.append(_make_rs(Number()))
+    analyser._clause_operands.append(_make_rs(String()))
+
+    assert isinstance(analyser.visit_Dimension(Dimension(FACT)).type, String)
+
+    analyser._clause_operands.pop()
+    assert isinstance(analyser.visit_Dimension(Dimension(FACT)).type, Number)
+
+
+def test_non_recordset_operand_raises_4_5_0_2_before_the_condition():
+    """A scalar operand is rejected before the condition is resolved.
+
+    ``ClauseOperator.validate`` rejects it too, but only after the condition
+    has been visited — and resolving the Fact needs a structure. Failing
+    first here keeps the operand stack total, with the same error code.
+    """
+    analyser = InputAnalyzer(expression="")
+    node = WhereClauseOp(
+        operand=Constant(type_="String", value="dummy"),
+        condition=Dimension(FACT),
+    )
+    node.key_components = [FACT]
+
+    with pytest.raises(SemanticError) as exc:
+        analyser.visit_WhereClauseOp(node)
+
+    assert exc.value.code == "4-5-0-2"
+    assert analyser._clause_operands == []
+
+
+def test_empty_condition_still_raises_4_5_2_1_first():
+    """Error precedence is unchanged: the empty-condition check comes first."""
+    analyser = InputAnalyzer(expression="")
+    node = WhereClauseOp(
+        operand=Constant(type_="String", value="dummy"),
+        condition=Dimension(FACT),
+    )
+
+    with pytest.raises(SemanticError) as exc:
+        analyser.visit_WhereClauseOp(node)
+
+    assert exc.value.code == "4-5-2-1"
+
+
+def test_fact_outside_a_clause_raises_4_5_0_1():
+    """Defensive guard: no operand in scope means no Fact to resolve.
+
+    The grammar only produces a ``Dimension`` inside a clause, so this is not
+    reachable from a parsed expression — but the resolution must fail loudly
+    rather than index an empty stack.
+    """
+    analyser = InputAnalyzer(expression="{tT}[where f]")
+
+    with pytest.raises(SemanticError) as exc:
+        analyser.visit_Dimension(Dimension(FACT))
+
+    assert exc.value.code == "4-5-0-1"


### PR DESCRIPTION
## Summary

Closes #266 

The clause operators accepted only DPM key components as targets, so any `where` condition filtering a recordset by its fact value was rejected by the semantic analyzer with `1-5 "open keys not found: ['f']"`. The dictionary pre-check resolves every clause identifier as an open key, and the Fact Component has no dictionary row. That blocked EGDQ_0070, EGDQ_0071a, EGDQ_0071b and EGDQ_0133.

Following the spec extension, `[where …]` now accepts the Fact Component. Concretely:

- **`where` accepts `f`.** The Fact is excluded from the open-key lookups and resolved structurally instead, against the Fact Component of the enclosing clause operand — so it is typed per operand. `[where f]` is a valid filter on a Boolean-typed selection and a type error (`3-3`) on a numeric one, and `[where f = …]` type-checks against the operand's data type.
- **`get`, `rename` and `sub` keep rejecting `f`,** but now with the structural error `4-5-0-1` ("clause operators can't be used with standard key components or fact component") rather than the misleading `1-5`. Standard key components (`r`, `c`, `s`) remain disallowed for every clause operator, and the `sub` clause gained the guard it was missing, so a backticked ``[sub `r` = …]`` reports `4-5-0-1` instead of falling through to `2-8`.
- **The Fact never contributes a where-equality pin.** Pins exist to detect an inner join that can never match (#121) and that join is over key components; two operands filtering on different fact values are perfectly joinable, so pinning the Fact would have produced a false `2-2`.
- **The result Fact Component of a `get` already took the data type of the selected component** — that part of the extension needed no change, only a test.

No grammar change was needed: `f` already lexes as an ordinary property code inside a clause, so the rejection was always semantic.

## Wire format

Unchanged, and no engine schema change is required. The Fact travels as `{"class_name": "Dimension", "dimension_code": "f"}`, exactly like a key dimension. The engine's `Dimension` definition accepts precisely `class_name` + `dimension_code` with `additionalProperties: false` and a closed `class_name` enum, so a dedicated node class or an extra role field would both have been rejected; component names are unique within a recordset and the Fact is named `f` by definition, so the code resolves unambiguously by name.

## Scope

This delivers the `where`-on-Fact part of the extension. Two pieces are deliberately left out, each with a follow-up issue drafted:

- `get` / `rename` over Attribute Components. `AttributeComponent` and the whole `propagate_attributes` machinery exist in the symbol layer, but nothing ever constructs an attribute component, and the current dictionary ships no attribute variables — so there is nothing to resolve against. Once a producer exists, the shared clause validation already resolves names against attributes, so most of that behaviour follows for free.
- A Fact-only `where_expression` in a `with` clause. The grammar accepts the `with … [where …]` block but the AST drops it, so the clause applies to nothing today and no error is raised. That is a separate defect, and the "must have at least one key component" constraint belongs with it.

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`)
- [x] Documentation updated (clause-operator target matrix in `specification/03-services.md`, which was also missing `GET` from the operator list)

## Notes