### PR TITLE
Apply the `where` block of a `with` clause

### DIFF
--- a/specification/03-services.md
+++ b/specification/03-services.md
@@ -820,7 +820,7 @@ It is not part of the public API but is documented here for completeness.
 
 ### 10.1 Grammar & Parser
 
-- **ANTLR4 grammar**: `dpm_xl.g4` defines the DPM-XL language syntax
+- **ANTLR4 grammar**: `dpm_xlLexer.g4` and `dpm_xlParser.g4` define the DPM-XL language syntax
 - **Generated parser**: Auto-generated lexer, parser, and listener from the grammar
 - **ANTLR version**: 4.9.2 (specific version required)
 
@@ -893,24 +893,27 @@ substituting it stays invalid (`4-5-0-1`). `GET` re-types the result Fact
 Component to the data type of the selected component. Attribute Components
 are accepted structurally but no selection currently produces any.
 
-A condition naming only the Fact Component needs no open key, so it applies
-to a selection on a table that declares none — but the selection must still
-be a recordset. On a single datapoint, whose only key components are the
-implicit globals (`refPeriod`, `entityID`, `baseCurrency`), there is nothing
-to filter and the clause is rejected with `4-5-2-3`.
+A `WHERE` condition naming only the Fact Component needs no open key, so it
+applies to a selection on a table that declares none. The selection must
+still be a recordset: on a single datapoint — one whose only key components
+are the implicit globals `refPeriod`, `entityID` and `baseCurrency` — the
+condition is rejected with `4-5-2-3`.
 
 #### The `where` block of a `with` clause
 
-`with partial_selection [where_expression]: expression` carries a clause that
-applies to every operand arising from a selection operator inside the body
-(DPM-XL §3.2.5), unless that operand has its own `where` or `sub`, which
-overrides it in full — even when the inner clause names other properties
-(§3.2.6).
+`dpm_xlParser.g4`, rule `expressionWithoutAssignment`:
 
-`ASTConstructor.visitExprWithSelection` desugars the block: it stores the
-condition on `WithExpression.where_condition` for introspection and grafts a
-copy of it onto each body selection as an ordinary `WhereClauseOp`. These two
-forms therefore build the same AST and serialize to the same payload:
+```antlr
+    | WITH partialSelection
+    (SQUARE_BRACKET_LEFT WHERE expression SQUARE_BRACKET_RIGHT)?
+    COLON expression                                                            #exprWithSelection
+```
+
+The optional block applies to every selection in the body, except a selection
+carrying its own `WHERE` or `SUB`, which overrides it in full — including when
+the inner clause names other components. Filtering precedes `GET` and `RENAME`
+on the same selection, so the condition names components as the selection
+declares them. These two are equivalent:
 
 ```
 with {tX}[where qEEA = [eba_qAE:qx2023]]: {c0250} + {c0260} >= 0
@@ -918,14 +921,9 @@ with {tX}: {c0250}[where qEEA = [eba_qAE:qx2023]]
          + {c0260}[where qEEA = [eba_qAE:qx2023]] >= 0
 ```
 
-Two consequences. The wrapper goes *inside* any `get`/`rename` on the operand,
-so the condition still names the components the selection had before those
-clauses reshaped it. And because each selection is then validated against the
-clause individually, a body selection whose table does not carry the
-referenced component is an error (`2-8`, or `1-5` when the property has no
-dictionary row at all) rather than a silent no-op — which matters for a body
-that mixes tables. `where_condition` is metadata only: the condition it holds
-is already in the body, so no visitor descends into it.
+Each selection is checked against the condition on its own: one whose table
+does not carry a referenced component raises `2-8`, and a component with no
+dictionary row raises `1-5`.
 
 ### 10.6 Semantic Analyzer
 

--- a/specification/03-services.md
+++ b/specification/03-services.md
@@ -893,6 +893,40 @@ substituting it stays invalid (`4-5-0-1`). `GET` re-types the result Fact
 Component to the data type of the selected component. Attribute Components
 are accepted structurally but no selection currently produces any.
 
+A condition naming only the Fact Component needs no open key, so it applies
+to a selection on a table that declares none — but the selection must still
+be a recordset. On a single datapoint, whose only key components are the
+implicit globals (`refPeriod`, `entityID`, `baseCurrency`), there is nothing
+to filter and the clause is rejected with `4-5-2-3`.
+
+#### The `where` block of a `with` clause
+
+`with partial_selection [where_expression]: expression` carries a clause that
+applies to every operand arising from a selection operator inside the body
+(DPM-XL §3.2.5), unless that operand has its own `where` or `sub`, which
+overrides it in full — even when the inner clause names other properties
+(§3.2.6).
+
+`ASTConstructor.visitExprWithSelection` desugars the block: it stores the
+condition on `WithExpression.where_condition` for introspection and grafts a
+copy of it onto each body selection as an ordinary `WhereClauseOp`. These two
+forms therefore build the same AST and serialize to the same payload:
+
+```
+with {tX}[where qEEA = [eba_qAE:qx2023]]: {c0250} + {c0260} >= 0
+with {tX}: {c0250}[where qEEA = [eba_qAE:qx2023]]
+         + {c0260}[where qEEA = [eba_qAE:qx2023]] >= 0
+```
+
+Two consequences. The wrapper goes *inside* any `get`/`rename` on the operand,
+so the condition still names the components the selection had before those
+clauses reshaped it. And because each selection is then validated against the
+clause individually, a body selection whose table does not carry the
+referenced component is an error (`2-8`, or `1-5` when the property has no
+dictionary row at all) rather than a silent no-op — which matters for a body
+that mixes tables. `where_condition` is metadata only: the condition it holds
+is already in the body, so no visitor descends into it.
+
 ### 10.6 Semantic Analyzer
 
 The `InputAnalyzer` walks the AST and:

--- a/src/dpmcore/dpm_xl/ast/constructor.py
+++ b/src/dpmcore/dpm_xl/ast/constructor.py
@@ -59,6 +59,7 @@ from dpmcore.dpm_xl.ast.nodes import (
     WindowClause,
     WithExpression,
 )
+from dpmcore.dpm_xl.ast.where_clause import graft_where_onto_selections
 from dpmcore.dpm_xl.grammar.generated.dpm_xlParser import dpm_xlParser
 from dpmcore.dpm_xl.grammar.generated.dpm_xlParserVisitor import (
     dpm_xlParserVisitor,
@@ -164,8 +165,22 @@ class ASTVisitor(dpm_xlParserVisitor):
         # so ctx_list[3] would land on the WHERE terminal rather than the
         # body.  ctx_list[-1] is correct in both cases.
         expression: AST = self._visit(ctx_list[-1])
+        # The optional [WHERE expression] block is inlined in the grammar
+        # rule rather than reached through a WhereExprContext, so it has no
+        # named accessor. It contributes the only other ``expression`` child,
+        # so two of them means the block is there and the first is its
+        # condition.
+        where_condition: AST | None = None
+        expressions = ctx.expression()
+        if len(expressions) == 2:
+            where_condition = self._visit(expressions[0])
+            expression = graft_where_onto_selections(
+                expression, where_condition
+            )
         return WithExpression(
-            partial_selection=partial_selection, expression=expression
+            partial_selection=partial_selection,
+            expression=expression,
+            where_condition=where_condition,
         )
 
     def visitPartialSelect(

--- a/src/dpmcore/dpm_xl/ast/nodes.py
+++ b/src/dpmcore/dpm_xl/ast/nodes.py
@@ -387,17 +387,29 @@ class WithExpression(AST):
     Example: {Table 1, row 1} + {Table 1, row 2} -> with {Table 1}: {row 1} + {row 2}
     :parameter partial_selection: Cell reference to be used
     :parameter expression: Expression after the double points to be modified by the partial selection
+    :parameter where_condition: Condition of the optional ``[where ...]`` block of the with clause,
+        kept for introspection only. The constructor has already grafted a copy of it onto every
+        selection in ``expression`` (see ``ast.where_clause.graft_where_onto_selections``), so no
+        visitor may descend into this field: doing so would count its dimensions and items twice in
+        ``OperandsChecking`` and renumber nodes in ``MLGeneration``.
     """
 
-    def __init__(self, partial_selection: "VarID", expression: AST) -> None:
+    def __init__(
+        self,
+        partial_selection: "VarID",
+        expression: AST,
+        where_condition: AST | None = None,
+    ) -> None:
         super().__init__()
         self.partial_selection: VarID = partial_selection
         self.expression: AST = expression
+        self.where_condition: AST | None = where_condition
 
     def __str__(self) -> str:
-        return "<AST(name='{name}', partial_selection={partial_selection}, expression={expression})>".format(
+        return "<AST(name='{name}', partial_selection={partial_selection}, where_condition={where_condition}, expression={expression})>".format(
             name=self.__class__.__name__,
             partial_selection=self.partial_selection,
+            where_condition=self.where_condition,
             expression=self.expression,
         )
 
@@ -407,6 +419,7 @@ class WithExpression(AST):
         return {
             "class_name": self.__class__.__name__,
             "partial_selection": self.partial_selection,
+            "where_condition": self.where_condition,
             "expression": self.expression,
         }
 

--- a/src/dpmcore/dpm_xl/ast/nodes.py
+++ b/src/dpmcore/dpm_xl/ast/nodes.py
@@ -387,11 +387,9 @@ class WithExpression(AST):
     Example: {Table 1, row 1} + {Table 1, row 2} -> with {Table 1}: {row 1} + {row 2}
     :parameter partial_selection: Cell reference to be used
     :parameter expression: Expression after the double points to be modified by the partial selection
-    :parameter where_condition: Condition of the optional ``[where ...]`` block of the with clause,
-        kept for introspection only. The constructor has already grafted a copy of it onto every
-        selection in ``expression`` (see ``ast.where_clause.graft_where_onto_selections``), so no
-        visitor may descend into this field: doing so would count its dimensions and items twice in
-        ``OperandsChecking`` and renumber nodes in ``MLGeneration``.
+    :parameter where_condition: Condition of the optional ``[where ...]`` block, or None. It is
+        already applied to every selection in ``expression``, so it is exposed for inspection only
+        and must not be visited -- see ``ast.where_clause.graft_where_onto_selections``.
     """
 
     def __init__(

--- a/src/dpmcore/dpm_xl/ast/where_clause.py
+++ b/src/dpmcore/dpm_xl/ast/where_clause.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from copy import deepcopy
 from typing import TypeGuard
 
 from dpmcore.dpm_xl.ast.nodes import (
@@ -9,6 +10,9 @@ from dpmcore.dpm_xl.ast.nodes import (
     Dimension,
     ParExpr,
     Scalar,
+    SubOp,
+    VarID,
+    WhereClauseOp,
 )
 from dpmcore.dpm_xl.ast.template import ASTTemplate
 from dpmcore.dpm_xl.utils import tokens
@@ -21,6 +25,69 @@ class WhereClauseChecker(ASTTemplate):
 
     def visit_Dimension(self, node: Dimension) -> None:
         self.key_components.append(node.dimension_code)
+
+
+# Attributes of ``AST`` that point back up the tree rather than down into a
+# child. The visitor passes populate them; at construction time they are all
+# ``None``, but the graft must not follow them regardless.
+_BACK_REFERENCES = frozenset({"parent", "prev"})
+
+
+def graft_where_onto_selections(node: AST, condition: AST) -> AST:
+    """Apply the ``where`` block of a ``with`` clause to the body selections.
+
+    §3.2.5: the clause applies to every operand arising from a selection
+    operator inside the body. §3.2.6: a ``where`` or ``sub`` written on an
+    operand overrides it for that operand -- fully, even when the inner
+    clause names different properties. Grafting therefore desugars
+
+        with {tX}[where A = 1]: {c0010} = {c0020}
+
+    into the AST of the equivalent explicit form
+
+        with {tX}: {c0010}[where A = 1] = {c0020}[where A = 1]
+
+    which every downstream pass already knows how to validate, scope and
+    serialise. The wrapper goes directly around the selection, inside any
+    ``get``/``rename``, so the condition still names the components the
+    operand had before those clauses reshaped it.
+
+    Args:
+        node: A node of the ``with`` body. Rewritten in place.
+        condition: The condition of the ``with``-level ``where`` block.
+
+    Returns:
+        ``node``, or the ``WhereClauseOp`` that now wraps it.
+    """
+    if isinstance(node, VarID):
+        # Each selection needs its own copy: the passes downstream annotate
+        # condition nodes in place (property_id, parent, argument, num), so a
+        # shared subtree would have every selection overwrite the last one's.
+        return WhereClauseOp(operand=node, condition=deepcopy(condition))
+    if isinstance(node, (WhereClauseOp, SubOp)):
+        return node
+    # ``vars`` rather than a per-class child list: the node types differ too
+    # much (left/right, operand, children, args, then_expr, ...) for an
+    # explicit table to stay correct as the grammar grows. Snapshot the items
+    # so the setattr below cannot disturb the iteration, and skip the
+    # back-references, which would turn the walk into a cycle.
+    for name, value in list(vars(node).items()):
+        if name in _BACK_REFERENCES:
+            continue
+        if isinstance(value, AST):
+            setattr(node, name, graft_where_onto_selections(value, condition))
+        elif isinstance(value, list):
+            setattr(
+                node,
+                name,
+                [
+                    graft_where_onto_selections(item, condition)
+                    if isinstance(item, AST)
+                    else item
+                    for item in value
+                ],
+            )
+    return node
 
 
 def _equality_value(node: AST) -> str | None:

--- a/src/dpmcore/dpm_xl/semantic_analyzer.py
+++ b/src/dpmcore/dpm_xl/semantic_analyzer.py
@@ -833,6 +833,17 @@ class InputAnalyzer(ASTTemplate, ABC):
         if not isinstance(operand, RecordSet):
             raise errors.SemanticError("4-5-0-2", operator=WHERE)
 
+        # A condition on the Fact Component alone needs no open key, so it can
+        # filter a selection on a table that has none. It still needs several
+        # records to choose between: on a single datapoint -- a selection whose
+        # only key components are the implicit globals -- there is nothing to
+        # filter, and the clause would silently do nothing.
+        if (
+            set(node.key_components) == {FACT}
+            and operand.has_only_global_components
+        ):
+            raise errors.SemanticError("4-5-2-3", recordset=operand.name)
+
         self._clause_operands.append(operand)
         try:
             condition = self.visit(node.condition)

--- a/src/dpmcore/errors.py
+++ b/src/dpmcore/errors.py
@@ -241,6 +241,11 @@ centralised_messages: Dict[str, str] = {
         " structure or condition must be a subset"
         " of selection."
     ),
+    "4-5-2-3": (
+        "For where operator, a condition on the fact"
+        " component requires recordset {recordset} to"
+        " have at least one key component."
+    ),
     # -- Sub
     "4-5-3-1": (
         "For sub operator, property code"

--- a/tests/integration/validation/test_semantic_with_where.py
+++ b/tests/integration/validation/test_semantic_with_where.py
@@ -1,0 +1,132 @@
+"""Issue #281 -- the ``where`` block of a ``with`` clause, against the real
+dictionary.
+
+The clause used to be parsed and thrown away, so it filtered nothing and
+raised nothing. Now it is grafted onto every body selection (§3.2.5), which
+means each selection is validated against it individually: a selection whose
+table does not carry the referenced component is an error, not a silent
+no-op.
+"""
+
+import json
+
+from dpmcore.dpm_xl.utils.serialization import serialize_ast
+from dpmcore.services.semantic import SemanticService
+
+RELEASE = "4.2.1"
+
+# C_08.01.a carries the open key ``qEEA``; C_01.00 has no open keys at all.
+KEYED = "tC_08.01.a, r0010"
+UNKEYED = "tC_01.00"
+
+
+def _validate(session, expression):
+    return SemanticService(session).validate(expression, release_code=RELEASE)
+
+
+def test_with_level_where_is_valid(fixture_session):
+    """A clause naming an open key of the body's table validates."""
+    expression = (
+        f"with {{{KEYED}}}[where qEEA = [eba_qAE:qx2023]]:"
+        " {c0250} + {c0260} >= 0"
+    )
+    result = _validate(fixture_session, expression)
+    assert result.is_valid, result.error_message
+
+
+def test_payload_matches_the_explicit_per_operand_form(fixture_session):
+    """The engine receives exactly the filter dpmcore validated.
+
+    Comparing against the hand-written form pins the whole enriched
+    payload -- cell ``data`` arrays included -- not just the presence of a
+    ``WhereClauseOp``.
+    """
+    implicit = SemanticService(fixture_session)
+    assert implicit.validate(
+        f"with {{{KEYED}}}[where qEEA = [eba_qAE:qx2023]]:"
+        " {c0250} + {c0260} >= 0",
+        release_code=RELEASE,
+    ).is_valid
+
+    explicit = SemanticService(fixture_session)
+    assert explicit.validate(
+        "{tC_08.01.a, r0010, c0250}[where qEEA = [eba_qAE:qx2023]] + "
+        "{tC_08.01.a, r0010, c0260}[where qEEA = [eba_qAE:qx2023]] >= 0",
+        release_code=RELEASE,
+    ).is_valid
+
+    assert json.dumps(
+        serialize_ast(implicit.ast), sort_keys=True, default=str
+    ) == json.dumps(serialize_ast(explicit.ast), sort_keys=True, default=str)
+
+
+def test_selection_on_a_table_without_the_component_yields_2_8(
+    fixture_session,
+):
+    """§3.2.5: a selection the clause cannot apply to is an error.
+
+    C_01.00 has no ``qEEA``. The same body without the block is valid, so
+    the rejection comes from the clause now being applied rather than
+    dropped.
+    """
+    body = "{c0250} = {tC_01.00, r0010, c0010}"
+
+    unfiltered = _validate(fixture_session, f"with {{{KEYED}}}: {body}")
+    assert unfiltered.is_valid, unfiltered.error_message
+
+    filtered = _validate(
+        fixture_session,
+        f"with {{{KEYED}}}[where qEEA = [eba_qAE:qx2023]]: {body}",
+    )
+    assert not filtered.is_valid
+    assert filtered.error_code == "2-8"
+
+
+def test_unknown_property_yields_1_5(fixture_session):
+    """A property with no dictionary row is caught by the operands pass."""
+    result = _validate(
+        fixture_session,
+        f"with {{{KEYED}}}[where qZZZZ = 1]: {{c0250}} >= 0",
+    )
+    assert not result.is_valid
+    assert result.error_code == "1-5"
+
+
+def test_fact_only_clause_applies_without_open_keys(fixture_session):
+    """Issue #266 amendment: ``f`` needs no open key on the table.
+
+    C_01.00 declares none, and the body selection still spans rows, so the
+    filter has records to choose between.
+    """
+    result = _validate(
+        fixture_session,
+        f"with {{{UNKEYED}}}[where f > 0]: sum({{c0010}}) >= 0",
+    )
+    assert result.is_valid, result.error_message
+
+
+def test_fact_only_clause_on_a_single_datapoint_yields_4_5_2_3(
+    fixture_session,
+):
+    """The selection must still be a recordset, not a Scalar.
+
+    ``{tC_01.00, r0010, c0010}`` is one datapoint -- its only key components
+    are the implicit globals -- so there is nothing for the filter to do.
+    """
+    result = _validate(
+        fixture_session,
+        f"with {{{UNKEYED}, r0010}}[where f > 0]: {{c0010}} >= 0",
+    )
+    assert not result.is_valid
+    assert result.error_code == "4-5-2-3"
+
+
+def test_operand_level_fact_clause_on_a_single_datapoint_also_rejected(
+    fixture_session,
+):
+    """The guard is on the clause, so both spellings behave alike."""
+    result = _validate(
+        fixture_session, "{tC_01.00, r0010, c0010}[where f > 0] >= 0"
+    )
+    assert not result.is_valid
+    assert result.error_code == "4-5-2-3"

--- a/tests/unit/ast/test_with_where_clause.py
+++ b/tests/unit/ast/test_with_where_clause.py
@@ -1,17 +1,59 @@
-"""Regression test for ``with { } [ where ]: body`` expression parsing.
+"""Parsing of the ``[where ...]`` block of a ``with`` clause.
 
-Bug: ``visitWithExpression`` hard-coded ``ctx_list[3]`` as the body
-expression.  When the optional ``[ WHERE expression ]`` block is present,
-ctx_list[3] is the WHERE terminal node, not the body.  Visiting a terminal
-node returns None, so ``WithExpression.expression`` was None, and the
-semantic analyzer then called ``self.visit(None)`` which raised
-``NotImplementedError: No visit_NoneType method``.
+Two defects, both in ``visitExprWithSelection``:
 
-The fix uses ``ctx_list[-1]`` which is always the body expression.
+Issue #281 -- the block was consumed by the parser and then discarded. The
+node had no field for the condition and the constructor read only the
+partial selection and the body, so the clause filtered nothing and no error
+was raised: the engine payload was byte-identical to the same expression
+written without the filter.
+
+The earlier one -- the body was read from a hard-coded ``ctx_list[3]``. With
+the optional block present that index lands on the WHERE terminal, so
+``WithExpression.expression`` came out None and the semantic analyzer then
+raised ``NotImplementedError: No visit_NoneType method``. The fix uses
+``ctx_list[-1]``, which is the body in both cases.
+
+The clause is now captured and grafted onto every body selection, so
+``with {tX}[where A = 1]: {c0010} = {c0020}`` builds exactly the AST of
+``with {tX}: {c0010}[where A = 1] = {c0020}[where A = 1]`` (DPM-XL §3.2.5),
+unless an operand carries its own ``where`` or ``sub`` (§3.2.6).
 """
 
-from dpmcore.dpm_xl.ast.nodes import Start, WithExpression
+from typing import Any
+
+from dpmcore.dpm_xl.ast.nodes import (
+    AggregationOp,
+    CondExpr,
+    GetOp,
+    RenameOp,
+    Start,
+    SubOp,
+    TimeShiftOp,
+    VarID,
+    WhereClauseOp,
+    WithExpression,
+)
+from dpmcore.dpm_xl.utils.serialization import serialize_ast
 from dpmcore.services.syntax import SyntaxService
+
+CONDITION = "id1 = 1"
+
+
+def _with_expression(expression: str) -> WithExpression:
+    """Parse ``expression`` and return its ``WithExpression`` root."""
+    ast = SyntaxService().parse(expression)
+    assert isinstance(ast, Start)
+    with_expr = ast.children[0]
+    assert isinstance(with_expr, WithExpression)
+    return with_expr
+
+
+def _dimension_codes(node: Any) -> list[str]:
+    """Dimension codes of the where condition wrapping ``node``, if any."""
+    if not isinstance(node, WhereClauseOp):
+        return []
+    return [node.condition.left.dimension_code]
 
 
 def test_with_where_clause_body_is_not_none() -> None:
@@ -21,8 +63,156 @@ def test_with_where_clause_body_is_not_none() -> None:
         " [where qPYB = [eba_qIA:qx2090]]:"
         " {r0100} >= 0"
     )
-    ast = SyntaxService().parse(expression)
-    assert isinstance(ast, Start)
-    with_expr = ast.children[0]
-    assert isinstance(with_expr, WithExpression)
-    assert with_expr.expression is not None
+    assert _with_expression(expression).expression is not None
+
+
+def test_condition_is_stored_on_the_node() -> None:
+    """The condition survives parsing instead of being discarded."""
+    with_expr = _with_expression(
+        f"with {{tX}}[where {CONDITION}]: {{c0010}} = {{c0020}}"
+    )
+    condition = with_expr.where_condition
+    assert condition is not None
+    assert condition.op == "="
+    assert condition.left.dimension_code == "id1"
+
+
+def test_no_where_block_leaves_the_body_untouched() -> None:
+    """Expressions without the block keep their previous AST exactly."""
+    with_expr = _with_expression("with {tX}: {c0010} = {c0020}")
+    assert with_expr.where_condition is None
+    assert isinstance(with_expr.expression.left, VarID)
+    assert isinstance(with_expr.expression.right, VarID)
+
+
+def test_clause_is_grafted_onto_every_body_selection() -> None:
+    """§3.2.5: the clause reaches every operand from a selection operator."""
+    body = _with_expression(
+        f"with {{tX}}[where {CONDITION}]: {{c0010}} = {{c0020}}"
+    ).expression
+    for side in (body.left, body.right):
+        assert isinstance(side, WhereClauseOp)
+        assert isinstance(side.operand, VarID)
+        assert _dimension_codes(side) == ["id1"]
+
+
+def test_each_selection_gets_its_own_copy_of_the_condition() -> None:
+    """Sharing one subtree would let the passes annotate over each other.
+
+    ``OperandsChecking`` writes ``property_id`` onto condition nodes and
+    ``MLGeneration`` writes ``parent``/``argument``/``num``, all in place.
+    """
+    with_expr = _with_expression(
+        f"with {{tX}}[where {CONDITION}]: {{c0010}} = {{c0020}}"
+    )
+    left, right = with_expr.expression.left, with_expr.expression.right
+    assert left.condition is not right.condition
+    assert left.condition is not with_expr.where_condition
+    assert serialize_ast(left.condition) == serialize_ast(right.condition)
+
+
+def test_inner_where_overrides_the_clause_for_that_operand() -> None:
+    """§3.2.6: an operand's own where wins, even naming another property."""
+    body = _with_expression(
+        f"with {{tX}}[where {CONDITION}]: {{c0010}}[where id2 = 2] = {{c0020}}"
+    ).expression
+    assert _dimension_codes(body.left) == ["id2"]
+    assert _dimension_codes(body.right) == ["id1"]
+
+
+def test_inner_sub_overrides_the_clause_for_that_operand() -> None:
+    """§3.2.6: a ``sub`` overrides the clause just as a ``where`` does."""
+    body = _with_expression(
+        f"with {{tX}}[where {CONDITION}]: {{c0010}}[sub id2 = 2] = {{c0020}}"
+    ).expression
+    assert isinstance(body.left, SubOp)
+    assert isinstance(body.left.operand, VarID)
+    assert _dimension_codes(body.right) == ["id1"]
+
+
+def test_override_survives_a_clause_chained_after_the_inner_where() -> None:
+    """``[where ...][get ...]`` still counts as an override."""
+    body = _with_expression(
+        f"with {{tX}}[where {CONDITION}]:"
+        f" {{c0010}}[where id2 = 2][get id3] = 0"
+    ).expression
+    assert isinstance(body.left, GetOp)
+    assert _dimension_codes(body.left.operand) == ["id2"]
+
+
+def test_graft_sits_inside_get_and_rename() -> None:
+    """Filter before projecting or renaming.
+
+    The condition names the components the operand had before the clause
+    reshaped it, so the where has to be the inner node.
+    """
+    get_body = _with_expression(
+        f"with {{tX}}[where {CONDITION}]: {{c0010}}[get id2] = 0"
+    ).expression
+    assert isinstance(get_body.left, GetOp)
+    assert _dimension_codes(get_body.left.operand) == ["id1"]
+
+    rename_body = _with_expression(
+        f"with {{tX}}[where {CONDITION}]: {{c0010}}[rename id2 to id3] = 0"
+    ).expression
+    assert isinstance(rename_body.left, RenameOp)
+    assert _dimension_codes(rename_body.left.operand) == ["id1"]
+
+
+def test_graft_reaches_selections_nested_in_operators() -> None:
+    """Aggregations, time shifts and every branch of a conditional."""
+    aggr = _with_expression(
+        f"with {{tX}}[where {CONDITION}]: sum({{c0010}}) = 0"
+    ).expression
+    assert isinstance(aggr.left, AggregationOp)
+    assert _dimension_codes(aggr.left.operand) == ["id1"]
+
+    shift = _with_expression(
+        f"with {{tX}}[where {CONDITION}]: time_shift({{c0010}}, Q, 1) = 0"
+    ).expression
+    assert isinstance(shift.left, TimeShiftOp)
+    assert _dimension_codes(shift.left.operand) == ["id1"]
+
+    cond = _with_expression(
+        f"with {{tX}}[where {CONDITION}]:"
+        f" if {{c0010}} > 0 then {{c0020}} else {{c0030}} endif = 1"
+    ).expression.left
+    assert isinstance(cond, CondExpr)
+    assert _dimension_codes(cond.condition.left) == ["id1"]
+    assert _dimension_codes(cond.then_expr) == ["id1"]
+    assert _dimension_codes(cond.else_expr) == ["id1"]
+
+
+def test_payload_differs_from_the_unfiltered_expression() -> None:
+    """The reported symptom: identical payloads with and without the block."""
+    parse = SyntaxService().parse
+    with_filter = 'with {tEXM, r0010}[where id1 = "ABC"]: {c0010} = {c0020}'
+    no_filter = "with {tEXM, r0010}: {c0010} = {c0020}"
+    assert serialize_ast(parse(with_filter)) != serialize_ast(parse(no_filter))
+
+
+def test_payload_matches_the_explicit_per_operand_form() -> None:
+    """The clause desugars to what the author would have written by hand."""
+    parse = SyntaxService().parse
+    implicit = 'with {tEXM, r0010}[where id1 = "ABC"]: {c0010} = {c0020}'
+    explicit = (
+        'with {tEXM, r0010}: {c0010}[where id1 = "ABC"]'
+        ' = {c0020}[where id1 = "ABC"]'
+    )
+    assert serialize_ast(parse(implicit)) == serialize_ast(parse(explicit))
+
+
+def test_payload_emits_a_where_clause_op_per_selection() -> None:
+    """Wire shape the engine expects, with no new ``class_name``."""
+    payload = serialize_ast(
+        SyntaxService().parse(
+            'with {tEXM, r0010}[where id1 = "ABC"]: {c0010} = {c0020}'
+        )
+    )
+    for side in (payload["left"], payload["right"]):
+        assert side["class_name"] == "WhereClauseOp"
+        assert side["operand"]["class_name"] == "VarID"
+        assert side["condition"]["left"] == {
+            "class_name": "Dimension",
+            "dimension_code": "id1",
+        }


### PR DESCRIPTION
## Summary

Closes #281

DPM-XL allows a `with` clause to carry a filter — `with partial_selection [where_expression]: expression` — which then applies to every operand arising from a selection operator inside the body, unless a more specific `where` or `sub` inside the body overrides it.

The grammar accepted the block and the expression parsed without error, but the AST node had no field for the condition and the constructor read only the partial selection and the body. The clause was silently dropped: it filtered nothing, raised nothing, and the generated engine payload contained no trace of it.

### The condition is captured and desugared

`ASTConstructor.visitExprWithSelection` stores it on `WithExpression.where_condition` and grafts a copy onto each body selection as an ordinary `WhereClauseOp`. These two spellings now build the same AST and serialize to the same payload:

```
with {tX}[where qEEA = [eba_qAE:qx2023]]: {c0250} + {c0260} >= 0
with {tX}: {c0250}[where qEEA = [eba_qAE:qx2023]]
         + {c0260}[where qEEA = [eba_qAE:qx2023]] >= 0
```

Desugaring at parse time means one implementation and one call site. Every downstream pass already handles `WhereClauseOp` — `OperandsChecking` (which populates `key_components`), `InputAnalyzer`, `MLGeneration`, `ModuleDependencies`, `ASTToJSONVisitor` — so semantic validation, scope, the engine payload and `serialize_ast` all became correct without further change. It also covers `ScopeCalculatorService`, which re-parses and re-runs `OperandsChecking` independently of `SemanticService.validate`.

### Override rules

The graft stops at a `WhereClauseOp` or `SubOp` without descending, so an operand's own clause overrides the `with`-level one in full — even when it names different properties — and the override survives a clause chained after it (`{c1}[where B = 2][get C]`). Overriding is per operand: in `{c1}[where B = 2] = {c2}`, only `{c2}` receives the clause.

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [x] Documentation updated 

## Impact / Risk

- **Breaking changes? (public API / CLI / REST endpoints / Django models)** None.
- **Database schema or migration concerns?** None.
- **Notes for release/changelog?** A `with`-level `where` now reaches the engine. Scripts regenerated after this change will differ for any rule using the form. No engine release is required — `WhereClauseOp` is already in the engine's AST `class_name` enum.

## Notes

- Based on `cr-266` (#280) and must merge after it. Open this PR against `cr-266`. The two branches touch disjoint files apart from this branch's own additions.
