### PR TITLE
feat(services): analyse an expression paired with a precondition expr…

### DIFF
--- a/specification/02-rest-api.md
+++ b/specification/02-rest-api.md
@@ -589,7 +589,8 @@ POST /api/v1/scope
 | `expression` | string | yes | DPM-XL expression to analyse |
 | `release_id` | int \| null | no | Restrict lookup to a specific release (by database ID) |
 | `release_code` | string \| null | no | Restrict lookup to a specific release (by code, e.g. `"3.4"`) |
-| `precondition_items` | `[string]` \| null | no | List of precondition item codes to apply |
+| `precondition_items` | `[string]` \| null | no | List of filing-indicator variable codes to apply |
+| `precondition_expression` | string \| null | no | Full DPM-XL gate expression. Its own operands join the scope resolution: table references widen the table set, mandatory filing-indicator references widen the precondition set. A gate that fails to resolve fails the call with `error_source: "precondition"`. |
 
 **Response body:**
 
@@ -600,6 +601,8 @@ POST /api/v1/scope
 | `module_versions` | `[int]` | Database IDs of the module versions involved |
 | `has_error` | bool | `true` if scope calculation failed |
 | `error_message` | string \| null | Error description if `has_error` is `true`, otherwise `null` |
+| `warning` | string \| null | Set when a supplied `precondition_expression` changed the computed scope, naming the module versions before and after |
+| `error_source` | string \| null | `"expression"` or `"precondition"` — which half a failure belongs to. `null` unless `has_error` |
 
 **Example:**
 

--- a/specification/02-rest-api.md
+++ b/specification/02-rest-api.md
@@ -444,16 +444,18 @@ POST /api/v1/validate/semantic
 | `expression` | string | yes | DPM-XL expression to validate |
 | `release_id` | int \| null | no | Restrict lookup to a specific release (by database ID) |
 | `release_code` | string \| null | no | Restrict lookup to a specific release (by code, e.g. `"3.4"`) |
+| `precondition_expression` | string \| null | no | Full DPM-XL gate expression. Both halves are validated against the same release, and the gate is checked *as a gate*, so it must return a boolean (`2-1`) |
 
 **Response body:**
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `is_valid` | bool | `true` if the expression is semantically valid |
-| `error_message` | string \| null | Validation error description, or `null` on success |
-| `error_code` | string \| null | Machine-readable error code, or `null` on success |
+| `is_valid` | bool | `true` if the expression is semantically valid. When a `precondition_expression` was supplied this is the verdict for the **pair**: `false` if either half failed, since a row whose gate does not resolve is not evaluable |
+| `error_message` | string \| null | Validation error description, or `null` on success. Names every failure that occurred; the gate's is prefixed `"Precondition: "` |
+| `error_code` | string \| null | Machine-readable error code, or `null` on success. A single value: the expression's when it failed, otherwise the gate's |
 | `expression` | string | The expression that was evaluated |
-| `warning` | string \| null | Non-fatal warning (e.g. deprecated reference), or `null` |
+| `warning` | string \| null | Non-fatal warning (e.g. deprecated reference), or `null`. Merges both halves' warnings, the gate's under the same prefix |
+| `error_source` | string \| null | `"expression"`, `"precondition"` or `"both"` — which half a failure belongs to. `null` when `is_valid` is `true` |
 
 **Example:**
 
@@ -473,7 +475,32 @@ Content-Type: application/json
   "error_message": null,
   "error_code": null,
   "expression": "{tC_01.00, r0010, c0010} = 0",
-  "warning": null
+  "warning": null,
+  "error_source": null
+}
+```
+
+Gated by a precondition expression that does not resolve:
+
+```bash
+POST /api/v1/validate/semantic
+Content-Type: application/json
+
+{
+  "expression": "{tC_01.00, r0010, c0010} = 0",
+  "precondition_expression": "{v_NOT_A_TABLE}",
+  "release_id": 1
+}
+```
+
+```json
+{
+  "is_valid": false,
+  "error_message": "Precondition: ...",
+  "error_code": "1-2",
+  "expression": "{tC_01.00, r0010, c0010} = 0",
+  "warning": null,
+  "error_source": "precondition"
 }
 ```
 

--- a/src/dpmcore/server/app.py
+++ b/src/dpmcore/server/app.py
@@ -27,6 +27,17 @@ class ExpressionRequest(BaseModel):
     release_code: Optional[str] = None
 
 
+class SemanticRequest(ExpressionRequest):
+    """Body for ``POST /validate/semantic``.
+
+    Adds the optional gate. Kept separate from
+    :class:`ExpressionRequest` so ``/validate/syntax``, which has no notion of
+    a gate, does not advertise a field it ignores.
+    """
+
+    precondition_expression: Optional[str] = None
+
+
 class SyntaxResponse(BaseModel):
     """Syntax validation result."""
 
@@ -36,13 +47,19 @@ class SyntaxResponse(BaseModel):
 
 
 class SemanticResponse(BaseModel):
-    """Semantic validation result."""
+    """Semantic validation result.
+
+    ``is_valid`` is pair-wide when a ``precondition_expression`` was supplied:
+    ``false`` if either half failed, since a row whose gate does not resolve
+    is not evaluable. ``error_source`` then names the failing half.
+    """
 
     is_valid: bool
     error_message: Optional[str]
     error_code: Optional[str]
     expression: str
     warning: Optional[str] = None
+    error_source: Optional[str] = None
 
 
 # ------------------------------------------------------------------ #
@@ -154,7 +171,7 @@ def create_app(
         tags=["Validation"],
     )
     def validate_semantic(
-        body: ExpressionRequest,
+        body: SemanticRequest,
         session: Session = Depends(get_session),  # noqa: B008
     ) -> SemanticResponse:
         from dpmcore.services.dpm_xl import DpmXlService
@@ -163,6 +180,7 @@ def create_app(
             body.expression,
             release_id=body.release_id,
             release_code=body.release_code,
+            precondition_expression=body.precondition_expression,
         )
         return SemanticResponse(
             is_valid=result["is_valid"],
@@ -170,6 +188,7 @@ def create_app(
             error_code=result["error_code"],
             expression=result["expression"],
             warning=result.get("warning"),
+            error_source=result.get("error_source"),
         )
 
     # -- structure endpoints (SDMX-style) --------------------------------

--- a/src/dpmcore/server/routers/scope.py
+++ b/src/dpmcore/server/routers/scope.py
@@ -11,12 +11,18 @@ from sqlalchemy.orm import Session
 
 
 class ScopeRequest(BaseModel):
-    """Request body for ``POST /scope``."""
+    """Request body for ``POST /scope``.
+
+    ``precondition_items`` are filing-indicator variable codes;
+    ``precondition_expression`` is a full DPM-XL gate expression whose own
+    operands join the scope resolution. The two are independent.
+    """
 
     expression: str
     release_id: Optional[int] = None
     release_code: Optional[str] = None
     precondition_items: Optional[List[str]] = None
+    precondition_expression: Optional[str] = None
 
 
 class ScopeResponse(BaseModel):
@@ -26,6 +32,9 @@ class ScopeResponse(BaseModel):
     omitted: it contains ORM objects that are not JSON-serialisable and
     callers only need the summary fields below. ``total_scopes`` and
     ``module_versions`` carry the information consumers actually use.
+
+    ``warning`` is set when a supplied ``precondition_expression`` changed the
+    scope; ``error_source`` names the half a failure belongs to.
     """
 
     total_scopes: int
@@ -33,6 +42,8 @@ class ScopeResponse(BaseModel):
     module_versions: List[int]
     has_error: bool
     error_message: Optional[str] = None
+    warning: Optional[str] = None
+    error_source: Optional[str] = None
 
 
 def create_scope_router(
@@ -58,6 +69,7 @@ def create_scope_router(
             release_id=body.release_id,
             precondition_items=body.precondition_items,
             release_code=body.release_code,
+            precondition_expression=body.precondition_expression,
         )
         return ScopeResponse(
             total_scopes=result.total_scopes,
@@ -65,6 +77,8 @@ def create_scope_router(
             module_versions=result.module_versions,
             has_error=result.has_error,
             error_message=result.error_message,
+            warning=result.warning,
+            error_source=result.error_source,
         )
 
     return router

--- a/src/dpmcore/services/_parameters.py
+++ b/src/dpmcore/services/_parameters.py
@@ -1,0 +1,49 @@
+"""Shared helper: merging parameter declarations across expressions.
+
+Kept as a module-level function rather than a service method so both
+:meth:`~dpmcore.services.semantic.SemanticService.validate` (applying the rule
+across an expression and its precondition gate) and
+``ASTGeneratorService._accumulate_parameters`` (applying it across a whole
+generated script) share one implementation of the rule.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Dict, Iterable
+
+from dpmcore.errors import SemanticError
+
+if TYPE_CHECKING:
+    from dpmcore.services.semantic import ParameterInfo
+
+
+def merge_parameters(
+    accumulated: Dict[str, "ParameterInfo"],
+    parameters: Iterable["ParameterInfo"],
+) -> None:
+    """Merge one expression's parameters into ``accumulated``, by code.
+
+    A parameter is an execution-time input bound to a single value across
+    everything it co-executes with, so its declared type is intrinsic and must
+    stay consistent across every co-executing expression.
+
+    Args:
+        accumulated: Registry of ``{code: ParameterInfo}`` seen so far, mutated
+            in place.
+        parameters: The next expression's already-deduped parameters.
+
+    Raises:
+        SemanticError: ``3-8`` when a code is redeclared with another type,
+            rather than silently letting one reference win.
+    """
+    for prm in parameters:
+        prior = accumulated.get(prm.code)
+        if prior is None:
+            accumulated[prm.code] = prm
+        elif prior.declared_type != prm.declared_type:
+            raise SemanticError(
+                "3-8",
+                parameter=prm.code,
+                type_1=prior.declared_type,
+                type_2=prm.declared_type,
+            )

--- a/src/dpmcore/services/_precondition_codes.py
+++ b/src/dpmcore/services/_precondition_codes.py
@@ -76,14 +76,25 @@ def _code_of(node: Any) -> Optional[str]:
 
 
 def _mandatory(node: Any) -> Set[str]:
-    """Codes that must hold for *node* to be evaluable.
+    """Codes that must be **true** for *node* to hold.
 
-    ``or``/``xor`` intersects its operands' requirements, because either side
-    alone can satisfy the gate; ``not`` requires nothing. Everything else —
-    ``and``, comparisons, arithmetic, function calls — unions its children's
-    requirements, since a code appearing inside one is genuinely needed to
-    evaluate it. That makes the union the default and the only special cases
-    the two that weaken a requirement.
+    The criterion is "must be true", not "must be readable". That is what
+    scope needs: a module hosts the operation only if the gate can be true
+    there, and ``precondition_items`` excludes any module that does not carry
+    the code. Requiring a code the gate needs to be *false* would exclude
+    exactly the modules the rule targets.
+
+    So ``or``/``xor`` intersects its operands — either side alone can satisfy
+    the gate, so neither is individually mandatory — and ``not`` contributes
+    nothing, since its operand has to be false. Those are one rule, not two:
+    ``{v_A} or {v_B}`` yields ``[]`` for the same reason ``not {v_A}`` does.
+    Consequently ``not {v_A} and {v_B}`` yields only ``B`` — ``A`` is dropped
+    on purpose, because the gate is *for* the modules that do not file ``A``.
+
+    Everything else — ``and``, comparisons, arithmetic, function calls —
+    unions its children, since a code inside one genuinely has to hold. That
+    makes the union the default and the only special cases the two that
+    weaken a requirement.
     """
     # Deferred like the ``ASTTemplate`` import above, so this module pulls in
     # nothing from the engine at import time.
@@ -129,10 +140,13 @@ def required_precondition_codes(ast: Any) -> List[str]:
     """Return the codes a module must provide to evaluate a precondition AST.
 
     Scope calculation counts every precondition code as an operand the module
-    has to supply, so only *mandatory* codes may be passed to it. A disjunctive
-    gate such as ``{v_A} or {v_B}`` requires neither code specifically, and
-    returns ``[]`` — the gate then constrains scope exactly as much as it
-    should, which is not at all.
+    has to supply, so only codes that must be **true** for the gate to hold
+    may be passed to it (see :func:`_mandatory`). A disjunctive gate such as
+    ``{v_A} or {v_B}`` requires neither code specifically, and returns ``[]``
+    — the gate then constrains scope exactly as much as it should, which is
+    not at all. A negated one behaves the same way: ``not {v_A}`` returns
+    ``[]``, and ``not {v_A} and {v_B}`` returns only ``B``, because a module
+    that never files ``A`` is precisely where such a gate is meant to fire.
 
     Order follows :func:`extract_precondition_codes` (first-seen), so the
     result is deterministic. Returns ``[]`` on any walk failure, matching

--- a/src/dpmcore/services/_precondition_codes.py
+++ b/src/dpmcore/services/_precondition_codes.py
@@ -1,0 +1,151 @@
+"""Shared helpers: the variable codes a precondition expression references.
+
+Kept as module-level functions rather than service methods so both
+:class:`~dpmcore.services.ast_generator.ASTGeneratorService` and
+:class:`~dpmcore.services.scope_calculator.ScopeCalculatorService` can use
+them without one service reaching into the private surface of the other.
+
+Two functions, because scope calculation and payload emission need different
+answers:
+
+* :func:`extract_precondition_codes` — *every* code the gate mentions. What
+  ``ASTGeneratorService`` has always used.
+* :func:`required_precondition_codes` — only the codes a module **must**
+  provide to evaluate the gate. Scope calculation needs this one: it counts
+  each precondition code as an operand a module has to supply
+  (``unique_operands_number`` in ``OperationScopeService``), so feeding it the
+  flat set makes a disjunctive gate demand every alternative at once. On the
+  real EBA dictionary that is not theoretical — of 965 persisted precondition
+  expressions, 62 use ``or``, and the widest flattens to 20 filing indicators
+  spanning frameworks, which resolves to a hard ``1-14``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, List, Optional, Set
+
+logger = logging.getLogger(__name__)
+
+
+def extract_precondition_codes(ast: Any) -> List[str]:
+    """Return the variable codes referenced by a precondition AST.
+
+    Walks the AST collecting:
+    - ``PreconditionItem.variable_code``
+    - ``VarRef.variable``
+
+    Either kind unambiguously identifies a precondition variable for
+    scope-calculation purposes. Deduplicated, first-seen order preserved.
+    Classifying those codes into genuine filing indicators (the only ones
+    that constrain module scope) happens downstream, in
+    ``OperationScopeService.calculate_operation_scope``.
+    """
+    from dpmcore.dpm_xl.ast.template import ASTTemplate
+
+    codes: List[str] = []
+
+    class _Extractor(ASTTemplate):
+        def visit_PreconditionItem(self, node: Any) -> None:
+            vc = getattr(node, "variable_code", None)
+            if vc and vc not in codes:
+                codes.append(vc)
+
+        def visit_VarRef(self, node: Any) -> None:
+            v = getattr(node, "variable", None)
+            if v and v not in codes:
+                codes.append(v)
+
+    try:
+        _Extractor().visit(ast)
+    except Exception:
+        logger.exception(
+            "Failed to extract precondition codes; continuing without them.",
+        )
+        return []
+    return codes
+
+
+def _code_of(node: Any) -> Optional[str]:
+    """Return the variable code a leaf precondition node names, if any."""
+    for attr in ("variable_code", "variable"):
+        value = getattr(node, attr, None)
+        if value:
+            return str(value)
+    return None
+
+
+def _mandatory(node: Any) -> Set[str]:
+    """Codes that must hold for *node* to be evaluable.
+
+    ``or``/``xor`` intersects its operands' requirements, because either side
+    alone can satisfy the gate; ``not`` requires nothing. Everything else —
+    ``and``, comparisons, arithmetic, function calls — unions its children's
+    requirements, since a code appearing inside one is genuinely needed to
+    evaluate it. That makes the union the default and the only special cases
+    the two that weaken a requirement.
+    """
+    # Deferred like the ``ASTTemplate`` import above, so this module pulls in
+    # nothing from the engine at import time.
+    from dpmcore.dpm_xl.utils.tokens import NOT, OR, XOR
+
+    code = _code_of(node)
+    if code is not None:
+        return {code}
+
+    op = getattr(node, "op", None)
+    left = getattr(node, "left", None)
+    right = getattr(node, "right", None)
+
+    if op == NOT:
+        return set()
+    if op in (OR, XOR) and left is not None and right is not None:
+        return _mandatory(left) & _mandatory(right)
+
+    # Union over every child: Start.children, ParExpr.expression, BinOp's
+    # left/right, UnaryOp.operand, and any other node's AST-valued attributes.
+    required: Set[str] = set()
+    for child in _children(node):
+        required |= _mandatory(child)
+    return required
+
+
+def _children(node: Any) -> List[Any]:
+    """AST-valued attributes of *node*, flattening lists."""
+    from dpmcore.dpm_xl.ast.nodes import AST
+
+    found: List[Any] = []
+    if not isinstance(node, AST):
+        return found
+    for value in vars(node).values():
+        if isinstance(value, AST):
+            found.append(value)
+        elif isinstance(value, list):
+            found.extend(item for item in value if isinstance(item, AST))
+    return found
+
+
+def required_precondition_codes(ast: Any) -> List[str]:
+    """Return the codes a module must provide to evaluate a precondition AST.
+
+    Scope calculation counts every precondition code as an operand the module
+    has to supply, so only *mandatory* codes may be passed to it. A disjunctive
+    gate such as ``{v_A} or {v_B}`` requires neither code specifically, and
+    returns ``[]`` — the gate then constrains scope exactly as much as it
+    should, which is not at all.
+
+    Order follows :func:`extract_precondition_codes` (first-seen), so the
+    result is deterministic. Returns ``[]`` on any walk failure, matching
+    :func:`extract_precondition_codes`: under-approximating can only fall back
+    to the pre-existing behaviour of ignoring the gate for scoping, never
+    invent a constraint.
+    """
+    try:
+        required = _mandatory(ast)
+    except Exception:
+        logger.exception(
+            "Failed to derive required precondition codes; "
+            "continuing without them.",
+        )
+        return []
+    return [c for c in extract_precondition_codes(ast) if c in required]

--- a/src/dpmcore/services/ast_generator.py
+++ b/src/dpmcore/services/ast_generator.py
@@ -22,7 +22,10 @@ from dpmcore.dpm_xl.utils.tokens import (
     SEVERITY_WARNING,
     VALID_SEVERITIES,
 )
-from dpmcore.errors import SemanticError
+from dpmcore.services._parameters import merge_parameters
+from dpmcore.services._precondition_codes import (
+    extract_precondition_codes as _extract_precondition_codes,
+)
 from dpmcore.services.semantic import ParameterInfo, SemanticService
 from dpmcore.services.syntax import SyntaxService
 
@@ -1165,19 +1168,12 @@ class ASTGeneratorService:
         it co-executes with, so its declared type is intrinsic and must stay
         consistent script-wide — the flat registry holds one type per code.
         Raises ``SemanticError`` ``3-8`` on a conflicting redeclaration rather
-        than silently letting one reference win.
+        than silently letting one reference win. The merge itself lives in
+        :func:`~dpmcore.services._parameters.merge_parameters`, shared with
+        :meth:`~dpmcore.services.semantic.SemanticService.validate`, which
+        applies the same rule across an expression and its precondition.
         """
-        for prm in parameters:
-            prior = accumulated.get(prm.code)
-            if prior is None:
-                accumulated[prm.code] = prm
-            elif prior.declared_type != prm.declared_type:
-                raise SemanticError(
-                    "3-8",
-                    parameter=prm.code,
-                    type_1=prior.declared_type,
-                    type_2=prm.declared_type,
-                )
+        merge_parameters(accumulated, parameters)
 
     def _build_precondition_index(
         self,
@@ -1216,37 +1212,12 @@ class ASTGeneratorService:
     def _extract_precondition_codes(ast: Any) -> List[str]:
         """Return the variable codes referenced by a precondition AST.
 
-        Walks the AST collecting:
-        - ``PreconditionItem.variable_code``
-        - ``VarRef.variable``
-
-        Either kind unambiguously identifies a precondition variable
-        for scope-calculation purposes.
+        Delegates to :func:`~dpmcore.services._precondition_codes.\
+extract_precondition_codes`, shared with
+        :class:`~dpmcore.services.scope_calculator.ScopeCalculatorService`.
+        Kept as a method so it stays an overridable seam.
         """
-        from dpmcore.dpm_xl.ast.template import ASTTemplate
-
-        codes: List[str] = []
-
-        class _Extractor(ASTTemplate):
-            def visit_PreconditionItem(self, node: Any) -> None:
-                vc = getattr(node, "variable_code", None)
-                if vc and vc not in codes:
-                    codes.append(vc)
-
-            def visit_VarRef(self, node: Any) -> None:
-                v = getattr(node, "variable", None)
-                if v and v not in codes:
-                    codes.append(v)
-
-        try:
-            _Extractor().visit(ast)
-        except Exception:
-            logger.exception(
-                "Failed to extract precondition codes; "
-                "continuing without them.",
-            )
-            return []
-        return codes
+        return _extract_precondition_codes(ast)
 
     def _build_dependency_info(
         self,

--- a/src/dpmcore/services/dpm_xl.py
+++ b/src/dpmcore/services/dpm_xl.py
@@ -22,13 +22,19 @@ class SyntaxValidationResult(TypedDict):
 
 
 class SemanticValidationResult(TypedDict):
-    """Shape of ``DpmXlService.validate_semantic`` return value."""
+    """Shape of ``DpmXlService.validate_semantic`` return value.
+
+    ``is_valid`` is pair-wide when a precondition expression was supplied, and
+    ``error_source`` then names the failing half. See
+    :class:`~dpmcore.services.semantic.SemanticResult`.
+    """
 
     is_valid: bool
     error_message: str | None
     error_code: str | None
     expression: str
     warning: str | None
+    error_source: str | None
 
 
 class DpmXlService:
@@ -68,14 +74,16 @@ class DpmXlService:
     def validate_semantic(
         self,
         expression: str,
+        precondition_expression: Optional[str] = None,
         release_id: Optional[int] = None,
         release_code: Optional[str] = None,
     ) -> SemanticValidationResult:
-        """Full semantic validation (requires DB)."""
+        """Full semantic validation, optionally gated (requires DB)."""
         if self.semantic is None:
             raise RuntimeError("No database session provided.")
         result = self.semantic.validate(
             expression,
+            precondition_expression=precondition_expression,
             release_id=release_id,
             release_code=release_code,
         )
@@ -85,6 +93,7 @@ class DpmXlService:
             "error_code": result.error_code,
             "expression": result.expression,
             "warning": result.warning,
+            "error_source": result.error_source,
         }
 
     def get_parameters(

--- a/src/dpmcore/services/dpm_xl.py
+++ b/src/dpmcore/services/dpm_xl.py
@@ -74,11 +74,17 @@ class DpmXlService:
     def validate_semantic(
         self,
         expression: str,
-        precondition_expression: Optional[str] = None,
         release_id: Optional[int] = None,
         release_code: Optional[str] = None,
+        *,
+        precondition_expression: Optional[str] = None,
     ) -> SemanticValidationResult:
-        """Full semantic validation, optionally gated (requires DB)."""
+        """Full semantic validation, optionally gated (requires DB).
+
+        ``precondition_expression`` is keyword-only and appended after the
+        pre-existing arguments, so ``validate_semantic(expr, 5)`` still means
+        ``release_id=5``.
+        """
         if self.semantic is None:
             raise RuntimeError("No database session provided.")
         result = self.semantic.validate(

--- a/src/dpmcore/services/scope_calculator.py
+++ b/src/dpmcore/services/scope_calculator.py
@@ -248,6 +248,7 @@ class ScopeCalculatorService:
         release_id: Optional[int] = None,
         precondition_items: Optional[List[str]] = None,
         release_code: Optional[str] = None,
+        *,
         precondition_expression: Optional[str] = None,
     ) -> ScopeResult:
         """Calculate scopes for *expression*, optionally gated.
@@ -291,6 +292,8 @@ class ScopeCalculatorService:
             release_code: Optional release code (mutually exclusive
                 with ``release_id``).
             precondition_expression: Optional DPM-XL gate expression.
+                Keyword-only, matching ``SemanticService.validate``, so the
+                pre-existing positional arguments keep their meaning.
         """
         base_items = list(precondition_items or [])
         try:

--- a/src/dpmcore/services/scope_calculator.py
+++ b/src/dpmcore/services/scope_calculator.py
@@ -35,6 +35,7 @@ from dpmcore.orm.variables import Variable, VariableVersion
 from dpmcore.services._open_keys import (
     get_open_keys_for_tables as _get_open_keys_for_tables,
 )
+from dpmcore.services._precondition_codes import required_precondition_codes
 from dpmcore.services.syntax import SyntaxService
 
 if TYPE_CHECKING:
@@ -45,7 +46,13 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class ScopeResult:
-    """Outcome of a scope calculation."""
+    """Outcome of a scope calculation.
+
+    ``warning`` is only ever set when a ``precondition_expression`` changed the
+    computed scope. ``error_source`` names the half a failure belongs to and is
+    set whenever ``has_error`` is true. Neither changes ``error_message`` for a
+    call that passes no precondition expression.
+    """
 
     scopes: list[Any] = field(default_factory=list)
     total_scopes: int = 0
@@ -53,6 +60,10 @@ class ScopeResult:
     module_versions: List[int] = field(default_factory=list)
     has_error: bool = False
     error_message: Optional[str] = None
+    # Set when the precondition expression changes the computed scope.
+    warning: Optional[str] = None
+    # Which half a failure belongs to: "expression" or "precondition".
+    error_source: Optional[str] = None
 
 
 class ScopeCalculatorService:
@@ -96,21 +107,192 @@ class ScopeCalculatorService:
             for s in scopes
         )
 
+    @staticmethod
+    def _scope_signature(scopes: list[Any]) -> frozenset[frozenset[int]]:
+        """Canonical identity of a scope set: the set of module-VID sets.
+
+        Comparing ``module_versions`` alone would miss a re-partitioning —
+        two intra-module scopes ``[[462], [513]]`` collapsing into one
+        cross-module scope ``[[462, 513]]`` lists the same module versions but
+        means something materially different. Comparing ``total_scopes`` alone
+        would miss a coincidental equal count. The set of module sets catches
+        module additions and removals, intra/cross re-grouping, splits, and the
+        empty case.
+        """
+        return frozenset(
+            frozenset(
+                c.module_vid
+                for c in getattr(s, "operation_scope_compositions", [])
+            )
+            for s in scopes
+        )
+
+    @staticmethod
+    def _module_vids(scopes: list[Any]) -> List[int]:
+        """Module VIDs across *scopes*, deduped in first-seen order."""
+        mvids: List[int] = []
+        for scope in scopes:
+            for comp in getattr(scope, "operation_scope_compositions", []):
+                if comp.module_vid not in mvids:
+                    mvids.append(comp.module_vid)
+        return mvids
+
+    def _result_from_scopes(self, scopes: list[Any]) -> ScopeResult:
+        """Project a computed scope list into a :class:`ScopeResult`."""
+        return ScopeResult(
+            scopes=scopes,
+            total_scopes=len(scopes),
+            is_cross_module=self._compute_cross_module(scopes),
+            module_versions=self._module_vids(scopes),
+        )
+
+    def _operand_tables(
+        self, expression: str, release_id: Optional[int]
+    ) -> tuple[Any, List[str]]:
+        """Parse *expression*, returning its AST and its table codes."""
+        ast = self._syntax.parse(expression)
+        oc = OperandsChecking(
+            session=self.session,
+            expression=expression,
+            ast=ast,
+            release_id=release_id,
+        )
+        return ast, (list(oc.tables.keys()) if oc.tables else [])
+
+    def _check_tables_hosted(
+        self, table_codes: List[str], release_id: Optional[int]
+    ) -> None:
+        """Raise ``1-13`` naming any table code no module version hosts.
+
+        ``OperationScopeService.extract_module_info`` only raises ``1-13`` when
+        *nothing* resolves, so an unhostable gate table is otherwise absorbed
+        by the main expression's own rows. It still inflates the operand count,
+        which usually empties the scope — but when the main expression resolves
+        to a single module-info row the resolver short-circuits before counting
+        operands at all, and the call would return a scope that cannot in fact
+        evaluate the pair. Checking the gate's codes on their own keeps that
+        case an error attributed to the gate rather than a silent wrong answer.
+        """
+        if not table_codes:
+            return
+        from dpmcore.dpm_xl.model_queries import ModuleVersionQuery
+
+        df = ModuleVersionQuery.get_from_table_codes(
+            session=self.session,
+            table_codes=table_codes,
+            release_id=release_id,
+        )
+        hosted = (
+            set(df["TableCode"].dropna().unique()) if not df.empty else set()
+        )
+        missing = [code for code in table_codes if code not in hosted]
+        if missing:
+            raise SemanticError("1-13", table_version_ids=missing)
+
+    def _run_scope(
+        self,
+        table_codes: List[str],
+        precondition_items: List[str],
+        release_id: Optional[int],
+    ) -> list[Any]:
+        """Resolve one scope set. A fresh service per call — it accumulates."""
+        scopes, _ = OperationScopeService(
+            session=self.session
+        ).calculate_operation_scope(
+            tables_vids=[],
+            precondition_items=precondition_items,
+            release_id=release_id,
+            table_codes=table_codes,
+        )
+        return scopes
+
+    @staticmethod
+    def _scope_change_warning(
+        baseline: list[Any],
+        combined: list[Any],
+        gate_tables: List[str],
+        gate_items: List[str],
+    ) -> str:
+        """Describe how the precondition moved the scope."""
+        before = sorted(ScopeCalculatorService._module_vids(baseline))
+        after = sorted(ScopeCalculatorService._module_vids(combined))
+        contributed = ", ".join(
+            part
+            for part in (
+                f"tables {', '.join(gate_tables)}" if gate_tables else "",
+                (
+                    f"filing indicators {', '.join(gate_items)}"
+                    if gate_items
+                    else ""
+                ),
+            )
+            if part
+        )
+        message = (
+            "Precondition expression changes the scope of the expression: "
+            f"module versions {before} -> {after} "
+            f"(scopes {len(baseline)} -> {len(combined)})."
+        )
+        if not combined:
+            message += (
+                " The pair is not evaluable in any module version:"
+                " no module reports every operand both halves need."
+            )
+        if contributed:
+            message += f" Precondition operands: {contributed}."
+        return message
+
     def calculate_from_expression(
         self,
         expression: str,
         release_id: Optional[int] = None,
         precondition_items: Optional[List[str]] = None,
         release_code: Optional[str] = None,
+        precondition_expression: Optional[str] = None,
     ) -> ScopeResult:
-        """Calculate scopes for *expression*.
+        """Calculate scopes for *expression*, optionally gated.
 
         Parses the expression, runs OperandsChecking to extract table
         codes, then delegates to :class:`OperationScopeService`.
         ``precondition_items`` is the list of precondition variable
         codes that gate the validation; pass ``None`` or ``[]`` if
         the validation has no preconditions.
+
+        When ``precondition_expression`` is supplied, the gate's own operands
+        join the resolution by their matching channels — its table codes are
+        unioned into ``table_codes`` and its *mandatory* precondition variable
+        codes into ``precondition_items`` (unioned with any the caller passed).
+        The two are not interchangeable: only ``table_codes`` resolves through
+        ``get_from_table_codes``, and only ``precondition_items`` gets the
+        filing-indicator filter and the ``1-14`` check. Because a module hosts
+        an intra-module scope only when it supplies *every* operand, a gate
+        reaching outside the expression's own modules widens the scope to
+        cross-module, or empties it — which is the honest verdict, since the
+        pair is only evaluable where both halves resolve. That change is
+        reported in ``warning``, and a gate-attributable failure sets
+        ``error_source`` to ``"precondition"`` with a prefixed message.
+
+        The two channels treat a disjunctive gate differently, deliberately.
+        Variable codes are intersected across ``or`` branches, so an optional
+        filing indicator does not constrain scope. Table codes come from the
+        gate's ``OperandsChecking`` pass, which does not model boolean
+        structure, so every table the gate mentions is required even when only
+        one branch needs it. That errs toward reporting a wider scope rather
+        than missing a table the pair genuinely needs, and costs nothing on the
+        real dictionary, where no persisted precondition references a table.
+
+        Passing no ``precondition_expression`` costs nothing: no second scope
+        resolution, no warning, and byte-identical error messages.
+
+        Args:
+            expression: The DPM-XL expression to scope.
+            release_id: Optional release ID filter.
+            precondition_items: Filing-indicator codes gating the validation.
+            release_code: Optional release code (mutually exclusive
+                with ``release_id``).
+            precondition_expression: Optional DPM-XL gate expression.
         """
+        base_items = list(precondition_items or [])
         try:
             release_id = resolve_release_id(
                 self.session,
@@ -118,45 +300,98 @@ class ScopeCalculatorService:
                 release_code=release_code,
             )
             self._check_release_exists(release_id)
-            ast = self._syntax.parse(expression)
-            oc = OperandsChecking(
-                session=self.session,
-                expression=expression,
-                ast=ast,
-                release_id=release_id,
-            )
+            _, main_tables = self._operand_tables(expression, release_id)
+        except Exception as exc:
+            return self._failed(exc, None)
 
-            table_codes: list[str] = (
-                list(oc.tables.keys()) if oc.tables else []
-            )
+        if precondition_expression is None:
+            return self._scope_or_error(main_tables, base_items, release_id)
 
-            scope_svc = OperationScopeService(session=self.session)
-            scopes, _ = scope_svc.calculate_operation_scope(
-                tables_vids=[],
-                precondition_items=precondition_items or [],
-                release_id=release_id,
-                table_codes=table_codes,
+        try:
+            gate_ast, gate_tables = self._operand_tables(
+                precondition_expression, release_id
             )
+            self._check_tables_hosted(gate_tables, release_id)
+        except Exception as exc:
+            return self._failed(exc, "precondition")
+        gate_items = required_precondition_codes(gate_ast)
 
-            mvids: List[int] = []
-            for scope in scopes:
-                for comp in getattr(scope, "operation_scope_compositions", []):
-                    vid = comp.module_vid
-                    if vid not in mvids:
-                        mvids.append(vid)
+        table_codes = main_tables + [
+            t for t in gate_tables if t not in main_tables
+        ]
+        items = base_items + [i for i in gate_items if i not in base_items]
 
-            return ScopeResult(
-                scopes=scopes,
-                total_scopes=len(scopes),
-                is_cross_module=self._compute_cross_module(scopes),
-                module_versions=mvids,
+        # A gate that contributed no new operand cannot move the scope, so the
+        # baseline is provably identical and never computed.
+        if set(table_codes) == set(main_tables) and set(items) == set(
+            base_items
+        ):
+            return self._scope_or_error(main_tables, base_items, release_id)
+
+        try:
+            combined = self._run_scope(table_codes, items, release_id)
+        except Exception as exc:
+            # The gate is only to blame if the expression scopes cleanly
+            # without it — settled by retrying, not guessed at.
+            baseline_ok = self._resolves(main_tables, base_items, release_id)
+            return self._failed(exc, "precondition" if baseline_ok else None)
+
+        result = self._result_from_scopes(combined)
+        try:
+            baseline = self._run_scope(main_tables, base_items, release_id)
+        except Exception:
+            # The expression alone does not resolve but the pair does; treat
+            # the baseline as empty so the change is still reported.
+            baseline = []
+        if self._scope_signature(baseline) != self._scope_signature(combined):
+            result.warning = self._scope_change_warning(
+                baseline, combined, gate_tables, gate_items
             )
+        return result
 
-        except (SemanticError, Exception) as exc:
-            return ScopeResult(
-                has_error=True,
-                error_message=str(exc),
+    @staticmethod
+    def _failed(exc: Exception, source: Optional[str]) -> ScopeResult:
+        """Build a failing result, attributed to *source* when known.
+
+        ``source`` is ``None`` for a failure that is the expression's own (or
+        that no precondition was involved in), which keeps ``error_message``
+        byte-identical to what callers saw before this argument existed.
+        """
+        message = str(exc)
+        if source == "precondition":
+            message = f"Precondition: {message}"
+        return ScopeResult(
+            has_error=True,
+            error_message=message,
+            error_source="expression" if source is None else source,
+        )
+
+    def _scope_or_error(
+        self,
+        table_codes: List[str],
+        items: List[str],
+        release_id: Optional[int],
+    ) -> ScopeResult:
+        """Resolve one scope set into a result, or an unattributed failure."""
+        try:
+            return self._result_from_scopes(
+                self._run_scope(table_codes, items, release_id)
             )
+        except Exception as exc:
+            return self._failed(exc, None)
+
+    def _resolves(
+        self,
+        table_codes: List[str],
+        items: List[str],
+        release_id: Optional[int],
+    ) -> bool:
+        """True when these operands resolve without raising."""
+        try:
+            self._run_scope(table_codes, items, release_id)
+        except Exception:
+            return False
+        return True
 
     def calculate_from_tables(
         self,

--- a/src/dpmcore/services/semantic.py
+++ b/src/dpmcore/services/semantic.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any, Optional, cast
 
 from sqlalchemy import func
@@ -26,6 +26,7 @@ from dpmcore.orm.operations import (
     OperationVersion,
 )
 from dpmcore.orm.query_utils import chunked_in
+from dpmcore.services._parameters import merge_parameters
 from dpmcore.services.syntax import SyntaxService
 
 if TYPE_CHECKING:
@@ -61,7 +62,23 @@ class ParameterInfo:
 
 @dataclass(frozen=True)
 class SemanticResult:
-    """Outcome of a semantic validation."""
+    """Outcome of a semantic validation.
+
+    When a ``precondition_expression`` is supplied, ``is_valid`` is the verdict
+    for the **pair**: it is ``False`` if either the expression or its gate
+    failed, because a row whose gate does not resolve is not evaluable. The
+    gate's own independent verdict is ``precondition``; ``error_source`` says
+    which half a failure belongs to — ``"expression"``, ``"precondition"``, or
+    ``"both"`` — so attribution never needs string matching. ``error_message``
+    names *every* failure that occurred, each from the gate prefixed
+    ``"Precondition: "``, and ``warning`` merges both halves' warnings the same
+    way, so a caller reading only the outer result never misses half the story.
+    ``error_code`` holds a single value: the expression's when it failed,
+    otherwise the gate's.
+
+    ``precondition`` is ``None`` exactly when the caller supplied no gate —
+    never as a way of signalling that one failed.
+    """
 
     is_valid: bool
     error_message: Optional[str]
@@ -70,6 +87,11 @@ class SemanticResult:
     results: Optional[Any] = None
     warning: Optional[str] = None
     parameters: tuple[ParameterInfo, ...] = field(default_factory=tuple)
+    # Populated only when a precondition expression was supplied.
+    precondition: Optional["SemanticResult"] = None
+    # Which input a failure belongs to: "expression", "precondition", or
+    # "both". Set whenever ``is_valid`` is False, matching ``ScopeResult``.
+    error_source: Optional[str] = None
 
 
 def _parameters_from_oc(
@@ -187,10 +209,11 @@ class SemanticService:
     def validate(
         self,
         expression: str,
+        precondition_expression: Optional[str] = None,
         release_id: Optional[int] = None,
         release_code: Optional[str] = None,
     ) -> SemanticResult:
-        """Full semantic validation of *expression*.
+        """Full semantic validation of *expression* and its optional gate.
 
         Returns a :class:`SemanticResult` — never raises on validation
         failure.
@@ -201,34 +224,108 @@ class SemanticService:
         parameter and is scoped in SQL to co-located operations, so it adds no
         overhead to a parameter-free database.
 
+        When ``precondition_expression`` is supplied, both halves are validated
+        against the same release, resolved once, and ``is_valid`` becomes the
+        verdict for the **pair** — ``False`` if either half failed, since a row
+        whose gate does not resolve is not evaluable. ``precondition`` carries
+        the gate's own verdict and ``error_source`` names the failing half.
+        Two checks then apply that a single expression never sees:
+
+        * The gate is validated *as a gate*, so its result must be a boolean
+          (``2-1``). A numeric selection is a valid expression but not a valid
+          precondition.
+        * Parameter declarations are cross-checked across the halves
+          (``3-8``). A gate co-executes with its expression, so a parameter
+          bound across them must declare one type.
+
+        The halves are evaluated gate-first, so the per-call state this service
+        publishes (``ast``, ``oc_data``, ``oc_tables``, ``oc_parameters``)
+        describes the *main* expression when the call returns — what existing
+        consumers of this method already rely on.
+
         Args:
             expression: The DPM-XL expression to validate.
+            precondition_expression: Optional DPM-XL gate expression. When
+                ``None``, the result is exactly as before this argument
+                existed: ``precondition`` is ``None`` and ``is_valid``
+                describes ``expression`` alone.
             release_id: Optional release ID filter. When neither this nor
                 ``release_code`` is given, defaults to the latest release.
             release_code: Optional release code (mutually exclusive
                 with ``release_id``).
         """
         try:
-            release_id = resolve_release_id(
-                self.session,
-                release_id=release_id,
-                release_code=release_code,
+            resolved = self._resolve_release(release_id, release_code)
+        except SemanticError as exc:
+            code = getattr(exc, "code", None)
+            return self._resolution_failure(
+                expression, precondition_expression, exc, code
             )
-            # Default to the latest release when none is specified, matching
-            # the DPM-XL engine convention (see scopes_calculator). This keeps
-            # the co-scope parameter check release-scoped instead of spanning
-            # every release. ``None`` only survives on an empty schema.
-            if release_id is None:
-                release_id = ModuleVersionQuery.get_last_release(self.session)
-            if release_id is not None:
-                exists = (
-                    self.session.query(Release.release_id)
-                    .filter(Release.release_id == release_id)
-                    .first()
-                )
-                if exists is None:
-                    raise SemanticError("1-21", release_id=release_id)
+        except Exception as exc:
+            return self._resolution_failure(
+                expression, precondition_expression, exc, "UNKNOWN"
+            )
 
+        if precondition_expression is None:
+            return self._validate_resolved(expression, resolved)
+
+        # Gate first, main expression last: the trailing ``self.ast`` /
+        # ``self.oc_*`` must describe the main expression (see docstring).
+        precondition = self._validate_resolved(
+            precondition_expression, resolved, as_precondition=True
+        )
+        main = self._validate_resolved(expression, resolved)
+        return self._combine(main, self._cross_check(main, precondition))
+
+    # ------------------------------------------------------------------ #
+    # Internals
+    # ------------------------------------------------------------------ #
+
+    def _resolve_release(
+        self,
+        release_id: Optional[int],
+        release_code: Optional[str],
+    ) -> Optional[int]:
+        """Resolve the release once, raising on an unknown or absent one."""
+        resolved = resolve_release_id(
+            self.session,
+            release_id=release_id,
+            release_code=release_code,
+        )
+        # Default to the latest release when none is specified, matching
+        # the DPM-XL engine convention (see scopes_calculator). This keeps
+        # the co-scope parameter check release-scoped instead of spanning
+        # every release. ``None`` only survives on an empty schema.
+        if resolved is None:
+            resolved = ModuleVersionQuery.get_last_release(self.session)
+        if resolved is not None:
+            exists = (
+                self.session.query(Release.release_id)
+                .filter(Release.release_id == resolved)
+                .first()
+            )
+            if exists is None:
+                raise SemanticError("1-21", release_id=resolved)
+        return resolved
+
+    def _validate_resolved(
+        self,
+        expression: str,
+        release_id: Optional[int],
+        *,
+        as_precondition: bool = False,
+    ) -> SemanticResult:
+        """Validate *expression* against an already-resolved release.
+
+        Args:
+            expression: The DPM-XL expression to validate.
+            release_id: Release the expression is checked against.
+            as_precondition: When ``True``, the expression is treated as a
+                precondition gate, so the analyzer enforces a boolean result
+                (``2-1``) even though the expression itself contains no
+                precondition item.
+        """
+        try:
             with collect_warnings() as wc:
                 # ``parse`` is inside the collector so warnings emitted from
                 # AST construction (e.g. deprecated ``"null"`` string literal
@@ -251,7 +348,7 @@ class SemanticService:
                 analyzer.data = oc.data
                 analyzer.key_components = oc.key_components
                 analyzer.open_keys = oc.open_keys
-                analyzer.preconditions = oc.preconditions
+                analyzer.preconditions = as_precondition or oc.preconditions
 
                 results = analyzer.visit(ast)
 
@@ -273,35 +370,143 @@ class SemanticService:
             )
 
         except SemanticError as exc:
-            self.oc_data = None
-            self.oc_tables = None
-            self.oc_parameters = None
+            return self._failure(expression, exc, getattr(exc, "code", None))
+        except Exception as exc:
+            return self._failure(expression, exc, "UNKNOWN")
+
+    def _failure(
+        self,
+        expression: str,
+        exc: Exception,
+        error_code: Optional[str],
+    ) -> SemanticResult:
+        """Clear the published per-call state and build a failing result.
+
+        ``ast`` is cleared alongside ``oc_*``; leaving the previous call's AST
+        readable after a failure invited consumers to act on stale state.
+        """
+        self.ast = None
+        self.oc_data = None
+        self.oc_tables = None
+        self.oc_parameters = None
+        return SemanticResult(
+            is_valid=False,
+            error_message=str(exc),
+            error_code=error_code,
+            expression=expression,
+            error_source="expression",
+        )
+
+    def _resolution_failure(
+        self,
+        expression: str,
+        precondition_expression: Optional[str],
+        exc: Exception,
+        error_code: Optional[str],
+    ) -> SemanticResult:
+        """Report a release-resolution failure across every supplied half.
+
+        The failure belongs to neither half — no expression was even parsed —
+        so it is attributed to ``"expression"`` and mirrored onto the gate's
+        own verdict when one was supplied.
+        """
+        failure = self._failure(expression, exc, error_code)
+        if precondition_expression is None:
+            return failure
+        return replace(
+            failure,
+            error_source="expression",
+            precondition=self._failure(
+                precondition_expression, exc, error_code
+            ),
+        )
+
+    @staticmethod
+    def _cross_check(
+        main: SemanticResult, precondition: SemanticResult
+    ) -> SemanticResult:
+        """Reject a parameter declared with different types across the halves.
+
+        A gate co-executes with its expression, so a parameter bound across the
+        pair must declare one type. The clash is reported on the *precondition*
+        half — it carries the second, conflicting declaration — leaving the
+        main expression's own verdict intact.
+        """
+        if not (
+            main.is_valid
+            and precondition.is_valid
+            and main.parameters
+            and precondition.parameters
+        ):
+            return precondition
+        accumulated: dict[str, ParameterInfo] = {}
+        try:
+            merge_parameters(accumulated, main.parameters)
+            merge_parameters(accumulated, precondition.parameters)
+        except SemanticError as exc:
             return SemanticResult(
                 is_valid=False,
                 error_message=str(exc),
                 error_code=getattr(exc, "code", None),
-                expression=expression,
+                expression=precondition.expression,
+                error_source="expression",
             )
-        except Exception as exc:
-            self.oc_data = None
-            self.oc_tables = None
-            self.oc_parameters = None
-            return SemanticResult(
+        return precondition
+
+    @staticmethod
+    def _combine(
+        main: SemanticResult, precondition: SemanticResult
+    ) -> SemanticResult:
+        """Fold the gate's verdict into the pair's result.
+
+        Every summary field on the outer result describes the *pair*, so a
+        caller reading only that result never misses half the story:
+        ``is_valid`` is pair-wide, warnings from both halves are merged, and
+        every failure that occurred is named — so ``is_valid=False`` never
+        arrives without a complete explanation. The ``"Precondition: "`` prefix
+        matches ``ScopeResult``'s, so both services read the same way.
+        """
+        warning = main.warning
+        if precondition.warning:
+            gate_warning = f"Precondition: {precondition.warning}"
+            # Newline-joined, matching WarningCollector.get_combined_warning.
+            warning = f"{warning}\n{gate_warning}" if warning else gate_warning
+        combined = replace(main, warning=warning, precondition=precondition)
+        gate_message = f"Precondition: {precondition.error_message}"
+
+        if main.is_valid and precondition.is_valid:
+            return combined
+        if main.is_valid:
+            return replace(
+                combined,
                 is_valid=False,
-                error_message=str(exc),
-                error_code="UNKNOWN",
-                expression=expression,
+                error_message=gate_message,
+                error_code=precondition.error_code,
+                error_source="precondition",
             )
+        if precondition.is_valid:
+            return replace(combined, error_source="expression")
+        # Both halves failed. Naming only the expression would read as "the
+        # gate is fine", costing the caller a round trip to discover it is not,
+        # so both messages are surfaced and ``error_source`` says ``"both"``.
+        # ``error_code`` holds a single value, so it stays the expression's.
+        return replace(
+            combined,
+            error_message=f"{main.error_message}\n{gate_message}",
+            error_source="both",
+        )
 
     def is_valid(
         self,
         expression: str,
+        precondition_expression: Optional[str] = None,
         release_id: Optional[int] = None,
         release_code: Optional[str] = None,
     ) -> bool:
-        """Quick boolean check."""
+        """Quick boolean check, pair-wide when a gate is supplied."""
         return self.validate(
             expression,
+            precondition_expression=precondition_expression,
             release_id=release_id,
             release_code=release_code,
         ).is_valid

--- a/src/dpmcore/services/semantic.py
+++ b/src/dpmcore/services/semantic.py
@@ -77,7 +77,9 @@ class SemanticResult:
     otherwise the gate's.
 
     ``precondition`` is ``None`` exactly when the caller supplied no gate —
-    never as a way of signalling that one failed.
+    never as a way of signalling that one failed. On that nested result
+    ``error_source`` is ``"precondition"`` whenever it failed, since it
+    describes the gate alone.
     """
 
     is_valid: bool
@@ -185,6 +187,20 @@ def _module_vids_for(
     return frozenset(int(vid) for vid in df["ModuleVID"].tolist())
 
 
+def _as_gate_verdict(result: SemanticResult) -> SemanticResult:
+    """Stamp a gate's own verdict with the half it describes.
+
+    A standalone validation attributes its failure to ``"expression"``,
+    because that is the only half it knows about. Nested under
+    ``SemanticResult.precondition`` that reads as a claim about the *main*
+    expression, so the gate's verdict is restamped: on the nested result the
+    failing half is always the precondition.
+    """
+    if result.is_valid:
+        return result
+    return replace(result, error_source="precondition")
+
+
 class SemanticService:
     """Validate DPM-XL expressions against the data dictionary.
 
@@ -209,9 +225,10 @@ class SemanticService:
     def validate(
         self,
         expression: str,
-        precondition_expression: Optional[str] = None,
         release_id: Optional[int] = None,
         release_code: Optional[str] = None,
+        *,
+        precondition_expression: Optional[str] = None,
     ) -> SemanticResult:
         """Full semantic validation of *expression* and its optional gate.
 
@@ -245,14 +262,16 @@ class SemanticService:
 
         Args:
             expression: The DPM-XL expression to validate.
-            precondition_expression: Optional DPM-XL gate expression. When
-                ``None``, the result is exactly as before this argument
-                existed: ``precondition`` is ``None`` and ``is_valid``
-                describes ``expression`` alone.
             release_id: Optional release ID filter. When neither this nor
                 ``release_code`` is given, defaults to the latest release.
             release_code: Optional release code (mutually exclusive
                 with ``release_id``).
+            precondition_expression: Optional DPM-XL gate expression.
+                Keyword-only, and appended after the pre-existing arguments,
+                so ``validate(expr, 5)`` still means ``release_id=5``. When
+                ``None``, the result is exactly as before this argument
+                existed: ``precondition`` is ``None`` and ``is_valid``
+                describes ``expression`` alone.
         """
         try:
             resolved = self._resolve_release(release_id, release_code)
@@ -271,8 +290,10 @@ class SemanticService:
 
         # Gate first, main expression last: the trailing ``self.ast`` /
         # ``self.oc_*`` must describe the main expression (see docstring).
-        precondition = self._validate_resolved(
-            precondition_expression, resolved, as_precondition=True
+        precondition = _as_gate_verdict(
+            self._validate_resolved(
+                precondition_expression, resolved, as_precondition=True
+            )
         )
         main = self._validate_resolved(expression, resolved)
         return self._combine(main, self._cross_check(main, precondition))
@@ -416,8 +437,8 @@ class SemanticService:
         return replace(
             failure,
             error_source="expression",
-            precondition=self._failure(
-                precondition_expression, exc, error_code
+            precondition=_as_gate_verdict(
+                self._failure(precondition_expression, exc, error_code)
             ),
         )
 
@@ -449,7 +470,7 @@ class SemanticService:
                 error_message=str(exc),
                 error_code=getattr(exc, "code", None),
                 expression=precondition.expression,
-                error_source="expression",
+                error_source="precondition",
             )
         return precondition
 
@@ -499,9 +520,10 @@ class SemanticService:
     def is_valid(
         self,
         expression: str,
-        precondition_expression: Optional[str] = None,
         release_id: Optional[int] = None,
         release_code: Optional[str] = None,
+        *,
+        precondition_expression: Optional[str] = None,
     ) -> bool:
         """Quick boolean check, pair-wide when a gate is supplied."""
         return self.validate(

--- a/tests/integration/api/test_scope_endpoint.py
+++ b/tests/integration/api/test_scope_endpoint.py
@@ -27,7 +27,13 @@ def fixture_client(fixture_db_url):
     engine.dispose()
 
 
-def _scope_result(is_cross=False, has_error=False, module_versions=None):
+def _scope_result(
+    is_cross=False,
+    has_error=False,
+    module_versions=None,
+    warning=None,
+    error_source=None,
+):
     return SimpleNamespace(
         scopes=[],
         total_scopes=2,
@@ -37,6 +43,8 @@ def _scope_result(is_cross=False, has_error=False, module_versions=None):
         else [1, 2],
         has_error=has_error,
         error_message="boom" if has_error else None,
+        warning=warning,
+        error_source=error_source,
     )
 
 
@@ -82,6 +90,64 @@ class TestPostScope:
         assert kwargs["release_id"] == 5
         assert kwargs["precondition_items"] == ["item1", "item2"]
         assert kwargs["release_code"] is None
+        assert kwargs["precondition_expression"] is None
+
+    def test_passes_precondition_expression(self, client):
+        """The full DPM-XL gate is forwarded verbatim (issue #279)."""
+        with patch(
+            "dpmcore.services.scope_calculator.ScopeCalculatorService"
+        ) as Svc:
+            Svc.return_value.calculate_from_expression.return_value = (
+                _scope_result()
+            )
+            client.post(
+                "/api/v1/scope",
+                json={
+                    "expression": "{tC_01.00, r0010, c0010} = 0",
+                    "precondition_expression": "{v_C_01.00}",
+                },
+            )
+
+        kwargs = Svc.return_value.calculate_from_expression.call_args.kwargs
+        assert kwargs["precondition_expression"] == "{v_C_01.00}"
+
+    def test_returns_warning_and_error_source(self, client):
+        with patch(
+            "dpmcore.services.scope_calculator.ScopeCalculatorService"
+        ) as Svc:
+            Svc.return_value.calculate_from_expression.return_value = (
+                _scope_result(warning="scope changed", error_source=None)
+            )
+            response = client.post(
+                "/api/v1/scope",
+                json={
+                    "expression": "{tC_01.00, r0010, c0010} = 0",
+                    "precondition_expression": "{v_C_01.00}",
+                },
+            )
+
+        body = response.json()
+        assert body["warning"] == "scope changed"
+        assert body["error_source"] is None
+
+    def test_returns_error_source_on_a_gate_failure(self, client):
+        with patch(
+            "dpmcore.services.scope_calculator.ScopeCalculatorService"
+        ) as Svc:
+            Svc.return_value.calculate_from_expression.return_value = (
+                _scope_result(has_error=True, error_source="precondition")
+            )
+            response = client.post(
+                "/api/v1/scope",
+                json={
+                    "expression": "{tC_01.00, r0010, c0010} = 0",
+                    "precondition_expression": "{v_NOPE}",
+                },
+            )
+
+        body = response.json()
+        assert body["has_error"] is True
+        assert body["error_source"] == "precondition"
 
     def test_passes_release_code(self, client):
         """release_code is forwarded to the service like /validate/semantic."""
@@ -179,6 +245,7 @@ class TestPostScope:
             "release_id",
             "release_code",
             "precondition_items",
+            "precondition_expression",
         }
         response_schema = spec["components"]["schemas"]["ScopeResponse"][
             "properties"
@@ -189,6 +256,8 @@ class TestPostScope:
             "module_versions",
             "has_error",
             "error_message",
+            "warning",
+            "error_source",
         } == set(response_schema.keys())
 
 

--- a/tests/integration/api/test_validate_semantic_endpoint.py
+++ b/tests/integration/api/test_validate_semantic_endpoint.py
@@ -1,0 +1,210 @@
+"""Tests for ``POST /api/v1/validate/semantic`` (issue #279).
+
+The endpoint gained ``precondition_expression`` in the request and
+``error_source`` in the response, so the paired validation the service layer
+supports is reachable over REST too.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+
+from dpmcore.server.app import create_app
+
+
+@pytest.fixture
+def client(memory_engine):
+    app = create_app("sqlite:///:memory:", engine=memory_engine)
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture
+def fixture_client(fixture_db_url):
+    """Client backed by the real fixture database for end-to-end tests."""
+    engine = create_engine(fixture_db_url)
+    app = create_app(fixture_db_url, engine=engine)
+    with TestClient(app) as c:
+        yield c
+    engine.dispose()
+
+
+def _result(
+    is_valid=True,
+    error_message=None,
+    error_code=None,
+    expression="{tC_01.00, r0010, c0010} = 0",
+    warning=None,
+    error_source=None,
+):
+    return {
+        "is_valid": is_valid,
+        "error_message": error_message,
+        "error_code": error_code,
+        "expression": expression,
+        "warning": warning,
+        "error_source": error_source,
+    }
+
+
+class TestPostValidateSemantic:
+    def test_ungated_request_forwards_no_gate(self, client):
+        with patch("dpmcore.services.dpm_xl.DpmXlService") as Svc:
+            Svc.return_value.validate_semantic.return_value = _result()
+            response = client.post(
+                "/api/v1/validate/semantic",
+                json={"expression": "{tC_01.00, r0010, c0010} = 0"},
+            )
+
+        assert response.status_code == 200
+        assert response.json()["is_valid"] is True
+        kwargs = Svc.return_value.validate_semantic.call_args.kwargs
+        assert kwargs["precondition_expression"] is None
+        assert response.json()["error_source"] is None
+
+    def test_gate_is_forwarded_verbatim(self, client):
+        with patch("dpmcore.services.dpm_xl.DpmXlService") as Svc:
+            Svc.return_value.validate_semantic.return_value = _result()
+            client.post(
+                "/api/v1/validate/semantic",
+                json={
+                    "expression": "{tC_01.00, r0010, c0010} = 0",
+                    "precondition_expression": "{v_C_01.00}",
+                    "release_code": "4.2.1",
+                },
+            )
+
+        call = Svc.return_value.validate_semantic.call_args
+        assert call.args == ("{tC_01.00, r0010, c0010} = 0",)
+        assert call.kwargs["precondition_expression"] == "{v_C_01.00}"
+        assert call.kwargs["release_code"] == "4.2.1"
+        assert call.kwargs["release_id"] is None
+
+    def test_gate_failure_is_attributed_in_the_response(self, client):
+        with patch("dpmcore.services.dpm_xl.DpmXlService") as Svc:
+            Svc.return_value.validate_semantic.return_value = _result(
+                is_valid=False,
+                error_message="Precondition: boom",
+                error_code="2-1",
+                error_source="precondition",
+            )
+            response = client.post(
+                "/api/v1/validate/semantic",
+                json={
+                    "expression": "{tC_01.00, r0010, c0010} = 0",
+                    "precondition_expression": "{tC_01.00, r0010, c0010}",
+                },
+            )
+
+        body = response.json()
+        assert body["is_valid"] is False
+        assert body["error_source"] == "precondition"
+        assert body["error_message"] == "Precondition: boom"
+        assert body["error_code"] == "2-1"
+
+    def test_merged_warning_is_returned(self, client):
+        with patch("dpmcore.services.dpm_xl.DpmXlService") as Svc:
+            Svc.return_value.validate_semantic.return_value = _result(
+                warning="main is odd\nPrecondition: gate is odd"
+            )
+            response = client.post(
+                "/api/v1/validate/semantic",
+                json={
+                    "expression": "{tC_01.00, r0010, c0010} = 0",
+                    "precondition_expression": "{v_C_01.00}",
+                },
+            )
+
+        assert response.json()["warning"] == (
+            "main is odd\nPrecondition: gate is odd"
+        )
+
+    def test_missing_expression_returns_422(self, client):
+        response = client.post("/api/v1/validate/semantic", json={})
+        assert response.status_code == 422
+
+    def test_openapi_exposes_the_new_fields(self, client):
+        spec = client.get("/api/v1/openapi.json").json()
+        request_schema = spec["components"]["schemas"]["SemanticRequest"][
+            "properties"
+        ]
+        assert set(request_schema) == {
+            "expression",
+            "release_id",
+            "release_code",
+            "precondition_expression",
+        }
+        response_schema = spec["components"]["schemas"]["SemanticResponse"][
+            "properties"
+        ]
+        assert set(response_schema) == {
+            "is_valid",
+            "error_message",
+            "error_code",
+            "expression",
+            "warning",
+            "error_source",
+        }
+
+    def test_syntax_endpoint_does_not_advertise_a_gate(self, client):
+        """``/validate/syntax`` has no notion of a precondition."""
+        spec = client.get("/api/v1/openapi.json").json()
+        request_schema = spec["components"]["schemas"]["ExpressionRequest"][
+            "properties"
+        ]
+        assert "precondition_expression" not in request_schema
+
+
+# ------------------------------------------------------------------ #
+# Real-engine tests against the fixture database; they auto-skip when
+# tests/fixtures/test_data.db is not present.
+# ------------------------------------------------------------------ #
+
+_MAIN = "{tF_01.02, r0010, c0010} >= 0"
+_RELEASE = "4.2.1"
+
+
+class TestPostValidateSemanticRealEngine:
+    def test_valid_pair_passes_end_to_end(self, fixture_client):
+        response = fixture_client.post(
+            "/api/v1/validate/semantic",
+            json={
+                "expression": _MAIN,
+                "precondition_expression": "{tC_01.00, r0010, c0010} > 0",
+                "release_code": _RELEASE,
+            },
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["is_valid"] is True, body["error_message"]
+        assert body["error_source"] is None
+
+    def test_non_boolean_gate_fails_the_pair_with_2_1(self, fixture_client):
+        """The same string is valid alone, but not *as a gate*."""
+        payload = {"expression": _MAIN, "release_code": _RELEASE}
+        assert fixture_client.post(
+            "/api/v1/validate/semantic",
+            json={**payload, "expression": "{tC_01.00, r0010, c0010}"},
+        ).json()["is_valid"]
+
+        body = fixture_client.post(
+            "/api/v1/validate/semantic",
+            json={
+                **payload,
+                "precondition_expression": "{tC_01.00, r0010, c0010}",
+            },
+        ).json()
+        assert body["is_valid"] is False
+        assert body["error_source"] == "precondition"
+        assert body["error_code"] == "2-1"
+        assert body["error_message"].startswith("Precondition: ")
+
+    def test_ungated_call_is_byte_identical_to_before(self, fixture_client):
+        body = fixture_client.post(
+            "/api/v1/validate/semantic",
+            json={"expression": _MAIN, "release_code": _RELEASE},
+        ).json()
+        assert body["is_valid"] is True
+        assert body["error_source"] is None

--- a/tests/integration/services/test_precondition_expression.py
+++ b/tests/integration/services/test_precondition_expression.py
@@ -150,7 +150,9 @@ class TestErrorAttribution:
 
 class TestValidateWithPrecondition:
     def test_both_halves_valid(self, semantic):
-        result = semantic.validate(MAIN, CROSS_GATE, release_code=RELEASE)
+        result = semantic.validate(
+            MAIN, release_code=RELEASE, precondition_expression=CROSS_GATE
+        )
         assert result.is_valid
         assert result.precondition.is_valid
         assert result.error_source is None
@@ -161,7 +163,11 @@ class TestValidateWithPrecondition:
         assert result.precondition is None
 
     def test_filing_indicator_gate_is_valid(self, semantic):
-        result = semantic.validate(MAIN, CROSS_FI_GATE, release_code=RELEASE)
+        result = semantic.validate(
+            MAIN,
+            release_code=RELEASE,
+            precondition_expression=CROSS_FI_GATE,
+        )
         assert result.is_valid
 
     def test_non_boolean_gate_fails_the_pair_with_2_1(self, semantic):
@@ -170,7 +176,9 @@ class TestValidateWithPrecondition:
         numeric = "{tC_01.00, r0010, c0010}"
         assert semantic.validate(numeric, release_code=RELEASE).is_valid
 
-        result = semantic.validate(MAIN, numeric, release_code=RELEASE)
+        result = semantic.validate(
+            MAIN, release_code=RELEASE, precondition_expression=numeric
+        )
         assert not result.is_valid
         assert result.error_source == "precondition"
         assert result.error_code == "2-1"
@@ -179,7 +187,9 @@ class TestValidateWithPrecondition:
 
     def test_broken_gate_invalidates_the_pair(self, semantic):
         result = semantic.validate(
-            MAIN, "{tNOPE, r0010, c0010} > 0", release_code=RELEASE
+            MAIN,
+            release_code=RELEASE,
+            precondition_expression="{tNOPE, r0010, c0010} > 0",
         )
         assert not result.is_valid
         assert result.error_source == "precondition"
@@ -187,7 +197,9 @@ class TestValidateWithPrecondition:
 
     def test_broken_expression_is_attributed_to_the_expression(self, semantic):
         result = semantic.validate(
-            "{tNOPE, r0010, c0010} >= 0", CROSS_GATE, release_code=RELEASE
+            "{tNOPE, r0010, c0010} >= 0",
+            release_code=RELEASE,
+            precondition_expression=CROSS_GATE,
         )
         assert not result.is_valid
         assert result.error_source == "expression"
@@ -197,8 +209,8 @@ class TestValidateWithPrecondition:
     def test_both_halves_broken_names_both(self, semantic):
         result = semantic.validate(
             "{tNOPE, r0010, c0010} >= 0",
-            "{v_ALSONOPE}",
             release_code=RELEASE,
+            precondition_expression="{v_ALSONOPE}",
         )
         assert not result.is_valid
         assert result.error_source == "both"
@@ -213,14 +225,18 @@ class TestValidateWithPrecondition:
     def test_published_state_describes_the_main_expression(self, semantic):
         # The gate selects C_01.00; the main expression selects F_01.02. After
         # the call, the state consumers read must be the main expression's.
-        semantic.validate(MAIN, CROSS_GATE, release_code=RELEASE)
+        semantic.validate(
+            MAIN, release_code=RELEASE, precondition_expression=CROSS_GATE
+        )
         assert list(semantic.oc_tables) == ["F_01.02"]
 
     def test_cross_half_parameter_conflict_fails_the_pair(self, semantic):
         result = semantic.validate(
             "{tF_01.02, r0010, c0010} >= {p_thr, number}",
-            "{tC_01.00, r0010, c0010} > {p_thr, integer}",
             release_code=RELEASE,
+            precondition_expression=(
+                "{tC_01.00, r0010, c0010} > {p_thr, integer}"
+            ),
         )
         assert not result.is_valid
         assert result.error_source == "precondition"
@@ -229,18 +245,26 @@ class TestValidateWithPrecondition:
     def test_cross_half_parameter_agreement_passes(self, semantic):
         result = semantic.validate(
             "{tF_01.02, r0010, c0010} >= {p_thr, number}",
-            "{tC_01.00, r0010, c0010} > {p_thr, number}",
             release_code=RELEASE,
+            precondition_expression=(
+                "{tC_01.00, r0010, c0010} > {p_thr, number}"
+            ),
         )
         assert result.is_valid
 
     def test_unknown_release_code_is_mirrored_onto_the_gate(self, semantic):
-        result = semantic.validate(MAIN, CROSS_GATE, release_code="9.9.9")
+        result = semantic.validate(
+            MAIN, release_code="9.9.9", precondition_expression=CROSS_GATE
+        )
         assert not result.is_valid
         assert result.error_message == result.precondition.error_message
 
     def test_is_valid_shortcut_is_pair_wide(self, semantic):
-        assert semantic.is_valid(MAIN, CROSS_GATE, release_code=RELEASE)
+        assert semantic.is_valid(
+            MAIN, release_code=RELEASE, precondition_expression=CROSS_GATE
+        )
         assert not semantic.is_valid(
-            MAIN, "{tC_01.00, r0010, c0010}", release_code=RELEASE
+            MAIN,
+            release_code=RELEASE,
+            precondition_expression="{tC_01.00, r0010, c0010}",
         )

--- a/tests/integration/services/test_precondition_expression.py
+++ b/tests/integration/services/test_precondition_expression.py
@@ -1,0 +1,246 @@
+"""Paired expression + precondition analysis against the real dictionary (#279).
+
+Every module-version number below is measured against the shipped DPM 4.2.1
+fixture, not hand-built: at release ``4.2.1``, ``F_01.02`` is hosted by FINREP9
+(462) and FINREP9DP (513), and ``C_01.00`` by COREP_OF (499). Pairing a FINREP
+expression with a COREP gate is therefore a real cross-framework case, which is
+what makes the scope-change warning exercisable.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dpmcore.services.scope_calculator import ScopeCalculatorService
+from dpmcore.services.semantic import SemanticService
+
+RELEASE = "4.2.1"
+
+# Main expression: FINREP, hosted by two module versions.
+MAIN = "{tF_01.02, r0010, c0010} >= 0"
+# Gate on the same table — contributes an operand already present.
+SAME_TABLE_GATE = "{tF_01.02, r0010, c0010} > 0"
+# Gate on a COREP table — no module hosts both, so the scope widens.
+CROSS_GATE = "{tC_01.00, r0010, c0010} > 0"
+# Filing-indicator gate reported by COREP only.
+CROSS_FI_GATE = "{v_C_01.00}"
+# Filing-indicator gate reported by the expression's own modules.
+OWN_FI_GATE = "{v_F_01.02}"
+
+MAIN_MODULES = [462, 513]
+CROSS_MODULES = [462, 499, 513]
+
+
+@pytest.fixture
+def scopes(fixture_session):
+    return ScopeCalculatorService(fixture_session)
+
+
+@pytest.fixture
+def semantic(fixture_session):
+    return SemanticService(fixture_session)
+
+
+def _scope(svc, gate=None, **kwargs):
+    return svc.calculate_from_expression(
+        MAIN, release_code=RELEASE, precondition_expression=gate, **kwargs
+    )
+
+
+class TestBaselineIsUnchanged:
+    def test_no_gate_matches_the_pre_change_result(self, scopes):
+        result = _scope(scopes)
+        assert not result.has_error
+        assert result.total_scopes == 2
+        assert not result.is_cross_module
+        assert sorted(result.module_versions) == MAIN_MODULES
+        assert result.warning is None
+        assert result.error_source is None
+
+    def test_gate_adding_no_operand_changes_nothing(self, scopes):
+        gated = _scope(scopes, SAME_TABLE_GATE)
+        assert not gated.has_error
+        assert gated.warning is None
+        assert sorted(gated.module_versions) == MAIN_MODULES
+        assert gated.total_scopes == 2
+
+    def test_own_module_filing_indicator_gate_changes_nothing(self, scopes):
+        gated = _scope(scopes, OWN_FI_GATE)
+        assert not gated.has_error
+        assert gated.warning is None
+        assert sorted(gated.module_versions) == MAIN_MODULES
+
+
+class TestScopeChangeWarning:
+    def test_cross_framework_table_gate_widens_the_scope(self, scopes):
+        gated = _scope(scopes, CROSS_GATE)
+        assert not gated.has_error
+        assert gated.is_cross_module
+        assert sorted(gated.module_versions) == CROSS_MODULES
+        assert gated.warning is not None
+        assert "[462, 513] -> [462, 499, 513]" in gated.warning
+        assert "tables C_01.00" in gated.warning
+
+    def test_cross_framework_filing_indicator_gate_empties_the_scope(
+        self, scopes
+    ):
+        # No module version hosts F_01.02 and reports the COREP filing
+        # indicator, so the pair cannot be evaluated anywhere. That is not an
+        # error, but it must not be silent either.
+        gated = _scope(scopes, CROSS_FI_GATE)
+        assert not gated.has_error
+        assert gated.total_scopes == 0
+        assert gated.module_versions == []
+        assert gated.warning is not None
+        assert "not evaluable in any module version" in gated.warning
+        assert "filing indicators C_01.00" in gated.warning
+
+
+class TestDisjunctiveGate:
+    def test_disjunction_does_not_constrain_the_scope(self, scopes):
+        # A flat union of these three filing indicators resolves to 1-14 on the
+        # real dictionary; only the mandatory (intersected) set is passed on,
+        # which for a pure disjunction is empty.
+        gate = "{v_C_06.02} or {v_C_105.01} or {v_C_27.00}"
+        gated = _scope(scopes, gate)
+        assert not gated.has_error
+        assert sorted(gated.module_versions) == MAIN_MODULES
+        assert gated.warning is None
+
+    def test_conjunct_inside_a_disjunction_still_constrains(self, scopes):
+        # ``A and (B or C)`` requires A, so the COREP indicator still applies
+        # and still empties the scope.
+        gate = "{v_C_01.00} and ({v_C_06.02} or {v_C_105.01})"
+        gated = _scope(scopes, gate)
+        assert gated.total_scopes == 0
+        assert gated.warning is not None
+
+
+class TestErrorAttribution:
+    def test_unknown_gate_table_is_attributed_and_prefixed(self, scopes):
+        gated = _scope(scopes, "{tNOPE, r0010, c0010} > 0")
+        assert gated.has_error
+        assert gated.error_source == "precondition"
+        assert gated.error_message.startswith("Precondition: ")
+
+    def test_unknown_gate_variable_is_attributed(self, scopes):
+        gated = _scope(scopes, "{v_NOPE}")
+        assert gated.has_error
+        assert gated.error_source == "precondition"
+        assert gated.error_message.startswith("Precondition: ")
+
+    def test_broken_expression_is_attributed_to_the_expression(self, scopes):
+        result = scopes.calculate_from_expression(
+            "{tNOPE, r0010, c0010} >= 0",
+            release_code=RELEASE,
+            precondition_expression=SAME_TABLE_GATE,
+        )
+        assert result.has_error
+        assert result.error_source == "expression"
+        assert not result.error_message.startswith("Precondition: ")
+
+    def test_message_is_unprefixed_when_no_gate_is_supplied(self, scopes):
+        result = scopes.calculate_from_expression(
+            "{tNOPE, r0010, c0010} >= 0", release_code=RELEASE
+        )
+        assert result.has_error
+        assert not result.error_message.startswith("Precondition: ")
+        assert result.warning is None
+
+
+class TestValidateWithPrecondition:
+    def test_both_halves_valid(self, semantic):
+        result = semantic.validate(MAIN, CROSS_GATE, release_code=RELEASE)
+        assert result.is_valid
+        assert result.precondition.is_valid
+        assert result.error_source is None
+
+    def test_no_gate_leaves_the_field_none(self, semantic):
+        result = semantic.validate(MAIN, release_code=RELEASE)
+        assert result.is_valid
+        assert result.precondition is None
+
+    def test_filing_indicator_gate_is_valid(self, semantic):
+        result = semantic.validate(MAIN, CROSS_FI_GATE, release_code=RELEASE)
+        assert result.is_valid
+
+    def test_non_boolean_gate_fails_the_pair_with_2_1(self, semantic):
+        # The same string is a perfectly valid main expression; it is only
+        # invalid *as a gate*, because a gate must evaluate to a boolean.
+        numeric = "{tC_01.00, r0010, c0010}"
+        assert semantic.validate(numeric, release_code=RELEASE).is_valid
+
+        result = semantic.validate(MAIN, numeric, release_code=RELEASE)
+        assert not result.is_valid
+        assert result.error_source == "precondition"
+        assert result.error_code == "2-1"
+        assert result.error_message.startswith("Precondition: ")
+        assert result.precondition.error_code == "2-1"
+
+    def test_broken_gate_invalidates_the_pair(self, semantic):
+        result = semantic.validate(
+            MAIN, "{tNOPE, r0010, c0010} > 0", release_code=RELEASE
+        )
+        assert not result.is_valid
+        assert result.error_source == "precondition"
+        assert not result.precondition.is_valid
+
+    def test_broken_expression_is_attributed_to_the_expression(self, semantic):
+        result = semantic.validate(
+            "{tNOPE, r0010, c0010} >= 0", CROSS_GATE, release_code=RELEASE
+        )
+        assert not result.is_valid
+        assert result.error_source == "expression"
+        assert not result.error_message.startswith("Precondition: ")
+        assert result.precondition.is_valid
+
+    def test_both_halves_broken_names_both(self, semantic):
+        result = semantic.validate(
+            "{tNOPE, r0010, c0010} >= 0",
+            "{v_ALSONOPE}",
+            release_code=RELEASE,
+        )
+        assert not result.is_valid
+        assert result.error_source == "both"
+        # The expression's own failure and the gate's are both named, so the
+        # caller does not fix one and then discover the other.
+        assert "NOPE, r0010, c0010" in result.error_message
+        assert "Precondition: " in result.error_message
+        assert "ALSONOPE" in result.error_message
+        assert result.error_code == "1-2"
+        assert result.precondition.error_code == "1-3"
+
+    def test_published_state_describes_the_main_expression(self, semantic):
+        # The gate selects C_01.00; the main expression selects F_01.02. After
+        # the call, the state consumers read must be the main expression's.
+        semantic.validate(MAIN, CROSS_GATE, release_code=RELEASE)
+        assert list(semantic.oc_tables) == ["F_01.02"]
+
+    def test_cross_half_parameter_conflict_fails_the_pair(self, semantic):
+        result = semantic.validate(
+            "{tF_01.02, r0010, c0010} >= {p_thr, number}",
+            "{tC_01.00, r0010, c0010} > {p_thr, integer}",
+            release_code=RELEASE,
+        )
+        assert not result.is_valid
+        assert result.error_source == "precondition"
+        assert result.error_code == "3-8"
+
+    def test_cross_half_parameter_agreement_passes(self, semantic):
+        result = semantic.validate(
+            "{tF_01.02, r0010, c0010} >= {p_thr, number}",
+            "{tC_01.00, r0010, c0010} > {p_thr, number}",
+            release_code=RELEASE,
+        )
+        assert result.is_valid
+
+    def test_unknown_release_code_is_mirrored_onto_the_gate(self, semantic):
+        result = semantic.validate(MAIN, CROSS_GATE, release_code="9.9.9")
+        assert not result.is_valid
+        assert result.error_message == result.precondition.error_message
+
+    def test_is_valid_shortcut_is_pair_wide(self, semantic):
+        assert semantic.is_valid(MAIN, CROSS_GATE, release_code=RELEASE)
+        assert not semantic.is_valid(
+            MAIN, "{tC_01.00, r0010, c0010}", release_code=RELEASE
+        )

--- a/tests/unit/dpm_xl/test_precondition_codes.py
+++ b/tests/unit/dpm_xl/test_precondition_codes.py
@@ -1,0 +1,110 @@
+"""Tests for the shared precondition-code extractors (issue #279).
+
+``required_precondition_codes`` is the one scope calculation may use: it counts
+each returned code as an operand a module must supply, so a disjunctive gate
+has to return the *intersection* of its branches. Flattening instead is not a
+theoretical problem — of the 965 precondition expressions persisted in the EBA
+dictionary, 62 use ``or``, and the widest flattens to 20 filing indicators
+spanning frameworks, which no module reports together.
+"""
+
+import pytest
+
+from dpmcore.services._precondition_codes import (
+    extract_precondition_codes,
+    required_precondition_codes,
+)
+from dpmcore.services.syntax import SyntaxService
+
+
+def _ast(expression):
+    return SyntaxService().parse(expression)
+
+
+class TestExtractPreconditionCodes:
+    """Every variable code the gate mentions, first-seen order."""
+
+    @pytest.mark.parametrize(
+        ("expression", "expected"),
+        [
+            ("{v_C_01.00}", ["C_01.00"]),
+            ("{v_C_09.01} and {v_C_07.00}", ["C_09.01", "C_07.00"]),
+            ("{v_B} or {v_A}", ["B", "A"]),
+            ("not {v_C_01.00}", ["C_01.00"]),
+            # A cell selection is a table reference, not a variable one.
+            ("{tC_01.00, r0010, c0010} > 0", []),
+            # Mixed: only the variable half is collected here.
+            ("{v_C_01.00} and {tC_01.00, r0010, c0010} > 0", ["C_01.00"]),
+        ],
+    )
+    def test_collects_variable_codes(self, expression, expected):
+        assert extract_precondition_codes(_ast(expression)) == expected
+
+    def test_dedupes_preserving_first_seen_order(self):
+        ast = _ast("{v_B} and {v_A} and {v_B}")
+        assert extract_precondition_codes(ast) == ["B", "A"]
+
+    def test_unwalkable_input_returns_empty(self):
+        # Logged and swallowed: a malformed AST must not abort the caller.
+        assert extract_precondition_codes(object()) == []
+
+
+class TestRequiredPreconditionCodes:
+    """Only the codes a module *must* provide to evaluate the gate."""
+
+    @pytest.mark.parametrize(
+        ("expression", "expected"),
+        [
+            # A bare reference is mandatory.
+            ("{v_C_01.00}", ["C_01.00"]),
+            # ``and`` unions its branches' requirements.
+            ("{v_C_09.01} and {v_C_07.00}", ["C_09.01", "C_07.00"]),
+            # ``or`` intersects: neither branch is individually required.
+            ("{v_A} or {v_B}", []),
+            ("{v_A} xor {v_B}", []),
+            # Nested: only the conjunct survives the disjunction.
+            ("{v_F_31.01} and ({v_F_09.01} or {v_F_09.01.1})", ["F_31.01"]),
+            # A wide disjunction requires nothing — the case that would
+            # otherwise resolve to 1-14 on the real dictionary.
+            ("{v_C_06.02} or {v_C_105.01} or {v_C_27.00}", []),
+            # ``not`` requires nothing: the gate holds when the code does not.
+            ("not {v_C_01.00}", []),
+            # A comparison is opaque, so its operands stay required.
+            ("{v_C_01.00} and {tC_01.00, r0010, c0010} > 0", ["C_01.00"]),
+        ],
+    )
+    def test_mandatory_set(self, expression, expected):
+        assert required_precondition_codes(_ast(expression)) == expected
+
+    def test_repeated_disjunct_is_still_optional(self):
+        # ``{v_A} or {v_A}`` intersects to {A}: every branch needs it.
+        assert required_precondition_codes(_ast("{v_A} or {v_A}")) == ["A"]
+
+    def test_never_exceeds_the_flat_set(self):
+        expression = "{v_F_31.01} and ({v_F_09.01} or {v_F_09.01.1})"
+        ast = _ast(expression)
+        flat = extract_precondition_codes(ast)
+        assert set(required_precondition_codes(ast)) <= set(flat)
+
+    def test_unwalkable_input_returns_empty(self):
+        assert required_precondition_codes(object()) == []
+
+
+class TestIssueExampleIsNotValidDpmXl:
+    """Pin the malformed gate quoted in issue #279.
+
+    ``{v_C_07.00, r0010, c0010} > 0`` cannot parse: ``varRef`` takes no
+    arguments. The real forms are ``{v_C_07.00}`` (filing indicator) or
+    ``{tC_07.00, r0010, c0010} > 0`` (data cell).
+    """
+
+    def test_issue_example_does_not_parse(self):
+        result = SyntaxService().validate("{v_C_07.00, r0010, c0010} > 0")
+        assert not result.is_valid
+
+    @pytest.mark.parametrize(
+        "expression",
+        ["{v_C_07.00}", "{tC_07.00, r0010, c0010} > 0"],
+    )
+    def test_intended_forms_do_parse(self, expression):
+        assert SyntaxService().validate(expression).is_valid

--- a/tests/unit/dpm_xl/test_precondition_codes.py
+++ b/tests/unit/dpm_xl/test_precondition_codes.py
@@ -69,11 +69,32 @@ class TestRequiredPreconditionCodes:
             ("{v_C_06.02} or {v_C_105.01} or {v_C_27.00}", []),
             # ``not`` requires nothing: the gate holds when the code does not.
             ("not {v_C_01.00}", []),
+            ("not ({v_A} or {v_B})", []),
             # A comparison is opaque, so its operands stay required.
             ("{v_C_01.00} and {tC_01.00, r0010, c0010} > 0", ["C_01.00"]),
         ],
     )
     def test_mandatory_set(self, expression, expected):
+        assert required_precondition_codes(_ast(expression)) == expected
+
+    @pytest.mark.parametrize(
+        ("expression", "expected"),
+        [
+            ("not {v_A} and {v_B}", ["B"]),
+            ("{v_A} and not {v_B}", ["A"]),
+        ],
+    )
+    def test_a_negated_conjunct_drops_out_of_the_union(
+        self, expression, expected
+    ):
+        """A negated code is dropped even inside a conjunction.
+
+        The set is "codes that must be **true**", not "codes the engine has
+        to read" — the same criterion that makes ``{v_A} or {v_B}`` require
+        neither. Each returned code is counted as an operand the module must
+        supply, so requiring the operand of a ``not`` would exclude exactly
+        the modules a "template not filed" gate is written for.
+        """
         assert required_precondition_codes(_ast(expression)) == expected
 
     def test_repeated_disjunct_is_still_optional(self):

--- a/tests/unit/services/test_scope_calculator.py
+++ b/tests/unit/services/test_scope_calculator.py
@@ -159,6 +159,275 @@ class TestCalculateFromExpression:
 
 
 # ------------------------------------------------------------------ #
+# precondition_expression (issue #279)
+# ------------------------------------------------------------------ #
+
+
+def _paired_svc(main_tables, gate_tables, gate_codes, scope_results):
+    """Build a service whose two OperandsChecking passes differ.
+
+    ``scope_results`` is consumed one entry per ``calculate_operation_scope``
+    call, so a test can make the combined and baseline runs disagree.
+    """
+    Svc, _ = _load_module()
+    mod = sys.modules["dpmcore.services.scope_calculator"]
+
+    def _oc(tables):
+        oc = MagicMock()
+        oc.tables = dict.fromkeys(tables, MagicMock())
+        oc.preconditions = False
+        return oc
+
+    mod.OperandsChecking.side_effect = [_oc(main_tables), _oc(gate_tables)]
+
+    scope_svc = MagicMock()
+    scope_svc.calculate_operation_scope.side_effect = [
+        (scopes, []) for scopes in scope_results
+    ]
+    mod.OperationScopeService.return_value = scope_svc
+    mod.OperationScopeService.reset_mock()
+
+    svc = Svc(MagicMock())
+    svc._syntax = MagicMock()
+    svc._syntax.parse.return_value = MagicMock()
+    svc._check_release_exists = MagicMock()
+    svc._check_tables_hosted = MagicMock()
+    mod.required_precondition_codes = MagicMock(return_value=gate_codes)
+    return svc, scope_svc, mod
+
+
+class TestPreconditionExpression:
+    """The gate's operands join the resolution by their matching channels."""
+
+    def test_gate_tables_union_into_table_codes(self):
+        svc, scope_svc, _ = _paired_svc(
+            main_tables=["T_A"],
+            gate_tables=["T_B"],
+            gate_codes=[],
+            scope_results=[[_scope([2])], [_scope([1])]],
+        )
+        svc.calculate_from_expression(
+            expression="main", precondition_expression="gate"
+        )
+        combined = scope_svc.calculate_operation_scope.call_args_list[0]
+        assert combined.kwargs["table_codes"] == ["T_A", "T_B"]
+        # The baseline run sees the main expression's operands only.
+        baseline = scope_svc.calculate_operation_scope.call_args_list[1]
+        assert baseline.kwargs["table_codes"] == ["T_A"]
+
+    def test_gate_codes_union_into_precondition_items(self):
+        svc, scope_svc, _ = _paired_svc(
+            main_tables=["T_A"],
+            gate_tables=[],
+            gate_codes=["FI_2"],
+            scope_results=[[_scope([2])], [_scope([1])]],
+        )
+        svc.calculate_from_expression(
+            expression="main",
+            precondition_items=["FI_1"],
+            precondition_expression="gate",
+        )
+        combined = scope_svc.calculate_operation_scope.call_args_list[0]
+        assert combined.kwargs["precondition_items"] == ["FI_1", "FI_2"]
+        assert combined.kwargs["table_codes"] == ["T_A"]
+
+    def test_gate_operands_are_deduped_against_the_main_expression(self):
+        svc, scope_svc, _ = _paired_svc(
+            main_tables=["T_A"],
+            gate_tables=["T_A"],
+            gate_codes=["FI_1"],
+            scope_results=[[_scope([1])]],
+        )
+        result = svc.calculate_from_expression(
+            expression="main",
+            precondition_items=["FI_1"],
+            precondition_expression="gate",
+        )
+        # Nothing new: one call only, and no baseline to compare against.
+        assert scope_svc.calculate_operation_scope.call_count == 1
+        assert result.warning is None
+
+    def test_no_precondition_expression_runs_once_and_warns_nothing(self):
+        svc, scope_svc, _ = _paired_svc(
+            main_tables=["T_A"],
+            gate_tables=[],
+            gate_codes=[],
+            scope_results=[[_scope([1])]],
+        )
+        result = svc.calculate_from_expression(expression="main")
+        assert scope_svc.calculate_operation_scope.call_count == 1
+        assert result.warning is None
+        assert result.error_source is None
+
+    def test_warns_when_the_scope_signature_changes(self):
+        svc, _, _ = _paired_svc(
+            main_tables=["T_A"],
+            gate_tables=["T_B"],
+            gate_codes=[],
+            scope_results=[[_scope([1, 2])], [_scope([1])]],
+        )
+        result = svc.calculate_from_expression(
+            expression="main", precondition_expression="gate"
+        )
+        assert result.warning is not None
+        assert "[1] -> [1, 2]" in result.warning
+        assert "tables T_B" in result.warning
+
+    def test_no_warning_when_the_signature_is_unchanged(self):
+        # The gate adds an operand, so the baseline is computed — but the
+        # resolved scope is identical, so there is nothing to report.
+        svc, scope_svc, _ = _paired_svc(
+            main_tables=["T_A"],
+            gate_tables=["T_B"],
+            gate_codes=[],
+            scope_results=[[_scope([1])], [_scope([1])]],
+        )
+        result = svc.calculate_from_expression(
+            expression="main", precondition_expression="gate"
+        )
+        assert scope_svc.calculate_operation_scope.call_count == 2
+        assert result.warning is None
+
+    def test_warns_on_re_partitioning_that_module_versions_alone_would_miss(
+        self,
+    ):
+        # Same module versions before and after, but regrouped: FINREP9 alone
+        # can no longer evaluate the pair. ``module_versions`` is identical, so
+        # only the per-scope signature catches this.
+        svc, _, _ = _paired_svc(
+            main_tables=["T_A"],
+            gate_tables=["T_B"],
+            gate_codes=[],
+            scope_results=[
+                [_scope([1, 2]), _scope([2])],
+                [_scope([1]), _scope([2])],
+            ],
+        )
+        result = svc.calculate_from_expression(
+            expression="main", precondition_expression="gate"
+        )
+        assert result.warning is not None
+
+    def test_warns_when_the_gate_empties_the_scope(self):
+        svc, _, _ = _paired_svc(
+            main_tables=["T_A"],
+            gate_tables=[],
+            gate_codes=["FI_1"],
+            scope_results=[[], [_scope([1])]],
+        )
+        result = svc.calculate_from_expression(
+            expression="main", precondition_expression="gate"
+        )
+        assert result.total_scopes == 0
+        assert not result.has_error
+        assert "not evaluable in any module version" in result.warning
+        assert "filing indicators FI_1" in result.warning
+
+    def test_gate_parse_failure_is_attributed_and_prefixed(self):
+        Svc, _ = _load_module()
+        mod = sys.modules["dpmcore.services.scope_calculator"]
+        oc = MagicMock()
+        oc.tables = {"T_A": MagicMock()}
+        oc.preconditions = False
+        mod.OperandsChecking.side_effect = [oc, RuntimeError("bad gate")]
+        svc = Svc(MagicMock())
+        svc._syntax = MagicMock()
+        svc._syntax.parse.return_value = MagicMock()
+        svc._check_release_exists = MagicMock()
+
+        result = svc.calculate_from_expression(
+            expression="main", precondition_expression="gate"
+        )
+        assert result.has_error
+        assert result.error_source == "precondition"
+        assert result.error_message == "Precondition: bad gate"
+
+    def test_main_expression_failure_is_not_prefixed(self):
+        Svc, _ = _load_module()
+        mod = sys.modules["dpmcore.services.scope_calculator"]
+        mod.OperandsChecking.side_effect = RuntimeError("bad main")
+        svc = Svc(MagicMock())
+        svc._syntax = MagicMock()
+        svc._syntax.parse.return_value = MagicMock()
+        svc._check_release_exists = MagicMock()
+
+        result = svc.calculate_from_expression(
+            expression="main", precondition_expression="gate"
+        )
+        assert result.has_error
+        assert result.error_source == "expression"
+        assert result.error_message == "bad main"
+
+    def test_combined_failure_blames_the_gate_only_if_the_main_resolves(self):
+        svc, scope_svc, _ = _paired_svc(
+            main_tables=["T_A"],
+            gate_tables=["T_B"],
+            gate_codes=[],
+            scope_results=[],
+        )
+        # Combined run raises; the baseline retry succeeds.
+        scope_svc.calculate_operation_scope.side_effect = [
+            RuntimeError("no modules"),
+            ([_scope([1])], []),
+        ]
+        result = svc.calculate_from_expression(
+            expression="main", precondition_expression="gate"
+        )
+        assert result.error_source == "precondition"
+        assert result.error_message == "Precondition: no modules"
+
+    def test_combined_failure_blames_the_expression_if_it_also_fails_alone(
+        self,
+    ):
+        svc, scope_svc, _ = _paired_svc(
+            main_tables=["T_A"],
+            gate_tables=["T_B"],
+            gate_codes=[],
+            scope_results=[],
+        )
+        scope_svc.calculate_operation_scope.side_effect = RuntimeError("boom")
+        result = svc.calculate_from_expression(
+            expression="main", precondition_expression="gate"
+        )
+        assert result.error_source == "expression"
+        assert result.error_message == "boom"
+
+    def test_a_fresh_scope_service_is_built_per_run(self):
+        # OperationScopeService accumulates into self.operation_scopes and
+        # never clears it, so sharing one instance would double-count.
+        svc, _, mod = _paired_svc(
+            main_tables=["T_A"],
+            gate_tables=["T_B"],
+            gate_codes=[],
+            scope_results=[[_scope([1, 2])], [_scope([1])]],
+        )
+        svc.calculate_from_expression(
+            expression="main", precondition_expression="gate"
+        )
+        assert mod.OperationScopeService.call_count == 2
+
+
+class TestScopeSignature:
+    """The invariant the warning is computed from."""
+
+    def test_empty_scopes(self):
+        Svc, _ = _load_module()
+        assert Svc._scope_signature([]) == frozenset()
+
+    def test_groups_module_vids_per_scope(self):
+        Svc, _ = _load_module()
+        assert Svc._scope_signature([_scope([1]), _scope([2])]) == frozenset(
+            {frozenset({1}), frozenset({2})}
+        )
+
+    def test_distinguishes_re_partitioning(self):
+        Svc, _ = _load_module()
+        split = Svc._scope_signature([_scope([1]), _scope([2])])
+        merged = Svc._scope_signature([_scope([1, 2])])
+        assert split != merged
+
+
+# ------------------------------------------------------------------ #
 # _compute_cross_module
 # ------------------------------------------------------------------ #
 

--- a/tests/unit/services/test_semantic_precondition.py
+++ b/tests/unit/services/test_semantic_precondition.py
@@ -86,7 +86,7 @@ class TestPairWideIsValid:
     def test_both_halves_valid(self, monkeypatch):
         svc = _svc()
         _stub(svc, monkeypatch)
-        result = svc.validate("main", "gate")
+        result = svc.validate("main", precondition_expression="gate")
         assert result.is_valid
         assert result.precondition.is_valid
 
@@ -95,7 +95,7 @@ class TestPairWideIsValid:
         # pair-wide verdict is False.
         svc = _svc()
         _stub(svc, monkeypatch, results={"gate": _bad("gate", "2-1")})
-        result = svc.validate("main", "gate")
+        result = svc.validate("main", precondition_expression="gate")
         assert not result.is_valid
         assert result.error_source == "precondition"
         assert result.error_code == "2-1"
@@ -104,12 +104,27 @@ class TestPairWideIsValid:
         assert not result.precondition.is_valid
         assert result.precondition.error_message == "broken: gate"
 
+    def test_nested_gate_verdict_names_its_own_half(self, monkeypatch):
+        # A standalone failure attributes itself to "expression" — the only
+        # half it knows about. Nested under ``precondition`` that would read
+        # as a claim about the main expression, so it is restamped.
+        svc = _svc()
+        _stub(svc, monkeypatch, results={"gate": _bad("gate")})
+        result = svc.validate("main", precondition_expression="gate")
+        assert result.precondition.error_source == "precondition"
+
+    def test_a_healthy_gate_carries_no_attribution(self, monkeypatch):
+        svc = _svc()
+        _stub(svc, monkeypatch)
+        result = svc.validate("main", precondition_expression="gate")
+        assert result.precondition.error_source is None
+
     def test_broken_expression_is_attributed_to_the_expression(
         self, monkeypatch
     ):
         svc = _svc()
         _stub(svc, monkeypatch, results={"main": _bad("main")})
-        result = svc.validate("main", "gate")
+        result = svc.validate("main", precondition_expression="gate")
         assert not result.is_valid
         assert result.error_source == "expression"
         assert result.error_message == "broken: main"
@@ -124,7 +139,7 @@ class TestPairWideIsValid:
             monkeypatch,
             results={"main": _bad("main"), "gate": _bad("gate", "2-1")},
         )
-        result = svc.validate("main", "gate")
+        result = svc.validate("main", precondition_expression="gate")
         assert not result.is_valid
         assert result.error_source == "both"
         assert result.error_message == (
@@ -144,14 +159,14 @@ class TestPairWideIsValid:
             {"main": _bad("main"), "gate": _bad("gate")},
         ):
             _stub(svc, monkeypatch, results=results)
-            result = svc.validate("main", "gate")
+            result = svc.validate("main", precondition_expression="gate")
             if result.error_source == "expression":
                 assert result.precondition.is_valid
 
     def test_an_invalid_pair_always_carries_a_message(self, monkeypatch):
         svc = _svc()
         _stub(svc, monkeypatch, results={"gate": _bad("gate")})
-        result = svc.validate("main", "gate")
+        result = svc.validate("main", precondition_expression="gate")
         assert not result.is_valid
         assert result.error_message
         assert result.error_code
@@ -167,7 +182,7 @@ class TestPairWideIsValid:
                 "gate": _ok("gate", warning="gate is odd"),
             },
         )
-        result = svc.validate("main", "gate")
+        result = svc.validate("main", precondition_expression="gate")
         assert result.warning == "main is odd\nPrecondition: gate is odd"
 
     def test_gate_warning_alone_still_surfaces(self, monkeypatch):
@@ -175,21 +190,84 @@ class TestPairWideIsValid:
         _stub(
             svc, monkeypatch, results={"gate": _ok("gate", warning="odd gate")}
         )
-        assert svc.validate("main", "gate").warning == "Precondition: odd gate"
+        assert (
+            svc.validate("main", precondition_expression="gate").warning
+            == "Precondition: odd gate"
+        )
 
     def test_no_warnings_stays_none(self, monkeypatch):
         svc = _svc()
         _stub(svc, monkeypatch)
-        assert svc.validate("main", "gate").warning is None
+        assert (
+            svc.validate("main", precondition_expression="gate").warning
+            is None
+        )
 
     def test_error_source_distinguishes_which_half_broke(self, monkeypatch):
         # Without this field a caller could not tell "the expression is broken"
         # from "only the gate is broken" except by matching on the prefix.
         svc = _svc()
         _stub(svc, monkeypatch, results={"gate": _bad("gate")})
-        assert svc.validate("main", "gate").error_source == "precondition"
+        assert (
+            svc.validate("main", precondition_expression="gate").error_source
+            == "precondition"
+        )
         _stub(svc, monkeypatch, results={"main": _bad("main")})
-        assert svc.validate("main", "gate").error_source == "expression"
+        assert (
+            svc.validate("main", precondition_expression="gate").error_source
+            == "expression"
+        )
+
+
+class TestSignatureIsBackwardCompatible:
+    """The gate is appended, keyword-only: positional callers are untouched.
+
+    Inserting it as the second parameter would have silently reinterpreted
+    every existing ``validate(expression, 5)`` call as a gated validation
+    against release ``None``.
+    """
+
+    def _capture(self, svc, monkeypatch, seen):
+        monkeypatch.setattr(
+            svc,
+            "_resolve_release",
+            lambda release_id, release_code: (
+                seen.append((release_id, release_code)) or 42
+            ),
+        )
+        monkeypatch.setattr(
+            svc,
+            "_validate_resolved",
+            lambda expression, release_id, **_kw: _ok(expression),
+        )
+
+    def test_second_positional_is_still_release_id(self, monkeypatch):
+        svc = _svc()
+        seen: list = []
+        self._capture(svc, monkeypatch, seen)
+        result = svc.validate("main", 5)
+        assert seen == [(5, None)]
+        assert result.precondition is None
+
+    def test_third_positional_is_still_release_code(self, monkeypatch):
+        svc = _svc()
+        seen: list = []
+        self._capture(svc, monkeypatch, seen)
+        svc.validate("main", None, "4.2.1")
+        assert seen == [(None, "4.2.1")]
+
+    def test_is_valid_keeps_its_positional_order_too(self, monkeypatch):
+        svc = _svc()
+        seen: list = []
+        self._capture(svc, monkeypatch, seen)
+        assert svc.is_valid("main", 5)
+        assert seen == [(5, None)]
+
+    @pytest.mark.parametrize("method", ["validate", "is_valid"])
+    def test_gate_cannot_be_passed_positionally(self, method):
+        svc = _svc()
+        with pytest.raises(TypeError):
+            getattr(svc, method)("main", None, None, "gate")
 
 
 class TestReleaseHandling:
@@ -207,7 +285,7 @@ class TestReleaseHandling:
                 calls.append((expression, release_id)) or _ok(expression)
             ),
         )
-        svc.validate("main", "gate")
+        svc.validate("main", precondition_expression="gate")
         assert len(seen) == 1
         assert [release for _, release in calls] == [42, 42]
 
@@ -218,11 +296,12 @@ class TestReleaseHandling:
             raise SemanticError("1-21", release_id=999)
 
         monkeypatch.setattr(svc, "_resolve_release", boom)
-        result = svc.validate("main", "gate")
+        result = svc.validate("main", precondition_expression="gate")
         assert not result.is_valid
         assert result.error_code == "1-21"
         assert result.error_source == "expression"
         assert result.precondition.error_code == "1-21"
+        assert result.precondition.error_source == "precondition"
 
     def test_resolution_failure_keeps_none_when_no_gate_supplied(
         self, monkeypatch
@@ -244,7 +323,7 @@ class TestGateIsValidatedAsAGate:
         svc = _svc()
         calls = []
         _stub(svc, monkeypatch, calls=calls)
-        svc.validate("main", "gate")
+        svc.validate("main", precondition_expression="gate")
         assert ("gate", True, 42) in calls
         assert ("main", False, 42) in calls
 
@@ -254,7 +333,7 @@ class TestGateIsValidatedAsAGate:
         svc = _svc()
         calls = []
         _stub(svc, monkeypatch, calls=calls)
-        svc.validate("main", "gate")
+        svc.validate("main", precondition_expression="gate")
         assert [expression for expression, _, _ in calls] == ["gate", "main"]
 
 
@@ -269,12 +348,13 @@ class TestCrossHalfParameterCheck:
                 "gate": _ok("gate", [ParameterInfo("thr", "Integer")]),
             },
         )
-        result = svc.validate("main", "gate")
+        result = svc.validate("main", precondition_expression="gate")
         assert not result.is_valid
         # The clash belongs to the second declaration, not the expression.
         assert result.error_source == "precondition"
         assert result.error_code == "3-8"
         assert result.precondition.error_code == "3-8"
+        assert result.precondition.error_source == "precondition"
 
     def test_agreeing_declarations_pass(self, monkeypatch):
         svc = _svc()
@@ -286,7 +366,7 @@ class TestCrossHalfParameterCheck:
                 "gate": _ok("gate", [ParameterInfo("thr", "Number")]),
             },
         )
-        assert svc.validate("main", "gate").is_valid
+        assert svc.validate("main", precondition_expression="gate").is_valid
 
     def test_disjoint_parameters_pass(self, monkeypatch):
         svc = _svc()
@@ -298,7 +378,7 @@ class TestCrossHalfParameterCheck:
                 "gate": _ok("gate", [ParameterInfo("b", "String")]),
             },
         )
-        assert svc.validate("main", "gate").is_valid
+        assert svc.validate("main", precondition_expression="gate").is_valid
 
     def test_not_run_when_a_half_already_failed(self, monkeypatch):
         # An already-invalid half carries no parameters worth comparing, and
@@ -312,7 +392,7 @@ class TestCrossHalfParameterCheck:
                 "gate": _ok("gate", [ParameterInfo("thr", "Integer")]),
             },
         )
-        result = svc.validate("main", "gate")
+        result = svc.validate("main", precondition_expression="gate")
         assert result.error_source == "expression"
         assert result.error_code == "1-2"
 
@@ -344,4 +424,4 @@ class TestIsValidShortcut:
             monkeypatch,
             results={"gate": _bad("gate")} if gate_broken else {},
         )
-        assert svc.is_valid("main", gate) is expected
+        assert svc.is_valid("main", precondition_expression=gate) is expected

--- a/tests/unit/services/test_semantic_precondition.py
+++ b/tests/unit/services/test_semantic_precondition.py
@@ -1,0 +1,347 @@
+"""Unit tests for ``validate(precondition_expression=...)`` (issue #279).
+
+DB-free: release resolution and the per-half validation are stubbed, so these
+pin the *pairing* contract — the pair-wide ``is_valid``, attribution, the single
+release resolution, which half the published per-call state describes, and the
+cross-half parameter check. The DB-backed behaviour (the ``2-1`` gate rule, real
+expressions) is covered by
+``tests/integration/services/test_precondition_expression.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dpmcore.errors import SemanticError
+from dpmcore.services.semantic import (
+    ParameterInfo,
+    SemanticResult,
+    SemanticService,
+)
+
+
+def _svc() -> SemanticService:
+    # session is unused: every DB-touching step is stubbed per test.
+    return SemanticService(session=None)  # type: ignore[arg-type]
+
+
+def _ok(expression: str, parameters=(), warning=None) -> SemanticResult:
+    return SemanticResult(
+        is_valid=True,
+        error_message=None,
+        error_code=None,
+        expression=expression,
+        parameters=tuple(parameters),
+        warning=warning,
+    )
+
+
+def _bad(expression: str, code: str = "1-2") -> SemanticResult:
+    return SemanticResult(
+        is_valid=False,
+        error_message=f"broken: {expression}",
+        error_code=code,
+        expression=expression,
+        error_source="expression",
+    )
+
+
+def _stub(svc, monkeypatch, results=None, calls=None):
+    """Stub release resolution and per-half validation.
+
+    ``results`` maps expression -> SemanticResult; anything absent validates.
+    ``calls``, when given, records (expression, as_precondition, release) in
+    order.
+    """
+    monkeypatch.setattr(svc, "_resolve_release", lambda *a, **k: 42)
+
+    def _validate_resolved(expression, release_id, *, as_precondition=False):
+        if calls is not None:
+            calls.append((expression, as_precondition, release_id))
+        return (results or {}).get(expression) or _ok(expression)
+
+    monkeypatch.setattr(svc, "_validate_resolved", _validate_resolved)
+
+
+class TestUngatedIsUnchanged:
+    def test_no_precondition_leaves_the_field_none(self, monkeypatch):
+        svc = _svc()
+        _stub(svc, monkeypatch)
+        result = svc.validate("main")
+        assert result.precondition is None
+        assert result.is_valid
+        assert result.error_source is None
+
+    def test_ungated_failure_is_reported_as_before(self, monkeypatch):
+        svc = _svc()
+        _stub(svc, monkeypatch, results={"main": _bad("main")})
+        result = svc.validate("main")
+        assert not result.is_valid
+        assert result.error_code == "1-2"
+        assert result.error_message == "broken: main"
+        assert result.precondition is None
+
+
+class TestPairWideIsValid:
+    def test_both_halves_valid(self, monkeypatch):
+        svc = _svc()
+        _stub(svc, monkeypatch)
+        result = svc.validate("main", "gate")
+        assert result.is_valid
+        assert result.precondition.is_valid
+
+    def test_broken_gate_invalidates_the_pair(self, monkeypatch):
+        # The expression itself is fine, but the row is not evaluable, so the
+        # pair-wide verdict is False.
+        svc = _svc()
+        _stub(svc, monkeypatch, results={"gate": _bad("gate", "2-1")})
+        result = svc.validate("main", "gate")
+        assert not result.is_valid
+        assert result.error_source == "precondition"
+        assert result.error_code == "2-1"
+        assert result.error_message == "Precondition: broken: gate"
+        # The gate's own independent verdict is still reachable.
+        assert not result.precondition.is_valid
+        assert result.precondition.error_message == "broken: gate"
+
+    def test_broken_expression_is_attributed_to_the_expression(
+        self, monkeypatch
+    ):
+        svc = _svc()
+        _stub(svc, monkeypatch, results={"main": _bad("main")})
+        result = svc.validate("main", "gate")
+        assert not result.is_valid
+        assert result.error_source == "expression"
+        assert result.error_message == "broken: main"
+        assert result.precondition.is_valid
+
+    def test_both_broken_names_both_failures(self, monkeypatch):
+        # Naming only the expression would read as "the gate is fine" and cost
+        # the caller a round trip to discover otherwise.
+        svc = _svc()
+        _stub(
+            svc,
+            monkeypatch,
+            results={"main": _bad("main"), "gate": _bad("gate", "2-1")},
+        )
+        result = svc.validate("main", "gate")
+        assert not result.is_valid
+        assert result.error_source == "both"
+        assert result.error_message == (
+            "broken: main\nPrecondition: broken: gate"
+        )
+        # error_code holds one value; the expression's takes precedence.
+        assert result.error_code == "1-2"
+        assert result.precondition.error_code == "2-1"
+
+    def test_error_source_never_implies_a_healthy_gate(self, monkeypatch):
+        # "expression" must mean the gate passed, so a broken gate can never be
+        # reported under it.
+        svc = _svc()
+        for results in (
+            {"main": _bad("main")},
+            {"gate": _bad("gate")},
+            {"main": _bad("main"), "gate": _bad("gate")},
+        ):
+            _stub(svc, monkeypatch, results=results)
+            result = svc.validate("main", "gate")
+            if result.error_source == "expression":
+                assert result.precondition.is_valid
+
+    def test_an_invalid_pair_always_carries_a_message(self, monkeypatch):
+        svc = _svc()
+        _stub(svc, monkeypatch, results={"gate": _bad("gate")})
+        result = svc.validate("main", "gate")
+        assert not result.is_valid
+        assert result.error_message
+        assert result.error_code
+
+    def test_gate_warnings_are_merged_onto_the_pair(self, monkeypatch):
+        # A caller reading only result.warning must not miss the gate's.
+        svc = _svc()
+        _stub(
+            svc,
+            monkeypatch,
+            results={
+                "main": _ok("main", warning="main is odd"),
+                "gate": _ok("gate", warning="gate is odd"),
+            },
+        )
+        result = svc.validate("main", "gate")
+        assert result.warning == "main is odd\nPrecondition: gate is odd"
+
+    def test_gate_warning_alone_still_surfaces(self, monkeypatch):
+        svc = _svc()
+        _stub(
+            svc, monkeypatch, results={"gate": _ok("gate", warning="odd gate")}
+        )
+        assert svc.validate("main", "gate").warning == "Precondition: odd gate"
+
+    def test_no_warnings_stays_none(self, monkeypatch):
+        svc = _svc()
+        _stub(svc, monkeypatch)
+        assert svc.validate("main", "gate").warning is None
+
+    def test_error_source_distinguishes_which_half_broke(self, monkeypatch):
+        # Without this field a caller could not tell "the expression is broken"
+        # from "only the gate is broken" except by matching on the prefix.
+        svc = _svc()
+        _stub(svc, monkeypatch, results={"gate": _bad("gate")})
+        assert svc.validate("main", "gate").error_source == "precondition"
+        _stub(svc, monkeypatch, results={"main": _bad("main")})
+        assert svc.validate("main", "gate").error_source == "expression"
+
+
+class TestReleaseHandling:
+    def test_release_is_resolved_once_for_both_halves(self, monkeypatch):
+        svc = _svc()
+        seen = []
+        monkeypatch.setattr(
+            svc, "_resolve_release", lambda *a, **k: seen.append(1) or 42
+        )
+        calls = []
+        monkeypatch.setattr(
+            svc,
+            "_validate_resolved",
+            lambda expression, release_id, *, as_precondition=False: (
+                calls.append((expression, release_id)) or _ok(expression)
+            ),
+        )
+        svc.validate("main", "gate")
+        assert len(seen) == 1
+        assert [release for _, release in calls] == [42, 42]
+
+    def test_resolution_failure_is_mirrored_onto_the_gate(self, monkeypatch):
+        svc = _svc()
+
+        def boom(*_a, **_k):
+            raise SemanticError("1-21", release_id=999)
+
+        monkeypatch.setattr(svc, "_resolve_release", boom)
+        result = svc.validate("main", "gate")
+        assert not result.is_valid
+        assert result.error_code == "1-21"
+        assert result.error_source == "expression"
+        assert result.precondition.error_code == "1-21"
+
+    def test_resolution_failure_keeps_none_when_no_gate_supplied(
+        self, monkeypatch
+    ):
+        svc = _svc()
+
+        def boom(*_a, **_k):
+            raise ValueError("Release code '9.9' not found.")
+
+        monkeypatch.setattr(svc, "_resolve_release", boom)
+        result = svc.validate("main")
+        # ``None`` means "caller shipped no gate", never "the gate failed".
+        assert result.precondition is None
+        assert result.error_code == "UNKNOWN"
+
+
+class TestGateIsValidatedAsAGate:
+    def test_only_the_gate_gets_as_precondition(self, monkeypatch):
+        svc = _svc()
+        calls = []
+        _stub(svc, monkeypatch, calls=calls)
+        svc.validate("main", "gate")
+        assert ("gate", True, 42) in calls
+        assert ("main", False, 42) in calls
+
+    def test_gate_is_validated_before_the_main_expression(self, monkeypatch):
+        # Ordering is load-bearing: the trailing published state must describe
+        # the main expression, so it has to be validated last.
+        svc = _svc()
+        calls = []
+        _stub(svc, monkeypatch, calls=calls)
+        svc.validate("main", "gate")
+        assert [expression for expression, _, _ in calls] == ["gate", "main"]
+
+
+class TestCrossHalfParameterCheck:
+    def test_conflicting_declaration_invalidates_the_pair(self, monkeypatch):
+        svc = _svc()
+        _stub(
+            svc,
+            monkeypatch,
+            results={
+                "main": _ok("main", [ParameterInfo("thr", "Number")]),
+                "gate": _ok("gate", [ParameterInfo("thr", "Integer")]),
+            },
+        )
+        result = svc.validate("main", "gate")
+        assert not result.is_valid
+        # The clash belongs to the second declaration, not the expression.
+        assert result.error_source == "precondition"
+        assert result.error_code == "3-8"
+        assert result.precondition.error_code == "3-8"
+
+    def test_agreeing_declarations_pass(self, monkeypatch):
+        svc = _svc()
+        _stub(
+            svc,
+            monkeypatch,
+            results={
+                "main": _ok("main", [ParameterInfo("thr", "Number")]),
+                "gate": _ok("gate", [ParameterInfo("thr", "Number")]),
+            },
+        )
+        assert svc.validate("main", "gate").is_valid
+
+    def test_disjoint_parameters_pass(self, monkeypatch):
+        svc = _svc()
+        _stub(
+            svc,
+            monkeypatch,
+            results={
+                "main": _ok("main", [ParameterInfo("a", "Number")]),
+                "gate": _ok("gate", [ParameterInfo("b", "String")]),
+            },
+        )
+        assert svc.validate("main", "gate").is_valid
+
+    def test_not_run_when_a_half_already_failed(self, monkeypatch):
+        # An already-invalid half carries no parameters worth comparing, and
+        # its own failure must be what gets reported.
+        svc = _svc()
+        _stub(
+            svc,
+            monkeypatch,
+            results={
+                "main": _bad("main"),
+                "gate": _ok("gate", [ParameterInfo("thr", "Integer")]),
+            },
+        )
+        result = svc.validate("main", "gate")
+        assert result.error_source == "expression"
+        assert result.error_code == "1-2"
+
+
+class TestPublishedState:
+    def test_failure_clears_the_published_ast(self):
+        svc = _svc()
+        svc.ast = "stale"
+        svc.oc_tables = {"T": {}}
+        result = svc._failure("expr", ValueError("boom"), "UNKNOWN")
+        assert not result.is_valid
+        # ``ast`` used to survive a failure, leaving stale state readable.
+        assert svc.ast is None
+        assert svc.oc_tables is None
+        assert svc.oc_parameters is None
+
+
+class TestIsValidShortcut:
+    @pytest.mark.parametrize(
+        ("gate", "gate_broken", "expected"),
+        [(None, False, True), ("gate", False, True), ("gate", True, False)],
+    )
+    def test_is_valid_is_pair_wide(
+        self, monkeypatch, gate, gate_broken, expected
+    ):
+        svc = _svc()
+        _stub(
+            svc,
+            monkeypatch,
+            results={"gate": _bad("gate")} if gate_broken else {},
+        )
+        assert svc.is_valid("main", gate) is expected


### PR DESCRIPTION
## Summary

Closes #279

A validation row is often a **pair**: a DPM-XL expression plus a *precondition expression* — a second full DPM-XL expression that gates it. The row is only evaluable when both halves resolve against the same release. dpmcore had no way to say that: `validate()` took one expression, and `calculate_from_expression(precondition_items=…)` takes filing-indicator *variable codes*, so a precondition expression passed there was silently dropped by the filing-indicator filter.

Both services now accept an optional `precondition_expression`, and the scope calculation flags when a precondition changes the expression's scope.

## Checklist

- [X] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [X] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [X] Documentation updated (if applicable)


## Semantic validation

`SemanticService.validate(expression, precondition_expression=None, …)`.

When a gate is supplied, `is_valid` is the verdict for the **pair** — `False` if either half failed, because a row whose gate does not resolve cannot be evaluated. The rest of the result is built so that reading only the outer object never hides half the story:

| expression | gate | `error_source` | `error_message` | `error_code` |
|---|---|---|---|---|
| ok | ok | `null` | `null` | `null` |
| bad | ok | `"expression"` | the expression's | the expression's |
| ok | bad | `"precondition"` | `"Precondition: …"` | the gate's |
| bad | bad | `"both"` | both, newline-joined | the expression's |

`SemanticResult.precondition` carries the gate's own standalone verdict, and is `null` exactly when no gate was supplied — never as a way of signalling that one failed. `warning` merges both halves' warnings, the gate's under the same `Precondition: ` prefix.

## Scope calculation

`ScopeCalculatorService.calculate_from_expression(…, precondition_expression=None)`.

The gate's operands join the resolution through the channel that can actually resolve them, and the two are not interchangeable: table references widen `table_codes`, filing-indicator references widen `precondition_items`. Only `table_codes` resolves through the table-code lookup, and only `precondition_items` gets the filing-indicator filter and the `1-14` check, so crossing the wires produces a spurious error either way.

**Only the mandatory filing-indicator codes are passed on.** Scope calculation counts every precondition code as an operand the module has to supply, so feeding it the flat set makes a disjunctive gate demand all of its alternatives at once. That is not theoretical: of the 965 precondition expressions in the dictionary, 62 use `or`, and the widest flattens to 20 filing indicators spanning frameworks — which no module reports together, so it resolves to a hard `1-14`. A new helper intersects across `or`/`xor`, contributes nothing for `not`, and unions everywhere else. Script generation keeps the existing flat extractor, so its output is unchanged.

## Scope-change warning

`ScopeResult` gains `warning`, set when the gate moved the scope, naming the module versions before and after. Two things worth calling out:


## Error atS-change tribution

A gate that fails to resolve **fails the call**, with `error_source: "precondition"` and the message prefixed `Precondition: `. Failing is the honest answer — the pair genuinely is not evaluable — and the attribution lets a caller drop the gate and retry rather than guess which half broke.

A failure raised while resolving the combined scope is only blamed on the gate if the expression resolves cleanly without it; that is settled by retrying, not guessed. The gate's own table codes are also checked on their own, because the resolver only reports "no module versions found" when *nothing* resolves — so an unhostable gate table would otherwise be absorbed by the expression's own rows and produce a scope that cannot actually evaluate the pair.

## Backwards compatibility

`precondition_expression` defaults to `None` on both services, and in that case behaviour is unchanged: no extra query, no warning, and byte-identical error messages. `precondition_items` keeps its existing meaning and is unioned with anything the gate implies.

Verified rather than assumed: `validate()` was run over **all 13158 expressions** in the dictionary against both this branch and `master`, and the results are identical — same 10392 valid, same 19 warnings, same codes and messages. `calculate_from_expression` was compared the same way over 600 calls. The two new `ScopeResult` fields are appended with defaults, and every construction site is keyword-based.

`REST POST /api/v1/scope` gains `precondition_expression` in the request and `warning` / `error_source` in the response.

## Out of scope

- **Script generation is untouched.** Wiring `precondition_expression` into `script()` would change the computed scope for every existing consumer, and the engine payload flattens preconditions to filing-indicator nodes anyway, discarding the gate's operator structure. Worth a separate issue.
- **A pre-existing silent case is now visible but not fixed:** a filing-indicator-only module cannot enter the cross-module pool, so a cross-framework gate yields zero scopes with no error. This is reachable today through `precondition_items` alone. The new warning surfaces it; fixing the pool behaviour would change existing script output and belongs on its own.


## UPDATE

- `precondition_expression` is keyword-only. It had been inserted as the second positional parameter, so an existing `validate(expression, 123)` would have been read as a gated validation instead of a release filter. 
- `POST /api/v1/validate/semantic` now exposes the gate.** It accepts `precondition_expression` and returns `error_source`.
- `not` still drops its operand, and now says why. The set holds the codes that must be true for the gate to hold, not the codes the engine has to read. 
