### PR TITLE
Reject duplicate persistent-assignment targets in a script

### DIFF
--- a/src/dpmcore/dpm_xl/model_queries.py
+++ b/src/dpmcore/dpm_xl/model_queries.py
@@ -58,6 +58,8 @@ from dpmcore.orm.release_sort_order import (
 from dpmcore.orm.rendering import (
     Cell,
     HeaderVersion,
+    TableGroup,
+    TableGroupComposition,
     TableVersion,
     TableVersionCell,
     TableVersionHeader,
@@ -619,6 +621,64 @@ class TableVersionQuery:
                 )
             )
         return query.first() is not None
+
+
+class TableGroupQuery:
+    """Query helpers around the TableGroup/TableGroupComposition models."""
+
+    @staticmethod
+    def get_member_table_codes(
+        session: "Session",
+        group_code: str,
+        release_id: int | None,
+    ) -> set[str]:
+        """Return the table-version codes belonging to a table group.
+
+        Args:
+            session: SQLAlchemy session.
+            group_code: The table group's code.
+            release_id: Release filter.
+
+        Returns:
+            The set of member table-version codes at that release.
+        """
+        group_ids = [
+            gid
+            for (gid,) in filter_by_release(
+                session.query(TableGroup.table_group_id).filter(
+                    TableGroup.code == group_code
+                ),
+                start_col=TableGroup.start_release_id,
+                end_col=TableGroup.end_release_id,
+                release_id=release_id,
+            ).all()
+        ]
+        if not group_ids:
+            return set()
+
+        table_ids = [
+            tid
+            for (tid,) in filter_by_release(
+                session.query(TableGroupComposition.table_id).filter(
+                    TableGroupComposition.table_group_id.in_(group_ids)
+                ),
+                start_col=TableGroupComposition.start_release_id,
+                end_col=TableGroupComposition.end_release_id,
+                release_id=release_id,
+            ).all()
+        ]
+        if not table_ids:
+            return set()
+
+        codes = filter_by_release(
+            session.query(TableVersion.code).filter(
+                TableVersion.table_id.in_(table_ids)
+            ),
+            start_col=TableVersion.start_release_id,
+            end_col=TableVersion.end_release_id,
+            release_id=release_id,
+        ).all()
+        return {code for (code,) in codes if code is not None}
 
 
 # ------------------------------------------------------------------ #

--- a/src/dpmcore/dpm_xl/semantic_analyzer.py
+++ b/src/dpmcore/dpm_xl/semantic_analyzer.py
@@ -118,7 +118,7 @@ _PARAMETER_SCALAR_TYPES: dict[str, str] = {
 
 def _check_duplicate_persistent_assignments(children: list[AST]) -> None:
     """Raise ``6-1`` when two statements assign the same ``{cellRef}``/``{varRef}``."""
-    seen: dict[tuple[Any, ...], str] = {}
+    seen: set[tuple[Any, ...]] = set()
     for child in children:
         target = child
         if isinstance(target, TemporaryAssignment):
@@ -153,7 +153,7 @@ def _check_duplicate_persistent_assignments(children: list[AST]) -> None:
             continue
         if key in seen:
             raise errors.SemanticError("6-1", variable=variable)
-        seen[key] = variable
+        seen.add(key)
 
 
 class InputAnalyzer(ASTTemplate, ABC):

--- a/src/dpmcore/dpm_xl/semantic_analyzer.py
+++ b/src/dpmcore/dpm_xl/semantic_analyzer.py
@@ -2,6 +2,7 @@ from abc import ABC
 from typing import Any, cast
 
 import pandas as pd
+from sqlalchemy.orm import Session
 
 from dpmcore import errors
 from dpmcore.dpm_xl.ast.nodes import (
@@ -50,6 +51,7 @@ from dpmcore.dpm_xl.ast.where_clause import (
     collect_where_equality_pins,
     merge_where_constraints,
 )
+from dpmcore.dpm_xl.model_queries import ViewDatapointsQuery
 from dpmcore.dpm_xl.operators.clause import Sub as SubOperator
 from dpmcore.dpm_xl.symbols import (
     Component,
@@ -116,44 +118,94 @@ _PARAMETER_SCALAR_TYPES: dict[str, str] = {
 }
 
 
-def _check_duplicate_persistent_assignments(children: list[AST]) -> None:
+def _check_duplicate_persistent_assignments(
+    children: list[AST],
+    session: Session | None,
+    release_id: int | None,
+) -> None:
     """Raise ``6-1`` when two statements assign the same ``{cellRef}``/``{varRef}``."""
-    seen: set[tuple[Any, ...]] = set()
+    seen_refs: set[str] = set()
+    seen_ids: list[VarID] = []
     for child in children:
-        target = child
-        if isinstance(target, TemporaryAssignment):
-            target = target.right
+        target = (
+            child.right if isinstance(child, TemporaryAssignment) else child
+        )
         if not isinstance(target, PersistentAssignment):
             continue
         left = target.left
-        if isinstance(left, VarID):
-            key: tuple[Any, ...] = (
-                "VarID",
-                left.table,
-                left.operation,
-                left.is_table_group,
-                frozenset(left.rows) if left.rows else None,
-                frozenset(left.cols) if left.cols else None,
-                frozenset(left.sheets) if left.sheets else None,
-            )
-            head = f"o{left.operation}" if left.operation else left.table
-            parts = [head]
-            if left.rows:
-                parts.append(", ".join(f"r{row}" for row in left.rows))
-            if left.cols:
-                parts.append(", ".join(f"c{col}" for col in left.cols))
-            if left.sheets:
-                parts.append(", ".join(f"s{sheet}" for sheet in left.sheets))
-            variable = ", ".join(part for part in parts if part)
-        elif isinstance(left, VarRef):
-            key = ("VarRef", left.variable)
-            variable = left.variable
-        else:
+        if isinstance(left, VarRef):
+            if left.variable in seen_refs:
+                raise errors.SemanticError("6-1", variable=left.variable)
+            seen_refs.add(left.variable)
+            continue
+        if not isinstance(left, VarID):
             # assignmentTarget only ever produces a VarID or a VarRef
             continue
-        if key in seen:
-            raise errors.SemanticError("6-1", variable=variable)
-        seen.add(key)
+        if left.table is None and left.operation is None:
+            # No table/operation to identify this target by, never compare it.
+            continue
+
+        head = f"o{left.operation}" if left.operation else left.table
+        parts = [head]
+        if left.rows:
+            parts.append(", ".join(f"r{row}" for row in left.rows))
+        if left.cols:
+            parts.append(", ".join(f"c{col}" for col in left.cols))
+        if left.sheets:
+            parts.append(", ".join(f"s{sheet}" for sheet in left.sheets))
+        variable = ", ".join(part for part in parts if part)
+
+        for other in seen_ids:
+            if (
+                other.table != left.table
+                or other.operation != left.operation
+                or other.is_table_group != left.is_table_group
+            ):
+                continue
+            # Operation/table-group refs keep exact-match, only plain table refs resolve via the DB below
+            if (
+                session is not None
+                and left.operation is None
+                and not left.is_table_group
+            ):
+                table = cast(str, left.table)
+                df_other = ViewDatapointsQuery.get_table_data(
+                    session,
+                    table,
+                    other.rows,
+                    other.cols,
+                    other.sheets,
+                    release_id,
+                )
+                df_left = ViewDatapointsQuery.get_table_data(
+                    session,
+                    table,
+                    left.rows,
+                    left.cols,
+                    left.sheets,
+                    release_id,
+                )
+                collides = (
+                    not df_other.empty
+                    and not df_left.empty
+                    and (
+                        not set(df_other["cell_code"]).isdisjoint(
+                            df_left["cell_code"]
+                        )
+                    )
+                )
+            else:
+                collides = (
+                    (frozenset(other.rows) if other.rows else None)
+                    == (frozenset(left.rows) if left.rows else None)
+                    and (frozenset(other.cols) if other.cols else None)
+                    == (frozenset(left.cols) if left.cols else None)
+                    and (frozenset(other.sheets) if other.sheets else None)
+                    == (frozenset(left.sheets) if left.sheets else None)
+                )
+            if collides:
+                raise errors.SemanticError("6-1", variable=variable)
+        seen_ids.append(left)
 
 
 class InputAnalyzer(ASTTemplate, ABC):
@@ -165,6 +217,12 @@ class InputAnalyzer(ASTTemplate, ABC):
         self.result: bool = False
         self._expression: str = expression  # For debugging purposes only
         self.preconditions: bool = False
+        # Only set by SemanticService.validate(); a bare InputAnalyzer (as
+        # constructed directly in unit tests) has neither, so the
+        # duplicate-assignment guard below falls back to exact-match
+        # comparison instead of resolving ranges/wildcards against the DB.
+        self.session: Session | None = None
+        self.release_id: int | None = None
 
         self.calculations_outputs: dict[str, Operand] = {}
 
@@ -188,7 +246,9 @@ class InputAnalyzer(ASTTemplate, ABC):
         self, node: Start
     ) -> Operand | list[Operand]:
 
-        _check_duplicate_persistent_assignments(node.children)
+        _check_duplicate_persistent_assignments(
+            node.children, self.session, self.release_id
+        )
 
         result: list[Operand] = []
         for child in node.children:

--- a/src/dpmcore/dpm_xl/semantic_analyzer.py
+++ b/src/dpmcore/dpm_xl/semantic_analyzer.py
@@ -130,11 +130,14 @@ def _check_duplicate_persistent_assignments(children: list[AST]) -> None:
             key: tuple[Any, ...] = (
                 "VarID",
                 left.table,
+                left.operation,
+                left.is_table_group,
                 tuple(sorted(left.rows)) if left.rows else None,
                 tuple(sorted(left.cols)) if left.cols else None,
                 tuple(sorted(left.sheets)) if left.sheets else None,
             )
-            parts = [left.table]
+            head = f"o{left.operation}" if left.operation else left.table
+            parts = [head]
             if left.rows:
                 parts.append(", ".join(f"r{row}" for row in left.rows))
             if left.cols:

--- a/src/dpmcore/dpm_xl/semantic_analyzer.py
+++ b/src/dpmcore/dpm_xl/semantic_analyzer.py
@@ -143,6 +143,7 @@ def _check_duplicate_persistent_assignments(children: list[AST]) -> None:
             key = ("VarRef", left.variable)
             variable = left.variable
         else:
+            # assignmentTarget only ever produces a VarID or a VarRef
             continue
         if key in seen:
             raise errors.SemanticError("6-1", variable=variable)

--- a/src/dpmcore/dpm_xl/semantic_analyzer.py
+++ b/src/dpmcore/dpm_xl/semantic_analyzer.py
@@ -5,6 +5,7 @@ import pandas as pd
 
 from dpmcore import errors
 from dpmcore.dpm_xl.ast.nodes import (
+    AST,
     AggregationOp,
     AnnualiseOp,
     BinOp,
@@ -115,6 +116,39 @@ _PARAMETER_SCALAR_TYPES: dict[str, str] = {
 }
 
 
+def _check_duplicate_persistent_assignments(children: list[AST]) -> None:
+    """Raise ``6-1`` when two statements assign the same ``{cellRef}``/``{varRef}``."""
+    seen: dict[tuple[Any, ...], str] = {}
+    for child in children:
+        if not isinstance(child, PersistentAssignment):
+            continue
+        left = child.left
+        if isinstance(left, VarID):
+            key: tuple[Any, ...] = (
+                "VarID",
+                left.table,
+                tuple(left.rows) if left.rows else None,
+                tuple(left.cols) if left.cols else None,
+                tuple(left.sheets) if left.sheets else None,
+            )
+            parts = [left.table]
+            if left.rows:
+                parts.append(", ".join(f"r{row}" for row in left.rows))
+            if left.cols:
+                parts.append(", ".join(f"c{col}" for col in left.cols))
+            if left.sheets:
+                parts.append(", ".join(f"s{sheet}" for sheet in left.sheets))
+            variable = ", ".join(part for part in parts if part)
+        elif isinstance(left, VarRef):
+            key = ("VarRef", left.variable)
+            variable = left.variable
+        else:
+            continue
+        if key in seen:
+            raise errors.SemanticError("6-1", variable=variable)
+        seen[key] = variable
+
+
 class InputAnalyzer(ASTTemplate, ABC):
     def __init__(self, expression: str) -> None:
         super().__init__()
@@ -146,6 +180,8 @@ class InputAnalyzer(ASTTemplate, ABC):
     def visit_Start(  # type: ignore[override]
         self, node: Start
     ) -> Operand | list[Operand]:
+
+        _check_duplicate_persistent_assignments(node.children)
 
         result: list[Operand] = []
         for child in node.children:

--- a/src/dpmcore/dpm_xl/semantic_analyzer.py
+++ b/src/dpmcore/dpm_xl/semantic_analyzer.py
@@ -130,9 +130,9 @@ def _check_duplicate_persistent_assignments(children: list[AST]) -> None:
             key: tuple[Any, ...] = (
                 "VarID",
                 left.table,
-                tuple(left.rows) if left.rows else None,
-                tuple(left.cols) if left.cols else None,
-                tuple(left.sheets) if left.sheets else None,
+                tuple(sorted(left.rows)) if left.rows else None,
+                tuple(sorted(left.cols)) if left.cols else None,
+                tuple(sorted(left.sheets)) if left.sheets else None,
             )
             parts = [left.table]
             if left.rows:

--- a/src/dpmcore/dpm_xl/semantic_analyzer.py
+++ b/src/dpmcore/dpm_xl/semantic_analyzer.py
@@ -51,7 +51,7 @@ from dpmcore.dpm_xl.ast.where_clause import (
     collect_where_equality_pins,
     merge_where_constraints,
 )
-from dpmcore.dpm_xl.model_queries import ViewDatapointsQuery
+from dpmcore.dpm_xl.model_queries import TableGroupQuery, ViewDatapointsQuery
 from dpmcore.dpm_xl.operators.clause import Sub as SubOperator
 from dpmcore.dpm_xl.symbols import (
     Component,
@@ -156,19 +156,28 @@ def _check_duplicate_persistent_assignments(
         variable = ", ".join(part for part in parts if part)
 
         for other in seen_ids:
-            if (
-                other.table != left.table
-                or other.operation != left.operation
-                or other.is_table_group != left.is_table_group
-            ):
+            if other.operation != left.operation:
                 continue
-            # Operation/table-group refs keep exact-match, only plain table refs resolve via the DB below
-            if (
-                session is not None
-                and left.operation is None
-                and not left.is_table_group
-            ):
-                table = cast(str, left.table)
+            if other.is_table_group == left.is_table_group:
+                if other.table != left.table:
+                    continue
+                # A group has no member table to resolve rows/cols against, so it keeps the exact-match below
+                table = left.table if not left.is_table_group else None
+            elif session is not None and left.operation is None:
+                # Group vs. plain table: only comparable if the table is an actual member of the group
+                group_side, plain_side = (
+                    (other, left) if other.is_table_group else (left, other)
+                )
+                member_codes = TableGroupQuery.get_member_table_codes(
+                    session, cast(str, group_side.table), release_id
+                )
+                if plain_side.table not in member_codes:
+                    continue
+                table = plain_side.table
+            else:
+                continue
+
+            if session is not None and left.operation is None and table:
                 df_other = ViewDatapointsQuery.get_table_data(
                     session,
                     table,

--- a/src/dpmcore/dpm_xl/semantic_analyzer.py
+++ b/src/dpmcore/dpm_xl/semantic_analyzer.py
@@ -120,9 +120,12 @@ def _check_duplicate_persistent_assignments(children: list[AST]) -> None:
     """Raise ``6-1`` when two statements assign the same ``{cellRef}``/``{varRef}``."""
     seen: dict[tuple[Any, ...], str] = {}
     for child in children:
-        if not isinstance(child, PersistentAssignment):
+        target = child
+        if isinstance(target, TemporaryAssignment):
+            target = target.right
+        if not isinstance(target, PersistentAssignment):
             continue
-        left = child.left
+        left = target.left
         if isinstance(left, VarID):
             key: tuple[Any, ...] = (
                 "VarID",

--- a/src/dpmcore/dpm_xl/semantic_analyzer.py
+++ b/src/dpmcore/dpm_xl/semantic_analyzer.py
@@ -132,9 +132,9 @@ def _check_duplicate_persistent_assignments(children: list[AST]) -> None:
                 left.table,
                 left.operation,
                 left.is_table_group,
-                tuple(sorted(left.rows)) if left.rows else None,
-                tuple(sorted(left.cols)) if left.cols else None,
-                tuple(sorted(left.sheets)) if left.sheets else None,
+                frozenset(left.rows) if left.rows else None,
+                frozenset(left.cols) if left.cols else None,
+                frozenset(left.sheets) if left.sheets else None,
             )
             head = f"o{left.operation}" if left.operation else left.table
             parts = [head]

--- a/src/dpmcore/services/semantic.py
+++ b/src/dpmcore/services/semantic.py
@@ -252,6 +252,8 @@ class SemanticService:
                 analyzer.key_components = oc.key_components
                 analyzer.open_keys = oc.open_keys
                 analyzer.preconditions = oc.preconditions
+                analyzer.session = self.session
+                analyzer.release_id = release_id
 
                 results = analyzer.visit(ast)
 

--- a/tests/integration/validation/test_semantic_release.py
+++ b/tests/integration/validation/test_semantic_release.py
@@ -584,3 +584,55 @@ def test_same_operation_ref_target_rejected(fixture_session):
 
     assert not result.is_valid, "Expected invalid, but validation passed"
     assert result.error_code == "6-1"
+
+
+def test_wildcard_target_overlapping_specific_row_rejected(fixture_session):
+    """A row wildcard target covers every row, including one assigned elsewhere."""
+    script = "{tF_01.01, r*, c0010} <- 1; {tF_01.01, r0010, c0010} <- 2;"
+    svc = SemanticService(fixture_session)
+    result = svc.validate(script, release_code="4.2.1")
+
+    assert not result.is_valid, "Expected invalid, but validation passed"
+    assert result.error_code == "6-1"
+
+
+def test_row_range_overlapping_enumerated_rows_rejected(fixture_session):
+    """A row range and the same rows spelled out individually are one target."""
+    script = (
+        "{tF_01.01, r0010-0030, c0010} <- 1; "
+        "{tF_01.01, (r0010, r0020, r0030), c0010} <- 2;"
+    )
+    svc = SemanticService(fixture_session)
+    result = svc.validate(script, release_code="4.2.1")
+
+    assert not result.is_valid, "Expected invalid, but validation passed"
+    assert result.error_code == "6-1"
+
+
+def test_non_overlapping_row_ranges_remain_valid(fixture_session):
+    """Two targets stay distinct when their row ranges don't actually overlap."""
+    script = (
+        "{tF_01.01, r0010-0020, c0010} <- 1; {tF_01.01, r0030, c0010} <- 2;"
+    )
+    svc = SemanticService(fixture_session)
+    result = svc.validate(script, release_code="4.2.1")
+
+    assert result.is_valid, (
+        f"Expected valid, but got error: {result.error_message}"
+    )
+
+
+def test_bare_target_paired_with_different_with_tables_remains_valid(
+    fixture_session,
+):
+    """A table-less target can't be proven to collide across statements."""
+    script = (
+        "{r0010, c0010} <- with {tF_01.01}: {r0020, c0010}; "
+        "{r0010, c0010} <- with {tF_01.02}: {r0020, c0010};"
+    )
+    svc = SemanticService(fixture_session)
+    result = svc.validate(script, release_code="4.2.1")
+
+    assert result.is_valid, (
+        f"Expected valid, but got error: {result.error_message}"
+    )

--- a/tests/integration/validation/test_semantic_release.py
+++ b/tests/integration/validation/test_semantic_release.py
@@ -548,3 +548,24 @@ def test_duplicate_target_with_rows_in_different_order_rejected(fixture_session)
 
     assert not result.is_valid, "Expected invalid, but validation passed"
     assert result.error_code == "6-1"
+
+
+def test_different_operation_ref_targets_are_not_duplicates(fixture_session):
+    """Two operation-ref targets with the same row/col are different cells."""
+    script = "{oOp1, r0010, c0010} <- 1; {oOp2, r0010, c0010} <- 2;"
+    svc = SemanticService(fixture_session)
+    result = svc.validate(script, release_code="4.2.1")
+
+    assert result.is_valid, (
+        f"Expected valid, but got error: {result.error_message}"
+    )
+
+
+def test_same_operation_ref_target_rejected(fixture_session):
+    """The same operation-ref target assigned twice is a genuine duplicate."""
+    script = "{oOp1, r0010, c0010} <- 1; {oOp1, r0010, c0010} <- 2;"
+    svc = SemanticService(fixture_session)
+    result = svc.validate(script, release_code="4.2.1")
+
+    assert not result.is_valid, "Expected invalid, but validation passed"
+    assert result.error_code == "6-1"

--- a/tests/integration/validation/test_semantic_release.py
+++ b/tests/integration/validation/test_semantic_release.py
@@ -636,3 +636,46 @@ def test_bare_target_paired_with_different_with_tables_remains_valid(
     assert result.is_valid, (
         f"Expected valid, but got error: {result.error_message}"
     )
+
+
+def test_group_target_overlapping_member_table_rejected(fixture_session):
+    """A table-group target and one of its real member tables collide."""
+    script = (
+        "{gAdditional_Liquidity_Monitoring, r0010, c0010} <- 1; "
+        "{tC_67.00.a, r0010, c0010} <- 2;"
+    )
+    svc = SemanticService(fixture_session)
+    result = svc.validate(script, release_code="4.2.1")
+
+    assert not result.is_valid, "Expected invalid, but validation passed"
+    assert result.error_code == "6-1"
+
+
+def test_group_target_and_unrelated_table_remain_valid(fixture_session):
+    """A table-group target doesn't collide with a table outside the group."""
+    script = (
+        "{gAdditional_Liquidity_Monitoring, r0010, c0010} <- 1; "
+        "{tF_01.01, r0010, c0010} <- 2;"
+    )
+    svc = SemanticService(fixture_session)
+    result = svc.validate(script, release_code="4.2.1")
+
+    assert result.is_valid, (
+        f"Expected valid, but got error: {result.error_message}"
+    )
+
+
+def test_group_target_overlapping_member_table_different_cell_remains_valid(
+    fixture_session,
+):
+    """A table-group target and a member table stay distinct cells apart."""
+    script = (
+        "{gAdditional_Liquidity_Monitoring, r0010, c0010} <- 1; "
+        "{tC_67.00.a, r0020, c0010} <- 2;"
+    )
+    svc = SemanticService(fixture_session)
+    result = svc.validate(script, release_code="4.2.1")
+
+    assert result.is_valid, (
+        f"Expected valid, but got error: {result.error_message}"
+    )

--- a/tests/integration/validation/test_semantic_release.py
+++ b/tests/integration/validation/test_semantic_release.py
@@ -516,3 +516,22 @@ def test_equality_alias_of_a_different_cell_remains_valid(fixture_session):
     assert result.is_valid, (
         f"Expected valid, but got error: {result.error_message}"
     )
+
+
+def test_duplicate_persistent_assignment_inside_temporary_assignment_rejected(
+    fixture_session,
+):
+    """Also catches ``v := {cell} <- expr``, not just bare cells.
+
+    ``v0172_m``/``v0173_m`` must be real operation codes, else an
+    unrelated check rejects the script first.
+    """
+    script = (
+        "v0172_m := {tF_01.01, r0010, c0010} <- 1; "
+        "v0173_m := {tF_01.01, r0010, c0010} <- 2;"
+    )
+    svc = SemanticService(fixture_session)
+    result = svc.validate(script, release_code="4.2.1")
+
+    assert not result.is_valid, "Expected invalid, but validation passed"
+    assert result.error_code == "6-1"

--- a/tests/integration/validation/test_semantic_release.py
+++ b/tests/integration/validation/test_semantic_release.py
@@ -552,6 +552,19 @@ def test_duplicate_target_with_rows_in_different_order_rejected(
     assert result.error_code == "6-1"
 
 
+def test_duplicate_target_with_repeated_row_rejected(fixture_session):
+    """A repeated row in a list is still just that one row."""
+    script = (
+        "{tF_01.01, (r0010, r0010), c0010} <- 1; "
+        "{tF_01.01, r0010, c0010} <- 2;"
+    )
+    svc = SemanticService(fixture_session)
+    result = svc.validate(script, release_code="4.2.1")
+
+    assert not result.is_valid, "Expected invalid, but validation passed"
+    assert result.error_code == "6-1"
+
+
 def test_different_operation_ref_targets_are_not_duplicates(fixture_session):
     """Two operation-ref targets with the same row/col are different cells."""
     script = "{oOp1, r0010, c0010} <- 1; {oOp2, r0010, c0010} <- 2;"

--- a/tests/integration/validation/test_semantic_release.py
+++ b/tests/integration/validation/test_semantic_release.py
@@ -482,3 +482,37 @@ def test_single_reference_omitting_closed_sheets_axis_rejected(
         f"Expected invalid, got: {result.error_message}"
     )
     assert result.error_code == "1-20"
+
+
+def test_duplicate_persistent_assignment_rejected(fixture_session):
+    """Two independent formulas assigning the same cell must be rejected.
+
+    Regression test for GitHub issue #289: a DPM-XL variable can only have
+    one value per reference period, so two unrelated formulas for the same
+    cell can't both be right.
+    """
+    script = "{tF_01.01, r0010, c0010} <- 1; {tF_01.01, r0010, c0010} <- 2;"
+    svc = SemanticService(fixture_session)
+    result = svc.validate(script, release_code="4.2.1")
+
+    assert not result.is_valid, "Expected invalid, but validation passed"
+    assert result.error_code == "6-1"
+
+
+def test_equality_alias_of_a_different_cell_remains_valid(fixture_session):
+    """A plain equality alias of another cell is not a duplicate output.
+
+    Companion case for GitHub issue #289: aliasing one cell's value into
+    another (``{B} <- {A}``) is a normal dependency, not a conflicting
+    formula for the same output, and must remain valid.
+    """
+    script = (
+        "{tF_01.01, r0010, c0010} <- 1; "
+        "{tF_01.01, r0020, c0010} <- {tF_01.01, r0010, c0010};"
+    )
+    svc = SemanticService(fixture_session)
+    result = svc.validate(script, release_code="4.2.1")
+
+    assert result.is_valid, (
+        f"Expected valid, but got error: {result.error_message}"
+    )

--- a/tests/integration/validation/test_semantic_release.py
+++ b/tests/integration/validation/test_semantic_release.py
@@ -537,7 +537,9 @@ def test_duplicate_persistent_assignment_inside_temporary_assignment_rejected(
     assert result.error_code == "6-1"
 
 
-def test_duplicate_target_with_rows_in_different_order_rejected(fixture_session):
+def test_duplicate_target_with_rows_in_different_order_rejected(
+    fixture_session,
+):
     """Same rows, listed in a different order, are still the same target."""
     script = (
         "{tF_01.01, (r0010, r0020), c0010} <- 1; "

--- a/tests/integration/validation/test_semantic_release.py
+++ b/tests/integration/validation/test_semantic_release.py
@@ -535,3 +535,16 @@ def test_duplicate_persistent_assignment_inside_temporary_assignment_rejected(
 
     assert not result.is_valid, "Expected invalid, but validation passed"
     assert result.error_code == "6-1"
+
+
+def test_duplicate_target_with_rows_in_different_order_rejected(fixture_session):
+    """Same rows, listed in a different order, are still the same target."""
+    script = (
+        "{tF_01.01, (r0010, r0020), c0010} <- 1; "
+        "{tF_01.01, (r0020, r0010), c0010} <- 2;"
+    )
+    svc = SemanticService(fixture_session)
+    result = svc.validate(script, release_code="4.2.1")
+
+    assert not result.is_valid, "Expected invalid, but validation passed"
+    assert result.error_code == "6-1"

--- a/tests/unit/semantic/test_duplicate_persistent_assignment.py
+++ b/tests/unit/semantic/test_duplicate_persistent_assignment.py
@@ -16,6 +16,11 @@ DUPLICATE_TARGET_SCRIPTS = [
         "F_01.01",
     ),
     ("{vFoo} <- 1; {vFoo} <- 2;", "Foo"),
+    (
+        "{tF_01.01, r0010, c0010, s0010} <- 1; "
+        "{tF_01.01, r0010, c0010, s0010} <- 2;",
+        "s0010",
+    ),
 ]
 
 NON_DUPLICATE_SCRIPTS = [

--- a/tests/unit/semantic/test_duplicate_persistent_assignment.py
+++ b/tests/unit/semantic/test_duplicate_persistent_assignment.py
@@ -30,6 +30,12 @@ DUPLICATE_TARGET_SCRIPTS = [
     ),
     # Same operation reference, same row/col
     ("{oOp1, r0010, c0010} <- 1; {oOp1, r0010, c0010} <- 2;", "oOp1"),
+    # A repeated row in a list is still just that one row
+    (
+        "{tF_01.01, (r0010, r0010), c0010} <- 1; "
+        "{tF_01.01, r0010, c0010} <- 2;",
+        "F_01.01",
+    ),
 ]
 
 NON_DUPLICATE_SCRIPTS = [

--- a/tests/unit/semantic/test_duplicate_persistent_assignment.py
+++ b/tests/unit/semantic/test_duplicate_persistent_assignment.py
@@ -51,6 +51,8 @@ NON_DUPLICATE_SCRIPTS = [
     "{oOp1, r0010, c0010} <- 1; {oOp2, r0010, c0010} <- 2;",
     # A table and a same-named table group are different targets
     "{gF_01.01, r0010, c0010} <- 1; {tF_01.01, r0010, c0010} <- 2;",
+    # Bare compRef target has no table, never compared
+    "{r0010, c0010} <- 1; {r0010, c0010} <- 2;",
 ]
 
 

--- a/tests/unit/semantic/test_duplicate_persistent_assignment.py
+++ b/tests/unit/semantic/test_duplicate_persistent_assignment.py
@@ -21,6 +21,7 @@ DUPLICATE_TARGET_SCRIPTS = [
         "{tF_01.01, r0010, c0010, s0010} <- 2;",
         "s0010",
     ),
+    ("v1 := {vFoo} <- 1; v2 := {vFoo} <- 2;", "Foo"),
 ]
 
 NON_DUPLICATE_SCRIPTS = [
@@ -30,6 +31,8 @@ NON_DUPLICATE_SCRIPTS = [
     "{vFoo} <- 1; {vBar} <- 2;",
     # A lone assignment never collides with itself
     "{tF_01.01, r0010, c0010} <- 1;",
+    # Different variable-reference targets, both wrapped in a temp assignment
+    "v1 := {vFoo} <- 1; v2 := {vBar} <- 2;",
 ]
 
 

--- a/tests/unit/semantic/test_duplicate_persistent_assignment.py
+++ b/tests/unit/semantic/test_duplicate_persistent_assignment.py
@@ -1,0 +1,49 @@
+"""Tests for the duplicate-output guard in InputAnalyzer.visit_Start.
+
+Two independent, top-level assignments to the same ``{cellRef}``/``{varRef}``
+must be rejected with error code 6-1 (GitHub issue #289).
+"""
+
+import pytest
+
+from dpmcore.dpm_xl.semantic_analyzer import InputAnalyzer
+from dpmcore.errors import SemanticError
+from dpmcore.services.syntax import SyntaxService
+
+DUPLICATE_TARGET_SCRIPTS = [
+    (
+        "{tF_01.01, r0010, c0010} <- 1; {tF_01.01, r0010, c0010} <- 2;",
+        "F_01.01",
+    ),
+    ("{vFoo} <- 1; {vFoo} <- 2;", "Foo"),
+]
+
+NON_DUPLICATE_SCRIPTS = [
+    # Different cells: a dependency/alias, not a duplicate output
+    "{tF_01.01, r0010, c0010} <- 1; {tF_01.01, r0020, c0010} <- 2;",
+    # Different variable-reference targets
+    "{vFoo} <- 1; {vBar} <- 2;",
+    # A lone assignment never collides with itself
+    "{tF_01.01, r0010, c0010} <- 1;",
+]
+
+
+@pytest.mark.parametrize(
+    ("script", "expected_in_message"), DUPLICATE_TARGET_SCRIPTS
+)
+def test_duplicate_target_raises_6_1(script, expected_in_message):
+    start = SyntaxService().parse(script)
+
+    with pytest.raises(SemanticError) as exc_info:
+        InputAnalyzer(expression=script).visit_Start(start)
+
+    assert exc_info.value.code == "6-1"
+    assert expected_in_message in str(exc_info.value)
+
+
+@pytest.mark.parametrize("script", NON_DUPLICATE_SCRIPTS)
+def test_distinct_targets_are_not_flagged(script):
+    start = SyntaxService().parse(script)
+
+    # No error raised means the guard did not treat these as duplicates
+    InputAnalyzer(expression=script).visit_Start(start)

--- a/tests/unit/semantic/test_duplicate_persistent_assignment.py
+++ b/tests/unit/semantic/test_duplicate_persistent_assignment.py
@@ -28,10 +28,12 @@ DUPLICATE_TARGET_SCRIPTS = [
         "{tF_01.01, (r0020, r0010), c0010} <- 2;",
         "F_01.01",
     ),
+    # Same operation reference, same row/col
+    ("{oOp1, r0010, c0010} <- 1; {oOp1, r0010, c0010} <- 2;", "oOp1"),
 ]
 
 NON_DUPLICATE_SCRIPTS = [
-    # Different cells: a dependency/alias, not a duplicate output
+    # Different cells: distinct outputs, not a duplicate target
     "{tF_01.01, r0010, c0010} <- 1; {tF_01.01, r0020, c0010} <- 2;",
     # Different variable-reference targets
     "{vFoo} <- 1; {vBar} <- 2;",
@@ -39,6 +41,10 @@ NON_DUPLICATE_SCRIPTS = [
     "{tF_01.01, r0010, c0010} <- 1;",
     # Different variable-reference targets, both wrapped in a temp assignment
     "v1 := {vFoo} <- 1; v2 := {vBar} <- 2;",
+    # Different operation references, same row/col
+    "{oOp1, r0010, c0010} <- 1; {oOp2, r0010, c0010} <- 2;",
+    # A table and a same-named table group are different targets
+    "{gF_01.01, r0010, c0010} <- 1; {tF_01.01, r0010, c0010} <- 2;",
 ]
 
 

--- a/tests/unit/semantic/test_duplicate_persistent_assignment.py
+++ b/tests/unit/semantic/test_duplicate_persistent_assignment.py
@@ -22,6 +22,12 @@ DUPLICATE_TARGET_SCRIPTS = [
         "s0010",
     ),
     ("v1 := {vFoo} <- 1; v2 := {vFoo} <- 2;", "Foo"),
+    # Same rows, listed in a different order
+    (
+        "{tF_01.01, (r0010, r0020), c0010} <- 1; "
+        "{tF_01.01, (r0020, r0010), c0010} <- 2;",
+        "F_01.01",
+    ),
 ]
 
 NON_DUPLICATE_SCRIPTS = [


### PR DESCRIPTION
Closes #289 

## Summary

Semantic validation accepted scripts with two independent, conflicting formulas assigning the same `{cellRef}`/`{varRef}` (e.g. `{tF_01.01, r0010, c0010} <- 1; {tF_01.01, r0010, c0010} <- 2;`), even though a DPM-XL variable can only hold one value per reference period.

Added a check in `InputAnalyzer.visit_Start` that raises error `6-1` when two top-level statements target the same output. A dependency between two different cells (`{B} <- {A}`) is unaffected.

## Checklist

- [X] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [X] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [X] Documentation updated (if applicable)

## Impact / Risk

- Breaking changes? (public API / CLI / REST endpoints / Django models)
- Database schema or migration concerns?
- Notes for release/changelog?

## Notes

<!-- Follow-ups, TODOs, or anything reviewers should know. -->
