### PR TITLE
fix(dpm-xl): propagate empty-set type in Equal/NotEqual to avoid Item promotion warning

### DIFF
--- a/src/dpmcore/dpm_xl/operators/comparison.py
+++ b/src/dpmcore/dpm_xl/operators/comparison.py
@@ -13,7 +13,7 @@ from dpmcore.dpm_xl.operators.base import (
     Unary as _BaseUnary,
 )
 from dpmcore.dpm_xl.symbols import RecordSet, Scalar, ScalarSet
-from dpmcore.dpm_xl.types.scalar import Boolean, ScalarType, String
+from dpmcore.dpm_xl.types.scalar import Boolean, Item, ScalarType, String
 from dpmcore.dpm_xl.utils import tokens
 from dpmcore.errors import SemanticError
 
@@ -50,6 +50,25 @@ def _reject_scalarset_mixed_with_recordset(
         )
 
 
+def _is_empty_set_placeholder(op: BinaryOperand) -> bool:
+    """True only for the empty set literal ``{}``.
+
+    ``visit_Set`` builds the origin string by joining stringified
+    children with ``", "``, so the singleton ``{""}`` (a set with one
+    empty string element) *also* renders as ``"{}"`` — the origin string
+    alone cannot distinguish it from the truly empty literal. The
+    unambiguous marker is the pair ``(origin == "{}", type is Item)``:
+    ``visit_Set`` assigns the ``Item`` placeholder only when the set has
+    no children, and no genuinely-typed literal reaches that origin
+    string.
+    """
+    return (
+        isinstance(op, ScalarSet)
+        and op.origin == "{}"
+        and isinstance(op.type, Item)
+    )
+
+
 def _element_type_of(op: BinaryOperand) -> ScalarType | None:
     """Return the element type of ``op`` if it is genuinely typed.
 
@@ -58,7 +77,7 @@ def _element_type_of(op: BinaryOperand) -> ScalarType | None:
     from the *other* operand rather than propagated onto it.
     """
     if isinstance(op, ScalarSet):
-        return None if op.origin == "{}" else op.type
+        return None if _is_empty_set_placeholder(op) else op.type
     if isinstance(op, Scalar):
         return op.type
     if isinstance(op, RecordSet):
@@ -81,11 +100,11 @@ def _propagate_empty_set_type(
     (Scalar in ScalarSet) do not raise a spurious "Implicit promotion
     between <T> and Item" warning against the placeholder.
     """
-    if isinstance(left, ScalarSet) and left.origin == "{}":
+    if _is_empty_set_placeholder(left):
         other = _element_type_of(right)
         if other is not None:
             left = ScalarSet(type_=other, name=left.name, origin=left.origin)
-    if isinstance(right, ScalarSet) and right.origin == "{}":
+    if _is_empty_set_placeholder(right):
         other = _element_type_of(left)
         if other is not None:
             right = ScalarSet(

--- a/src/dpmcore/dpm_xl/operators/comparison.py
+++ b/src/dpmcore/dpm_xl/operators/comparison.py
@@ -12,7 +12,7 @@ from dpmcore.dpm_xl.operators.base import (
 from dpmcore.dpm_xl.operators.base import (
     Unary as _BaseUnary,
 )
-from dpmcore.dpm_xl.symbols import RecordSet, ScalarSet
+from dpmcore.dpm_xl.symbols import RecordSet, Scalar, ScalarSet
 from dpmcore.dpm_xl.types.scalar import Boolean, ScalarType, String
 from dpmcore.dpm_xl.utils import tokens
 from dpmcore.errors import SemanticError
@@ -50,6 +50,22 @@ def _reject_scalarset_mixed_with_recordset(
         )
 
 
+def _element_type_of(op: BinaryOperand) -> ScalarType | None:
+    """Return the element type of ``op`` if it is genuinely typed.
+
+    The empty set literal ``{}`` carries the placeholder ``Item`` type
+    from :func:`visit_Set`; treat it as untyped so its type is inferred
+    from the *other* operand rather than propagated onto it.
+    """
+    if isinstance(op, ScalarSet):
+        return None if op.origin == "{}" else op.type
+    if isinstance(op, Scalar):
+        return op.type
+    if isinstance(op, RecordSet):
+        return op.get_fact_component().type
+    return None
+
+
 def _propagate_empty_set_type(
     left: BinaryOperand, right: BinaryOperand
 ) -> tuple[BinaryOperand, BinaryOperand]:
@@ -60,18 +76,20 @@ def _propagate_empty_set_type(
     placeholder is not a real element type; ``_visit_set_operands``
     already filters it out of the homogeneity check for
     ``union``/``intersect``/``setdiff``/``symdiff``. Apply the same
-    convention to ``=`` / ``!=`` set equality so patterns like
-    ``setdiff(A, B) = {}`` do not raise a spurious "Implicit promotion
+    convention to any binary op with a ``{}`` operand so patterns like
+    ``setdiff(A, B) = {}`` (ScalarSet = ScalarSet) and ``5 in {}``
+    (Scalar in ScalarSet) do not raise a spurious "Implicit promotion
     between <T> and Item" warning against the placeholder.
     """
-    if isinstance(left, ScalarSet) and isinstance(right, ScalarSet):
-        if left.origin == "{}" and right.origin != "{}":
-            left = ScalarSet(
-                type_=right.type, name=left.name, origin=left.origin
-            )
-        elif right.origin == "{}" and left.origin != "{}":
+    if isinstance(left, ScalarSet) and left.origin == "{}":
+        other = _element_type_of(right)
+        if other is not None:
+            left = ScalarSet(type_=other, name=left.name, origin=left.origin)
+    if isinstance(right, ScalarSet) and right.origin == "{}":
+        other = _element_type_of(left)
+        if other is not None:
             right = ScalarSet(
-                type_=left.type, name=right.name, origin=right.origin
+                type_=other, name=right.name, origin=right.origin
             )
     return left, right
 
@@ -85,7 +103,7 @@ class Equal(Binary):
     @classmethod
     def validate(
         cls, left: BinaryOperand, right: BinaryOperand
-    ) -> "Scalar | RecordSet":  # type: ignore[name-defined]  # noqa: F821
+    ) -> Scalar | RecordSet:
         _reject_scalarset_mixed_with_recordset(left, right, cls.op or "=")
         left, right = _propagate_empty_set_type(left, right)
         return super().validate(left, right)
@@ -100,7 +118,7 @@ class NotEqual(Binary):
     @classmethod
     def validate(
         cls, left: BinaryOperand, right: BinaryOperand
-    ) -> "Scalar | RecordSet":  # type: ignore[name-defined]  # noqa: F821
+    ) -> Scalar | RecordSet:
         _reject_scalarset_mixed_with_recordset(left, right, cls.op or "!=")
         left, right = _propagate_empty_set_type(left, right)
         return super().validate(left, right)
@@ -146,7 +164,7 @@ class In(Binary):
     @classmethod
     def validate(
         cls, left: BinaryOperand, right: BinaryOperand
-    ) -> "Scalar | RecordSet":  # type: ignore[name-defined]  # noqa: F821
+    ) -> Scalar | RecordSet:
         # The MR !74 grammar widens ``in``'s RHS from ``setExpression`` to a
         # generic ``expression``; the semantic layer must reject any RHS that
         # is not set-valued (e.g. ``5 in 3``), otherwise validation would fall
@@ -160,6 +178,7 @@ class In(Binary):
                 type_op="ScalarSet",
                 origin="in",
             )
+        left, right = _propagate_empty_set_type(left, right)
         return super().validate(left, right)
 
 

--- a/src/dpmcore/dpm_xl/operators/comparison.py
+++ b/src/dpmcore/dpm_xl/operators/comparison.py
@@ -50,6 +50,32 @@ def _reject_scalarset_mixed_with_recordset(
         )
 
 
+def _propagate_empty_set_type(
+    left: BinaryOperand, right: BinaryOperand
+) -> tuple[BinaryOperand, BinaryOperand]:
+    """Unify the type of the empty set literal ``{}`` to the other operand.
+
+    ``visit_Set`` gives the empty set literal a placeholder ``Item`` type
+    because there are no elements from which to infer one. That
+    placeholder is not a real element type; ``_visit_set_operands``
+    already filters it out of the homogeneity check for
+    ``union``/``intersect``/``setdiff``/``symdiff``. Apply the same
+    convention to ``=`` / ``!=`` set equality so patterns like
+    ``setdiff(A, B) = {}`` do not raise a spurious "Implicit promotion
+    between <T> and Item" warning against the placeholder.
+    """
+    if isinstance(left, ScalarSet) and isinstance(right, ScalarSet):
+        if left.origin == "{}" and right.origin != "{}":
+            left = ScalarSet(
+                type_=right.type, name=left.name, origin=left.origin
+            )
+        elif right.origin == "{}" and left.origin != "{}":
+            right = ScalarSet(
+                type_=left.type, name=right.name, origin=right.origin
+            )
+    return left, right
+
+
 class Equal(Binary):
     op: ClassVar[str | None] = tokens.EQ
     py_op: ClassVar[PyOp | None] = operator.eq
@@ -61,6 +87,7 @@ class Equal(Binary):
         cls, left: BinaryOperand, right: BinaryOperand
     ) -> "Scalar | RecordSet":  # type: ignore[name-defined]  # noqa: F821
         _reject_scalarset_mixed_with_recordset(left, right, cls.op or "=")
+        left, right = _propagate_empty_set_type(left, right)
         return super().validate(left, right)
 
 
@@ -75,6 +102,7 @@ class NotEqual(Binary):
         cls, left: BinaryOperand, right: BinaryOperand
     ) -> "Scalar | RecordSet":  # type: ignore[name-defined]  # noqa: F821
         _reject_scalarset_mixed_with_recordset(left, right, cls.op or "!=")
+        left, right = _propagate_empty_set_type(left, right)
         return super().validate(left, right)
 
 

--- a/tests/unit/semantic/test_set_operators.py
+++ b/tests/unit/semantic/test_set_operators.py
@@ -425,3 +425,79 @@ def test_notequal_scalar_set_and_recordset_rejected_both_directions():
     with pytest.raises(SemanticError) as exc2:
         NotEqual.validate(rs, ss)
     assert exc2.value.code == "3-3"
+
+
+# ---------------------------------------------------------------------------
+# Issue #293: set equality against the empty set literal must not raise
+# a spurious "Implicit promotion between <T> and Item" warning.
+#
+# ``visit_Set`` gives the empty set literal ``{}`` a placeholder ``Item``
+# type — no elements to infer from. For union/intersect/setdiff/symdiff
+# that placeholder is already filtered out of the homogeneity check
+# (``_visit_set_operands``). ``=`` / ``!=`` between two ScalarSets used
+# to forward the placeholder to ``binary_implicit_type_promotion``,
+# clashing with the other operand's real type. The canonical pattern
+# ``setdiff(A, B) = {}`` (used across BdI DORA validations) therefore
+# emitted a false-positive warning even though the expression is valid
+# per §13.7 set equality.
+# ---------------------------------------------------------------------------
+
+
+def _implicit_promotion_warnings(expression: str) -> list[str]:
+    from dpmcore.dpm_xl.warning_collector import collect_warnings
+    from dpmcore.services.syntax import SyntaxService
+
+    ast = SyntaxService().parse(expression)
+    with collect_warnings() as collector:
+        _analyzer().visit(ast)
+    return [w for w in collector.get_warnings() if "Implicit promotion" in w]
+
+
+def test_set_equality_setdiff_empty_rhs_does_not_warn():
+    """``setdiff(strings) = {}`` must not raise implicit-promotion warning."""
+    assert (
+        _implicit_promotion_warnings('setdiff({"a", "b"}, {"c"}) = {}') == []
+    )
+
+
+def test_set_equality_empty_lhs_setdiff_rhs_does_not_warn():
+    """Operand order is irrelevant — ``{} = setdiff(...)`` also OK."""
+    assert (
+        _implicit_promotion_warnings('{} = setdiff({"a", "b"}, {"c"})') == []
+    )
+
+
+def test_set_inequality_setdiff_empty_rhs_does_not_warn():
+    assert (
+        _implicit_promotion_warnings('setdiff({"a", "b"}, {"c"}) != {}') == []
+    )
+
+
+def test_set_equality_empty_and_empty_still_returns_boolean_scalar():
+    """``{} = {}`` stays valid (returns Boolean Scalar, no warning)."""
+    from dpmcore.services.syntax import SyntaxService
+
+    ast = SyntaxService().parse("{} = {}")
+    result = _analyzer().visit(ast)
+    assert isinstance(result, Scalar)
+    assert str(result.type) == "Boolean"
+    assert _implicit_promotion_warnings("{} = {}") == []
+
+
+def test_set_equality_string_set_and_empty_does_not_warn():
+    """Non-set-operator literal on the LHS — placeholder propagation must
+    still kick in.
+    """
+    assert _implicit_promotion_warnings('{"a", "b"} = {}') == []
+
+
+def test_set_equality_mismatched_real_types_still_warns():
+    """The fix must only bypass promotion for the empty-set placeholder;
+    two typed sets with mismatched element types must still emit the
+    implicit-promotion warning like any other binary op.
+    """
+    # Integer vs String — real type mismatch, not the placeholder.
+    warnings = _implicit_promotion_warnings('{1, 2} = {"a"}')
+    assert any("Integer" in w and "String" in w for w in warnings), (
+        f"expected Integer/String promotion warning, got {warnings!r}"
+    )

--- a/tests/unit/semantic/test_set_operators.py
+++ b/tests/unit/semantic/test_set_operators.py
@@ -501,3 +501,52 @@ def test_set_equality_mismatched_real_types_still_warns():
     assert any("Integer" in w and "String" in w for w in warnings), (
         f"expected Integer/String promotion warning, got {warnings!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Follow-up on #293 (PR #294 review by @andres-sole): the placeholder
+# propagation was too narrow — it only covered ``ScalarSet = ScalarSet``.
+# Two additional cases still leaked the ``Implicit promotion between
+# <T> and Item`` warning:
+#   * ``5 in {}`` (Scalar ``in`` empty ScalarSet) — a legitimate shape.
+#   * ``5 = {}`` (Scalar ``=`` empty ScalarSet) — semantically invalid,
+#     but the warning was recorded *before* the delayed 3-3 rejection,
+#     so callers still observed a stale warning next to the error.
+# ---------------------------------------------------------------------------
+
+
+def test_in_scalar_empty_set_does_not_warn():
+    """``5 in {}`` is well-formed (§13 ``in`` accepts a ScalarSet RHS);
+    the empty set placeholder must not trigger a promotion warning.
+    """
+    assert _implicit_promotion_warnings("5 in {}") == []
+
+
+def test_in_scalar_empty_set_still_returns_boolean_scalar():
+    from dpmcore.services.syntax import SyntaxService
+
+    ast = SyntaxService().parse("5 in {}")
+    result = _analyzer().visit(ast)
+    assert isinstance(result, Scalar)
+    assert str(result.type) == "Boolean"
+
+
+def test_equal_scalar_empty_set_rejects_without_stale_warning():
+    """``5 = {}`` is semantically invalid — set equality requires a
+    ScalarSet on both sides. The 3-3 rejection must fire *without* first
+    recording an implicit-promotion warning against the placeholder.
+    """
+    from dpmcore.errors import SemanticError
+    from dpmcore.services.syntax import SyntaxService
+
+    ast = SyntaxService().parse("5 = {}")
+    from dpmcore.dpm_xl.warning_collector import collect_warnings
+
+    with collect_warnings() as collector:
+        with pytest.raises(SemanticError) as exc:
+            _analyzer().visit(ast)
+    assert exc.value.code == "3-3"
+    ghosts = [w for w in collector.get_warnings() if "Implicit promotion" in w]
+    assert ghosts == [], (
+        f"3-3 rejection must not leave a stale promotion warning; got {ghosts!r}"
+    )

--- a/tests/unit/semantic/test_set_operators.py
+++ b/tests/unit/semantic/test_set_operators.py
@@ -531,6 +531,26 @@ def test_in_scalar_empty_set_still_returns_boolean_scalar():
     assert str(result.type) == "Boolean"
 
 
+def test_singleton_empty_string_set_is_not_the_empty_placeholder():
+    """``{""}`` (a set with one empty-string element) renders with the
+    same ``origin`` string as the empty set literal ``{}``, but is
+    genuinely typed as ``String``. The placeholder-detection must use
+    both ``origin == "{}"`` *and* the ``Item`` type marker so that
+    ``{""} = {1, 2}`` still surfaces the real ``String``/``Integer``
+    mismatch, and ``{""} = {}`` does *not* fabricate a spurious
+    ``String``/``Item`` warning against the placeholder.
+    """
+    # Real mismatch — must warn.
+    real = _implicit_promotion_warnings('{""} = {1, 2}')
+    assert any("String" in w and "Integer" in w for w in real), (
+        f"expected String/Integer promotion warning on real mismatch, "
+        f"got {real!r}"
+    )
+    # Typed String vs the placeholder — must not warn (either order).
+    assert _implicit_promotion_warnings('{""} = {}') == []
+    assert _implicit_promotion_warnings('{} = {""}') == []
+
+
 def test_equal_scalar_empty_set_rejects_without_stale_warning():
     """``5 = {}`` is semantically invalid — set equality requires a
     ScalarSet on both sides. The 3-3 rejection must fire *without* first


### PR DESCRIPTION
Fixes the spurious `Implicit promotion between <T> and Item` semantic warning raised by set equality (`=` / `!=`) when one side is the empty set literal `{}`.
 
  `visit_Set` gives the empty set literal a placeholder `Item` type — there are no elements from which to infer one. `_visit_set_operands` already filters this placeholder out of the
  homogeneity check for `union` / `intersect` / `setdiff` / `symdiff` (semantic_analyzer.py:932-937). `Equal.validate` / `NotEqual.validate` were missing the same treatment: the placeholder 
  was forwarded to `binary_implicit_type_promotion`, which then compared it against the other operand's real type (e.g. `String`) and emitted a false-positive warning.
 
  The canonical DPM-XL pattern `setdiff(A, B) = {}` — "every element of A is also in B" — used across the BdI DORA validations (BDI_DORA_034…_052) tripped this warning on every use.
 
  ## Changes
 
  - New helper `_propagate_empty_set_type` in `src/dpmcore/dpm_xl/operators/comparison.py` that unifies the empty-set placeholder to the other operand's type when both sides are `ScalarSet`.
  - `Equal.validate` and `NotEqual.validate` call the helper before delegating to `super().validate`.
  - No grammar changes, no AST changes, no changes to `visit_Set`. Scope limited to set-equality validation.
 
  ## Test plan

  - [x] Regression tests in `tests/unit/semantic/test_set_operators.py`:
    - `setdiff({"a","b"}, {"c"}) = {}` → no warning
    - `{} = setdiff(...)` (reversed order) → no warning
    - `setdiff(...) != {}` → no warning
    - `{"a","b"} = {}` → no warning
    - `{} = {}` still returns `Boolean` Scalar, no warning
    - `{1,2} = {"a"}` (real type mismatch) → still emits `Integer`/`String` promotion warning (regression guard)
  - [x] `poetry run ruff format` + `ruff check` clean on changed files.
  - [x] `poetry run mypy src/dpmcore/dpm_xl/operators/comparison.py` clean.
  - [x] `poetry run pytest -m unit --ignore=tests/unit/cli` — 1494 passed, 71 skipped. (CLI failures on master are unrelated: optional `rich` dep not installed.)
 
  Fixes #293