### PR TITLE
Fix releases: treat "playground" NOT NULL sentinel and self-reference as latest

### DIFF
--- a/src/dpmcore/dpm_xl/utils/filters.py
+++ b/src/dpmcore/dpm_xl/utils/filters.py
@@ -208,17 +208,26 @@ def filter_active_only(query: Any, end_col: Any) -> Any:
     """Filter for currently active records.
 
     Args:
-        query: SQLAlchemy Query or Select object.
+        query: SQLAlchemy ``Query`` — must be a session-bound ``Query``
+            (i.e. produced by ``Session.query(...)``); see
+            :func:`filter_by_release`.
         end_col: Column for end release.
 
     Returns:
         Filtered query: ``end_col IS NULL``, or ``end_col`` is itself an
         "always latest" release (undated or non-chronological), which
         never actually closes.
+
+    Raises:
+        TypeError: If ``query`` is not a session-bound SQLAlchemy
+            ``Query``.
     """
     session = getattr(query, "session", None)
     if session is None:
-        return query.filter(end_col.is_(None))
+        raise TypeError(
+            "filter_active_only(query=...) expects a session-bound "
+            "SQLAlchemy Query (Session.query(...))."
+        )
     sort_orders = load_release_sort_orders(session)
     perpetual_ids = release_ids_for_sort_order(
         sort_orders, ge=compute_sort_order(None)

--- a/src/dpmcore/dpm_xl/utils/filters.py
+++ b/src/dpmcore/dpm_xl/utils/filters.py
@@ -140,16 +140,18 @@ def filter_by_release(
             or undated release, which always ranks as the latest
             regardless of its literal date.
         If release_id is None:
-            * ``active_only_fallback=True`` → ``end_col IS NULL`` only
-              (currently-active rows). Useful for callers that want a
-              deterministic default when no release is supplied.
-            * Otherwise → return query unmodified.
+            * ``active_only_fallback=True`` → apply
+              :func:`filter_active_only` (see its own docstring for the
+              perpetual-end exception).
+            * Otherwise → return query unmodified, no session required.
 
     Args:
         query: SQLAlchemy ``Query`` — must be a session-bound ``Query``
-            (i.e. produced by ``Session.query(...)``). Core ``Select``
-            statements are not supported because the helper needs the
-            session to load the release mapping.
+            (i.e. produced by ``Session.query(...)``) whenever a session
+            is actually needed (``release_id`` given, or
+            ``active_only_fallback=True``). Core ``Select`` statements
+            are not supported because the helper needs the session to
+            load the release mapping.
         start_col: Column for start release ID (FK to ``Release``).
         end_col: Column for end release ID (FK to ``Release``).
         release_id: Release ID to filter for.
@@ -161,14 +163,13 @@ def filter_by_release(
         Filtered query.
 
     Raises:
-        TypeError: If ``query`` is not a session-bound SQLAlchemy
-            ``Query`` (e.g. a Core ``Select`` was passed).
+        TypeError: If a session is needed (see ``query`` above) and
+            ``query`` is not a session-bound SQLAlchemy ``Query`` (e.g. a
+            Core ``Select`` was passed).
         ValueError: If ``release_id`` does not correspond to a known
             ``Release`` row.
     """
-    if release_id is None:
-        if active_only_fallback:
-            return filter_active_only(query, end_col)
+    if release_id is None and not active_only_fallback:
         return query
 
     session = getattr(query, "session", None)
@@ -179,6 +180,9 @@ def filter_by_release(
             f"{type(query).__name__!r} which has no .session — Core "
             "Select statements are not supported.",
         )
+
+    if release_id is None:
+        return filter_active_only(query, end_col)
 
     # Order releases by date. resolve_sort_order already handles
     # non-chronological types like "Playground". This block only compares

--- a/src/dpmcore/dpm_xl/utils/filters.py
+++ b/src/dpmcore/dpm_xl/utils/filters.py
@@ -190,7 +190,7 @@ def filter_by_release(
     # A row ending at an "always latest" release (undated or
     # non-chronological) is still open even when queried at that release.
     perpetual_ids = release_ids_for_sort_order(
-        sort_orders, ge=compute_sort_order(None)
+        sort_orders, ge=compute_sort_order(None, None)
     )
     return query.filter(
         and_(
@@ -230,7 +230,7 @@ def filter_active_only(query: Any, end_col: Any) -> Any:
         )
     sort_orders = load_release_sort_orders(session)
     perpetual_ids = release_ids_for_sort_order(
-        sort_orders, ge=compute_sort_order(None)
+        sort_orders, ge=compute_sort_order(None, None)
     )
     return query.filter(or_(end_col.is_(None), end_col.in_(perpetual_ids)))
 
@@ -269,7 +269,7 @@ def filter_item_version(
     # A row ending at an "always latest" release (undated or
     # non-chronological) is still open even when queried at that release.
     perpetual_ids = release_ids_for_sort_order(
-        sort_orders, ge=compute_sort_order(None)
+        sort_orders, ge=compute_sort_order(None, None)
     )
     return and_(
         item_start_col.in_(start_ids),

--- a/src/dpmcore/dpm_xl/utils/filters.py
+++ b/src/dpmcore/dpm_xl/utils/filters.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any, Dict, Optional
 from sqlalchemy import Date, and_, cast, or_
 
 from dpmcore.orm.release_sort_order import (
+    compute_sort_order,
     load_release_sort_orders,
     release_ids_for_sort_order,
     resolve_sort_order,
@@ -188,10 +189,17 @@ def filter_by_release(
     sort_orders = load_release_sort_orders(session)
     start_ids = release_ids_for_sort_order(sort_orders, le=target_sort_order)
     end_ids = release_ids_for_sort_order(sort_orders, gt=target_sort_order)
+    perpetual_ids = release_ids_for_sort_order(
+        sort_orders, ge=compute_sort_order(None)
+    )
     return query.filter(
         and_(
             start_col.in_(start_ids),
-            or_(end_col.is_(None), end_col.in_(end_ids)),
+            or_(
+                end_col.is_(None),
+                end_col.in_(end_ids),
+                end_col.in_(perpetual_ids),
+            ),
         )
     )
 
@@ -240,7 +248,14 @@ def filter_item_version(
 
     start_ids = release_ids_for_sort_order(sort_orders, le=ref_sort_order)
     end_ids = release_ids_for_sort_order(sort_orders, gt=ref_sort_order)
+    perpetual_ids = release_ids_for_sort_order(
+        sort_orders, ge=compute_sort_order(None)
+    )
     return and_(
         item_start_col.in_(start_ids),
-        or_(item_end_col.is_(None), item_end_col.in_(end_ids)),
+        or_(
+            item_end_col.is_(None),
+            item_end_col.in_(end_ids),
+            item_end_col.in_(perpetual_ids),
+        ),
     )

--- a/src/dpmcore/dpm_xl/utils/filters.py
+++ b/src/dpmcore/dpm_xl/utils/filters.py
@@ -188,6 +188,8 @@ def filter_by_release(
     sort_orders = load_release_sort_orders(session)
     start_ids = release_ids_for_sort_order(sort_orders, le=target_sort_order)
     end_ids = release_ids_for_sort_order(sort_orders, gt=target_sort_order)
+    # A row ending at an "always latest" release (undated or
+    # non-chronological) is still open even when queried at that release.
     perpetual_ids = release_ids_for_sort_order(
         sort_orders, ge=compute_sort_order(None)
     )
@@ -247,6 +249,8 @@ def filter_item_version(
 
     start_ids = release_ids_for_sort_order(sort_orders, le=ref_sort_order)
     end_ids = release_ids_for_sort_order(sort_orders, gt=ref_sort_order)
+    # A row ending at an "always latest" release (undated or
+    # non-chronological) is still open even when queried at that release.
     perpetual_ids = release_ids_for_sort_order(
         sort_orders, ge=compute_sort_order(None)
     )

--- a/src/dpmcore/dpm_xl/utils/filters.py
+++ b/src/dpmcore/dpm_xl/utils/filters.py
@@ -134,12 +134,11 @@ def filter_by_release(
     Logic (date-ordered):
         If release_id provided:
             ``sort_order(start) <= sort_order(target)`` AND
-            ``(end IS NULL OR sort_order(end) > sort_order(target))``,
-            where ``sort_order`` is the release's ``Release.date``. This
-            works for every ``code`` format — a ``"Playground"``/working
-            release orders by its date like any other, and an undated
-            working release ranks as the latest, so a request for it
-            naturally resolves to the current rows.
+            ``(end IS NULL OR sort_order(end) > sort_order(target) OR
+            end is itself "always latest")``, where ``sort_order`` is the
+            release's ``Release.date``, except a ``"Playground"``/working
+            or undated release, which always ranks as the latest
+            regardless of its literal date.
         If release_id is None:
             * ``active_only_fallback=True`` → ``end_col IS NULL`` only
               (currently-active rows). Useful for callers that want a

--- a/src/dpmcore/dpm_xl/utils/filters.py
+++ b/src/dpmcore/dpm_xl/utils/filters.py
@@ -181,10 +181,9 @@ def filter_by_release(
             "Select statements are not supported.",
         )
 
-    # Order releases by date. A "Playground"/working release orders by
-    # its date like any other (an undated one ranks as the latest), so no
-    # code parsing and no special-casing is needed; an unknown release_id
-    # raises.
+    # Order releases by date. resolve_sort_order already handles
+    # non-chronological types like "Playground". This block only compares
+    # the sort order it returns. An unknown release_id raises.
     target_sort_order = resolve_sort_order(session, release_id)
     sort_orders = load_release_sort_orders(session)
     start_ids = release_ids_for_sort_order(sort_orders, le=target_sort_order)

--- a/src/dpmcore/dpm_xl/utils/filters.py
+++ b/src/dpmcore/dpm_xl/utils/filters.py
@@ -212,9 +212,18 @@ def filter_active_only(query: Any, end_col: Any) -> Any:
         end_col: Column for end release.
 
     Returns:
-        Filtered query with end_col IS NULL.
+        Filtered query: ``end_col IS NULL``, or ``end_col`` is itself an
+        "always latest" release (undated or non-chronological), which
+        never actually closes.
     """
-    return query.filter(end_col.is_(None))
+    session = getattr(query, "session", None)
+    if session is None:
+        return query.filter(end_col.is_(None))
+    sort_orders = load_release_sort_orders(session)
+    perpetual_ids = release_ids_for_sort_order(
+        sort_orders, ge=compute_sort_order(None)
+    )
+    return query.filter(or_(end_col.is_(None), end_col.in_(perpetual_ids)))
 
 
 def filter_item_version(

--- a/src/dpmcore/loaders/migration.py
+++ b/src/dpmcore/loaders/migration.py
@@ -27,7 +27,7 @@ from io import StringIO
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from sqlalchemy import case, inspect, select, text
+from sqlalchemy import inspect, select, text
 from sqlalchemy.engine import Engine
 
 from dpmcore.orm.base import Base
@@ -368,26 +368,33 @@ class MigrationService:
         """Return a filename-safe code for the current release."""
         from sqlalchemy.orm import Session
 
-        # Latest first: an undated (unpublished) working release ranks as
-        # the latest. The NULL-first CASE keeps this uniform across
-        # backends (SQLite/SQL Server otherwise sort NULLs last in DESC).
-        latest_first = (
-            case((Release.date.is_(None), 1), else_=0).desc(),
-            Release.date.desc(),
-        )
-        with Session(self._engine) as session:
-            stmt = (
-                select(Release.code)
-                .where(Release.is_current.is_(True))
-                .order_by(*latest_first)
+        from dpmcore.orm.release_sort_order import compute_sort_order
+
+        def _latest_code(rows: Any) -> Optional[str]:
+            # Latest first: an undated or non-chronological (e.g.
+            # "playground") release ranks as the latest, regardless of
+            # its literal date.
+            ranked = sorted(
+                rows,
+                key=lambda r: compute_sort_order(r.date, r.type),
+                reverse=True,
             )
-            code = session.scalars(stmt).first()
+            return ranked[0].code if ranked else None
+
+        with Session(self._engine) as session:
+            rows = session.execute(
+                select(Release.code, Release.date, Release.type).where(
+                    Release.is_current.is_(True)
+                )
+            ).all()
+            code = _latest_code(rows)
             if code is None:
-                code = session.scalars(
-                    select(Release.code)
-                    .where(Release.code.is_not(None))
-                    .order_by(*latest_first)
-                ).first()
+                rows = session.execute(
+                    select(Release.code, Release.date, Release.type).where(
+                        Release.code.is_not(None)
+                    )
+                ).all()
+                code = _latest_code(rows)
 
         if not code:
             return None

--- a/src/dpmcore/loaders/migration.py
+++ b/src/dpmcore/loaders/migration.py
@@ -371,28 +371,35 @@ class MigrationService:
         from dpmcore.orm.release_sort_order import compute_sort_order
 
         def _latest_code(rows: Any) -> Optional[str]:
-            # Latest first: an undated or non-chronological (e.g.
-            # "playground") release ranks as the latest, regardless of
-            # its literal date.
+            # Latest first, including playground. release_id breaks ties.
             ranked = sorted(
                 rows,
-                key=lambda r: compute_sort_order(r.date, r.type),
+                key=lambda r: (
+                    compute_sort_order(r.date, r.type),
+                    r.release_id,
+                ),
                 reverse=True,
             )
             return ranked[0].code if ranked else None
 
         with Session(self._engine) as session:
             rows = session.execute(
-                select(Release.code, Release.date, Release.type).where(
-                    Release.is_current.is_(True)
-                )
+                select(
+                    Release.code,
+                    Release.date,
+                    Release.type,
+                    Release.release_id,
+                ).where(Release.is_current.is_(True))
             ).all()
             code = _latest_code(rows)
             if code is None:
                 rows = session.execute(
-                    select(Release.code, Release.date, Release.type).where(
-                        Release.code.is_not(None)
-                    )
+                    select(
+                        Release.code,
+                        Release.date,
+                        Release.type,
+                        Release.release_id,
+                    ).where(Release.code.is_not(None))
                 ).all()
                 code = _latest_code(rows)
 

--- a/src/dpmcore/orm/release_sort_order.py
+++ b/src/dpmcore/orm/release_sort_order.py
@@ -51,8 +51,9 @@ def compute_sort_order(
     """Return a sortable integer for a release's publication date.
 
     Ordering is purely chronological: an earlier ``Release.date`` sorts
-    before a later one. Dates are unique per release, so the ordinal is a
-    total order and needs no tiebreak.
+    before a later one. Dates are unique per release, so no tiebreak is
+    needed, except at the "latest" sentinel, which more than one release
+    can map to.
 
     Args:
         release_date: The release's ``Release.date``. ``None`` (an

--- a/src/dpmcore/orm/release_sort_order.py
+++ b/src/dpmcore/orm/release_sort_order.py
@@ -15,6 +15,11 @@ which represents the current in-progress state; it therefore sorts *after*
 every dated release — i.e. it is the latest. This is expressed by mapping a
 missing date to a sentinel ordinal greater than any real date's.
 
+Some schemas declare ``Release.Date`` ``NOT NULL`` and
+mark their perpetual release via ``Release.Type`` instead (e.g.
+``"playground"``), with an irrelevant placeholder date. That type sorts as
+latest like an undated release. See :data:`_NON_CHRONOLOGICAL_TYPES`.
+
 The order key is the date's proleptic-Gregorian ordinal, computed in
 Python at query time and held as a plain ``int`` — there is no persisted
 SQL column; only its ordering is ever used.
@@ -23,7 +28,7 @@ SQL column; only its ordering is ever used.
 from __future__ import annotations
 
 from datetime import date
-from typing import TYPE_CHECKING, Dict, List, Optional
+from typing import TYPE_CHECKING, Dict, FrozenSet, List, Optional
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -33,8 +38,14 @@ if TYPE_CHECKING:
 # unpublished working release ranks as the latest.
 _UNDATED_SORT_ORDER = date.max.toordinal() + 1
 
+# ``Release.type`` values marking a perpetual release (sorts as latest,
+# like an undated one) on schemas where ``Release.Date`` is ``NOT NULL``.
+_NON_CHRONOLOGICAL_TYPES: FrozenSet[str] = frozenset({"playground"})
 
-def compute_sort_order(release_date: Optional[date]) -> int:
+
+def compute_sort_order(
+    release_date: Optional[date], release_type: Optional[str] = None
+) -> int:
     """Return a sortable integer for a release's publication date.
 
     Ordering is purely chronological: an earlier ``Release.date`` sorts
@@ -44,13 +55,17 @@ def compute_sort_order(release_date: Optional[date]) -> int:
     Args:
         release_date: The release's ``Release.date``. ``None`` (an
             unpublished working release) sorts as the latest release.
+        release_type: The release's ``Release.type``, if available. A
+            value in :data:`_NON_CHRONOLOGICAL_TYPES` (e.g.
+            ``"playground"``) sorts as latest regardless of
+            ``release_date``, which may just be a ``NOT NULL`` placeholder.
 
     Returns:
         The date's ordinal (days since 0001-01-01), or the "latest"
         sentinel (:data:`_UNDATED_SORT_ORDER`) when ``release_date`` is
-        missing.
+        missing or ``release_type`` is non-chronological.
     """
-    if release_date is None:
+    if release_date is None or release_type in _NON_CHRONOLOGICAL_TYPES:
         return _UNDATED_SORT_ORDER
     return release_date.toordinal()
 
@@ -61,15 +76,15 @@ def load_release_sort_orders(
     """Return ``{release_id: sort_order}`` derived from ``Release.date``.
 
     Every release maps to an ``int``: dated releases to their date's
-    ordinal, and an undated (unpublished) release to the "latest"
-    sentinel. The mapping never holds ``None`` values; only a ``.get()``
-    miss on a release_id absent from the mapping (an orphan FK) yields
-    ``None`` for a caller.
+    ordinal, and an undated (unpublished) or non-chronological (e.g.
+    ``"playground"``-typed) release to the "latest" sentinel. The mapping
+    never holds ``None`` values; only a ``.get()`` miss on a release_id
+    absent from the mapping (an orphan FK) yields ``None`` for a caller.
     """
     from dpmcore.orm.infrastructure import Release
 
-    rows = session.query(Release.release_id, Release.date).all()
-    return {rid: compute_sort_order(d) for rid, d in rows}
+    rows = session.query(Release.release_id, Release.date, Release.type).all()
+    return {rid: compute_sort_order(d, t) for rid, d, t in rows}
 
 
 def resolve_sort_order(
@@ -86,8 +101,9 @@ def resolve_sort_order(
             don't have to wrap the call in their own try/except just to
             customise wording.
 
-    An undated (unpublished) release is *not* an error — it resolves to
-    the "latest" sentinel like any other release.
+    An undated (unpublished) or non-chronological (e.g.
+    ``"playground"``-typed) release is *not* an error — it resolves to the
+    "latest" sentinel like any other release.
 
     Raises:
         ValueError: If no Release row matches ``release_id``.
@@ -95,7 +111,7 @@ def resolve_sort_order(
     from dpmcore.orm.infrastructure import Release
 
     row = (
-        session.query(Release.date)
+        session.query(Release.date, Release.type)
         .filter(Release.release_id == release_id)
         .first()
     )
@@ -104,7 +120,7 @@ def resolve_sort_order(
             f"{role} {release_id} has no sort_order — "
             "no Release row matches that ID."
         )
-    return compute_sort_order(row[0])
+    return compute_sort_order(row[0], row[1])
 
 
 def release_ids_for_sort_order(

--- a/src/dpmcore/orm/release_sort_order.py
+++ b/src/dpmcore/orm/release_sort_order.py
@@ -68,7 +68,10 @@ def compute_sort_order(
         sentinel (:data:`_UNDATED_SORT_ORDER`) when ``release_date`` is
         missing or ``release_type`` is non-chronological.
     """
-    if release_date is None or release_type in _NON_CHRONOLOGICAL_TYPES:
+    normalized_type = (
+        release_type.strip().lower() if release_type is not None else None
+    )
+    if release_date is None or normalized_type in _NON_CHRONOLOGICAL_TYPES:
         return _UNDATED_SORT_ORDER
     return release_date.toordinal()
 

--- a/src/dpmcore/orm/release_sort_order.py
+++ b/src/dpmcore/orm/release_sort_order.py
@@ -46,7 +46,7 @@ _NON_CHRONOLOGICAL_TYPES: FrozenSet[str] = frozenset({"playground"})
 
 
 def compute_sort_order(
-    release_date: Optional[date], release_type: Optional[str] = None
+    release_date: Optional[date], release_type: Optional[str]
 ) -> int:
     """Return a sortable integer for a release's publication date.
 
@@ -55,10 +55,13 @@ def compute_sort_order(
     needed, except at the "latest" sentinel, which more than one release
     can map to.
 
+    ``release_type`` has no default: a caller must pass ``None``
+    explicitly rather than silently reverting to date-only ordering.
+
     Args:
         release_date: The release's ``Release.date``. ``None`` (an
             unpublished working release) sorts as the latest release.
-        release_type: The release's ``Release.type``, if available. A
+        release_type: The release's ``Release.type``, or ``None``. A
             value in :data:`_NON_CHRONOLOGICAL_TYPES` (e.g.
             ``"playground"``) sorts as latest regardless of
             ``release_date``, which may just be a ``NOT NULL`` placeholder.

--- a/src/dpmcore/orm/release_sort_order.py
+++ b/src/dpmcore/orm/release_sort_order.py
@@ -8,7 +8,9 @@ lineage order, and the date is present regardless of the ``code`` format,
 so date ordering handles every code — the classic ``MAJOR.MINOR[.PATCH]``
 form, EBA's four-segment codes (e.g. ``4.2.1.3``) and non-versioned
 working releases like ``"Playground"`` — uniformly, without parsing the
-code. Release dates are unique, so no tiebreak is needed.
+code. Release dates are unique, so no tiebreak is needed, except at the
+"latest" sentinel below, since more than one release can map to it there.
+Callers that need a deterministic order break such ties by ``release_id``.
 
 A release with **no publication date** is an unpublished working release,
 which represents the current in-progress state; it therefore sorts *after*

--- a/src/dpmcore/services/ast_generator.py
+++ b/src/dpmcore/services/ast_generator.py
@@ -669,7 +669,7 @@ class ASTGeneratorService:
         rows = self.session.query(Release).all()
         candidates: List[tuple[int, Any]] = []
         for r in rows:
-            so = compute_sort_order(r.date)
+            so = compute_sort_order(r.date, r.type)
             if start_sort is not None and so < start_sort:
                 continue
             if end_sort is not None and so >= end_sort:

--- a/src/dpmcore/services/ast_generator.py
+++ b/src/dpmcore/services/ast_generator.py
@@ -459,7 +459,10 @@ class ASTGeneratorService:
         whose start ``predates`` the requested release.
         """
         from dpmcore.orm.infrastructure import Release
-        from dpmcore.orm.release_sort_order import resolve_sort_order
+        from dpmcore.orm.release_sort_order import (
+            compute_sort_order,
+            resolve_sort_order,
+        )
 
         if self.session is None:
             raise RuntimeError("session required")
@@ -483,16 +486,24 @@ class ASTGeneratorService:
             )
         if end is not None:
             effective_end_id = self._effective_end_release_id(mv)
-            if effective_end_id is not None and target >= resolve_sort_order(
-                self.session,
-                effective_end_id,
-                role="module version effective end release",
-            ):
-                raise ValueError(
-                    f"Release {release} is past the end of module "
-                    f"version {module_code} {module_version} "
-                    f"(ends at release_id={end})."
+            if effective_end_id is not None:
+                effective_end_sort = resolve_sort_order(
+                    self.session,
+                    effective_end_id,
+                    role="module version effective end release",
                 )
+                # A row ending at an "always latest" release (undated or
+                # non-chronological) is still open even when queried at
+                # that release.
+                if (
+                    effective_end_sort != compute_sort_order(None)
+                    and target >= effective_end_sort
+                ):
+                    raise ValueError(
+                        f"Release {release} is past the end of module "
+                        f"version {module_code} {module_version} "
+                        f"(ends at release_id={end})."
+                    )
         return release_row
 
     def _effective_end_release_id(self, mv: Any) -> Optional[int]:
@@ -668,24 +679,33 @@ class ASTGeneratorService:
                 mv.end_release_id,
                 role="Module version window end release",
             )
+        perpetual_sort_order = compute_sort_order(None)
 
         rows = self.session.query(Release).all()
-        candidates: List[tuple[int, Any]] = []
+        candidates: List[tuple[int, int, Any]] = []
         for r in rows:
             so = compute_sort_order(r.date, r.type)
             if start_sort is not None and so < start_sort:
                 continue
-            if end_sort is not None and so >= end_sort:
+            # A row ending at an "always latest" release (undated or
+            # non-chronological) is still open even when queried at
+            # that release.
+            if (
+                end_sort is not None
+                and end_sort != perpetual_sort_order
+                and so >= end_sort
+            ):
                 continue
-            candidates.append((so, r))
+            candidates.append((so, r.release_id, r))
         if not candidates:
             return None
-        current = [(so, r) for so, r in candidates if r.is_current]
+        # release_id breaks ties among releases sharing a sort order.
+        current = [c for c in candidates if c[2].is_current]
         if current:
-            return max(current, key=lambda pair: pair[0])[1]
-        released = [(so, r) for so, r in candidates if r.status == "released"]
+            return max(current, key=lambda c: (c[0], c[1]))[2]
+        released = [c for c in candidates if c[2].status == "released"]
         pool = released or candidates
-        return max(pool, key=lambda pair: pair[0])[1]
+        return max(pool, key=lambda c: (c[0], c[1]))[2]
 
     def _resolve_severities(
         self,

--- a/src/dpmcore/services/ast_generator.py
+++ b/src/dpmcore/services/ast_generator.py
@@ -496,7 +496,7 @@ class ASTGeneratorService:
                 # non-chronological) is still open even when queried at
                 # that release.
                 if (
-                    effective_end_sort != compute_sort_order(None)
+                    effective_end_sort != compute_sort_order(None, None)
                     and target >= effective_end_sort
                 ):
                     raise ValueError(
@@ -679,7 +679,7 @@ class ASTGeneratorService:
                 mv.end_release_id,
                 role="Module version window end release",
             )
-        perpetual_sort_order = compute_sort_order(None)
+        perpetual_sort_order = compute_sort_order(None, None)
 
         rows = self.session.query(Release).all()
         candidates: List[tuple[int, int, Any]] = []

--- a/src/dpmcore/services/data_dictionary.py
+++ b/src/dpmcore/services/data_dictionary.py
@@ -63,7 +63,7 @@ class DataDictionaryService:
         """
         rows = self.session.query(Release).all()
         rows.sort(
-            key=lambda r: (compute_sort_order(r.date), r.release_id),
+            key=lambda r: (compute_sort_order(r.date, r.type), r.release_id),
             reverse=True,
         )
         return [r.to_dict() for r in rows]
@@ -98,7 +98,8 @@ class DataDictionaryService:
         if not rows:
             return None
         row = max(
-            rows, key=lambda r: (compute_sort_order(r.date), r.release_id)
+            rows,
+            key=lambda r: (compute_sort_order(r.date, r.type), r.release_id),
         )
         return row.to_dict()
 

--- a/src/dpmcore/services/ecb_validations_import.py
+++ b/src/dpmcore/services/ecb_validations_import.py
@@ -396,6 +396,7 @@ class EcbValidationsImportService:
         ``code`` format.
         """
         from dpmcore.orm.release_sort_order import (
+            compute_sort_order,
             load_release_sort_orders,
             release_ids_for_sort_order,
         )
@@ -415,9 +416,16 @@ class EcbValidationsImportService:
                 f"Release {end_release_id} has no sort_order — "
                 "no Release row matches that ID."
             )
-        return release_ids_for_sort_order(
+        ids = release_ids_for_sort_order(
             sort_orders, ge=start_sort, lt=end_sort
         )
+        # A row ending at an "always latest" release (undated or
+        # non-chronological) is still open even when queried at that release.
+        if end_sort >= compute_sort_order(None):
+            ids += release_ids_for_sort_order(
+                sort_orders, ge=compute_sort_order(None)
+            )
+        return ids
 
     def _collect_table_codes_from_ast(self, node: Any) -> Set[str]:
         table_codes: Set[str] = set()

--- a/src/dpmcore/services/ecb_validations_import.py
+++ b/src/dpmcore/services/ecb_validations_import.py
@@ -393,7 +393,8 @@ class EcbValidationsImportService:
         Comparison runs against the date-based sort order of each release
         (``Release.date``), not the opaque ``ReleaseID`` FK, so releases
         place correctly within their version lineage regardless of the
-        ``code`` format.
+        ``code`` format. An "always latest" ``end_release_id`` (undated or
+        non-chronological) is included too, since it never closes the range.
         """
         from dpmcore.orm.release_sort_order import (
             compute_sort_order,

--- a/src/dpmcore/services/ecb_validations_import.py
+++ b/src/dpmcore/services/ecb_validations_import.py
@@ -422,9 +422,9 @@ class EcbValidationsImportService:
         )
         # A row ending at an "always latest" release (undated or
         # non-chronological) is still open even when queried at that release.
-        if end_sort >= compute_sort_order(None):
+        if end_sort >= compute_sort_order(None, None):
             ids += release_ids_for_sort_order(
-                sort_orders, ge=compute_sort_order(None)
+                sort_orders, ge=compute_sort_order(None, None)
             )
         return ids
 

--- a/src/dpmcore/services/structure.py
+++ b/src/dpmcore/services/structure.py
@@ -299,8 +299,10 @@ class StructureService:
 
         if latest or latest_stable:
             rows = rows[:1]
+        elif limit is None:
+            rows = rows[offset:]
         else:
-            rows = rows[offset : offset + limit]
+            rows = rows[offset : offset + max(limit, 0)]
 
         return [_release_to_dict(r, detail) for r in rows], total
 

--- a/src/dpmcore/services/structure.py
+++ b/src/dpmcore/services/structure.py
@@ -197,6 +197,7 @@ class StructureService:
                 key=lambda r: (
                     sort_orders[r.release_id] is not None,
                     sort_orders[r.release_id] or 0,
+                    r.release_id,
                 )
             )
             self._releases_cache = releases

--- a/src/dpmcore/services/structure.py
+++ b/src/dpmcore/services/structure.py
@@ -14,7 +14,7 @@ from typing import (
     cast,
 )
 
-from sqlalchemy import case, func, or_
+from sqlalchemy import func, or_
 from sqlalchemy.orm import joinedload
 
 from dpmcore.orm.glossary import (
@@ -189,7 +189,8 @@ class StructureService:
         if self._releases_cache is None:
             releases = self.session.query(Release).all()
             self._sort_orders_cache = {
-                r.release_id: compute_sort_order(r.date) for r in releases
+                r.release_id: compute_sort_order(r.date, r.type)
+                for r in releases
             }
             sort_orders = self._sort_orders_cache
             releases.sort(
@@ -288,21 +289,18 @@ class StructureService:
         # Count before pagination/limiting
         total = q.count()
 
-        # Latest first: an undated (unpublished) working release ranks as
-        # the latest, then dated releases descending. The explicit
-        # NULL-first CASE keeps this uniform across backends (SQLite and
-        # SQL Server otherwise sort NULLs last in DESC).
-        q = q.order_by(
-            case((Release.date.is_(None), 1), else_=0).desc(),
-            Release.date.desc(),
+        # Latest first via compute_sort_order
+        rows = sorted(
+            q.all(),
+            key=lambda r: (compute_sort_order(r.date, r.type), r.release_id),
+            reverse=True,
         )
 
         if latest or latest_stable:
-            q = q.limit(1)
+            rows = rows[:1]
         else:
-            q = q.offset(offset).limit(limit)
+            rows = rows[offset : offset + limit]
 
-        rows = q.all()
         return [_release_to_dict(r, detail) for r in rows], total
 
     def get_release_by_code(

--- a/tests/integration/releases/test_release_sort_order.py
+++ b/tests/integration/releases/test_release_sort_order.py
@@ -763,3 +763,116 @@ def test_filter_item_version_self_reference_at_playground_type(
         "ItemCategory ends at the perpetual release itself — querying AT "
         "that same release must not treat it as closed"
     )
+
+
+# --------------------------------------------------------------------- #
+# Same self-reference gap in three more call sites: ECB validations
+# import, and the AST generator's release-window resolution.
+# --------------------------------------------------------------------- #
+
+
+def test_ecb_valid_release_ids_self_reference_at_playground_type(
+    memory_session,
+):
+    """A validation ending at Playground is valid AT Playground too."""
+    from dpmcore.services.ecb_validations_import import (
+        EcbValidationsImportService,
+    )
+
+    session = memory_session
+    session.add_all(
+        [
+            Release(release_id=1, code="4.2", date=date(2025, 10, 31)),
+            Release(
+                release_id=9999,
+                code="Playground",
+                date=date(1970, 1, 1),
+                type="playground",
+            ),
+        ]
+    )
+    session.commit()
+
+    ids = EcbValidationsImportService._get_valid_release_ids(
+        session, start_release_id=1, end_release_id=9999
+    )
+    assert set(ids) == {1, 9999}, (
+        "a validation ending at the perpetual release itself must still "
+        "be valid at that same release"
+    )
+
+
+def test_latest_release_in_window_self_reference_at_playground_type(
+    memory_session,
+):
+    """The AST generator resolves Playground itself, not an older release."""
+    from dpmcore.services.ast_generator import ASTGeneratorService
+
+    session = memory_session
+    mv = ModuleVersion(
+        module_vid=10,
+        module_id=1,
+        code="MV1",
+        start_release_id=1,
+        end_release_id=9999,
+    )
+    session.add_all(
+        [
+            Release(release_id=1, code="4.2", date=date(2025, 10, 31)),
+            Release(
+                release_id=9999,
+                code="Playground",
+                date=date(1970, 1, 1),
+                type="playground",
+            ),
+            Framework(framework_id=1, code="FW"),
+            Module(module_id=1, framework_id=1),
+            mv,
+        ]
+    )
+    session.commit()
+
+    svc = ASTGeneratorService(session)
+    latest = svc._latest_release_in_window(mv)
+    assert latest is not None
+    assert latest.release_id == 9999, (
+        "a module version open via the perpetual release must resolve "
+        "to that release, not fall back to an older one"
+    )
+
+
+def test_resolve_explicit_release_self_reference_at_playground_type(
+    memory_session,
+):
+    """Requesting Playground explicitly is not "past the end" at Playground."""
+    from dpmcore.services.ast_generator import ASTGeneratorService
+
+    session = memory_session
+    mv = ModuleVersion(
+        module_vid=10,
+        module_id=1,
+        code="MV1",
+        start_release_id=1,
+        end_release_id=9999,
+    )
+    session.add_all(
+        [
+            Release(release_id=1, code="4.2", date=date(2025, 10, 31)),
+            Release(
+                release_id=9999,
+                code="Playground",
+                date=date(1970, 1, 1),
+                type="playground",
+            ),
+            Framework(framework_id=1, code="FW"),
+            Module(module_id=1, framework_id=1),
+            mv,
+        ]
+    )
+    session.commit()
+
+    svc = ASTGeneratorService(session)
+    release_row = svc._resolve_explicit_release(
+        "Playground", mv, "MOD", "1.0"
+    )
+    assert release_row.release_id == 9999

--- a/tests/integration/releases/test_release_sort_order.py
+++ b/tests/integration/releases/test_release_sort_order.py
@@ -765,6 +765,42 @@ def test_filter_item_version_self_reference_at_playground_type(
     )
 
 
+def test_filter_active_only_dated_playground_end_is_active(memory_session):
+    """A row ending at Playground is still "active" with no release given."""
+    from dpmcore.dpm_xl.utils.filters import filter_active_only
+
+    session = memory_session
+    session.add_all(
+        [
+            Release(release_id=1, code="4.2", date=date(2025, 10, 31)),
+            Release(
+                release_id=9999,
+                code="Playground",
+                date=date(1970, 1, 1),
+                type="playground",
+            ),
+            Table(table_id=1),
+            TableVersion(
+                table_vid=1,
+                table_id=1,
+                code="T1",
+                start_release_id=1,
+                end_release_id=9999,
+            ),
+        ]
+    )
+    session.commit()
+
+    q = filter_active_only(
+        session.query(TableVersion), TableVersion.end_release_id
+    )
+    vids = {tv.table_vid for tv in q.all()}
+    assert vids == {1}, (
+        "T1 ends at the dated Playground sentinel, which never closes, "
+        "so it must still count as active"
+    )
+
+
 # --------------------------------------------------------------------- #
 # Same self-reference gap in three more call sites: ECB validations
 # import, and the AST generator's release-window resolution.

--- a/tests/integration/releases/test_release_sort_order.py
+++ b/tests/integration/releases/test_release_sort_order.py
@@ -528,3 +528,238 @@ def test_undated_release_resolves_to_current_rows(memory_session):
     )
     vids = {tv.table_vid for tv in filtered.all()}
     assert vids == {1}, "undated Playground (latest) yields the current rows"
+
+
+# --------------------------------------------------------------------- #
+# Non-chronological release type
+# A NOT NULL Release.Date schema marks its perpetual release via Release.Type instead, with an irrelevant placeholder date.
+# --------------------------------------------------------------------- #
+
+
+def test_compute_sort_order_playground_type_ignores_its_date() -> None:
+    """A ``"playground"``-typed release sorts latest despite an early date."""
+    assert compute_sort_order(
+        date(1970, 1, 1), "playground"
+    ) == compute_sort_order(None)
+    assert compute_sort_order(date(1970, 1, 1), "playground") > (
+        compute_sort_order(date(2026, 12, 31))
+    )
+
+
+def test_resolve_sort_order_playground_type_with_real_date_is_latest(
+    memory_session,
+):
+    """A dated ``"playground"`` release still resolves as the latest."""
+    session = memory_session
+    session.add(Release(release_id=1, code="4.2", date=date(2025, 10, 31)))
+    session.add(
+        Release(
+            release_id=9999,
+            code="Playground",
+            date=date(1970, 1, 1),
+            type="playground",
+        )
+    )
+    session.commit()
+
+    assert resolve_sort_order(session, 9999) > resolve_sort_order(session, 1)
+
+
+def test_get_last_release_ignores_dated_playground_type(memory_session):
+    """``get_last_release`` is not fooled by a dated ``"playground"`` row."""
+    from dpmcore.dpm_xl.model_queries import ModuleVersionQuery
+
+    session = memory_session
+    session.add_all(
+        [
+            Release(
+                release_id=9999,
+                code="Playground",
+                date=date(1970, 1, 1),
+                type="playground",
+            ),
+            Release(release_id=1, code="4.2", date=date(2025, 10, 31)),
+            Release(release_id=2, code="4.2.1", date=date(2026, 2, 15)),
+        ]
+    )
+    session.commit()
+
+    assert ModuleVersionQuery.get_last_release(session) == 9999
+
+
+def test_module_version_open_via_dated_playground_end_release(
+    memory_session,
+):
+    """A ``ModuleVersion`` kept open via a dated ``"playground"`` end."""
+    session = memory_session
+    session.add_all(
+        [
+            Release(release_id=1, code="4.2", date=date(2025, 10, 31)),
+            Release(release_id=2, code="4.2.1", date=date(2026, 2, 15)),
+            Release(
+                release_id=9999,
+                code="Playground",
+                date=date(1970, 1, 1),
+                type="playground",
+            ),
+            Framework(framework_id=1, code="FW"),
+            Module(module_id=1, framework_id=1),
+            # Open-ended via the dated Playground sentinel, not None.
+            ModuleVersion(
+                module_vid=10,
+                module_id=1,
+                code="MV1",
+                start_release_id=1,
+                end_release_id=9999,
+            ),
+            Table(table_id=100),
+            TableVersion(
+                table_vid=1000,
+                table_id=100,
+                code="T1",
+                start_release_id=1,
+                end_release_id=9999,
+            ),
+            ModuleVersionComposition(
+                module_vid=10, table_vid=1000, table_id=100
+            ),
+        ]
+    )
+    session.commit()
+
+    svc = HierarchyService(session)
+    deep = svc.get_all_frameworks(deep=True, release_code="4.2.1")
+    fws = [fw for fw in deep if fw["code"] == "FW"]
+    assert len(fws) == 1
+    mv_codes = {mv["code"] for mv in fws[0]["module_versions"]}
+    assert mv_codes == {"MV1"}, (
+        "a ModuleVersion open via a dated 'playground' end_release_id "
+        "must still cover a real, later release — it must not appear "
+        "closed in 1970"
+    )
+
+
+def test_filter_by_release_self_reference_at_playground_type(memory_session):
+    """A row ending at Playground is still open when querying AT Playground."""
+    from dpmcore.dpm_xl.model_queries import ModuleVersionQuery
+    from dpmcore.dpm_xl.utils.filters import filter_by_release
+
+    session = memory_session
+    session.add_all(
+        [
+            Release(release_id=1, code="4.2", date=date(2025, 10, 31)),
+            Release(
+                release_id=9999,
+                code="Playground",
+                date=date(1970, 1, 1),
+                type="playground",
+            ),
+            Table(table_id=1),
+            TableVersion(
+                table_vid=1,
+                table_id=1,
+                code="T1",
+                start_release_id=1,
+                end_release_id=9999,
+            ),
+        ]
+    )
+    session.commit()
+
+    last_release = ModuleVersionQuery.get_last_release(session)
+    assert last_release == 9999
+
+    q = session.query(TableVersion)
+    filtered = filter_by_release(
+        q,
+        start_col=TableVersion.start_release_id,
+        end_col=TableVersion.end_release_id,
+        release_id=last_release,
+    )
+    vids = {tv.table_vid for tv in filtered.all()}
+    assert vids == {1}, (
+        "T1 ends at the perpetual release itself — querying AT that same "
+        "release must not treat it as closed"
+    )
+
+
+def test_filter_by_release_self_reference_at_undated_release(memory_session):
+    """The same self-reference gap, with a genuinely undated release."""
+    from dpmcore.dpm_xl.utils.filters import filter_by_release
+
+    session = memory_session
+    session.add_all(
+        [
+            Release(release_id=1, code="4.2", date=date(2025, 10, 31)),
+            Release(release_id=2, code="Playground", date=None),
+            TableVersion(
+                table_vid=1,
+                table_id=1,
+                start_release_id=1,
+                end_release_id=2,
+            ),
+        ]
+    )
+    session.commit()
+
+    q = session.query(TableVersion)
+    filtered = filter_by_release(
+        q,
+        start_col=TableVersion.start_release_id,
+        end_col=TableVersion.end_release_id,
+        release_id=2,
+    )
+    vids = {tv.table_vid for tv in filtered.all()}
+    assert vids == {1}, (
+        "a row ending at an undated release must still be open when "
+        "querying AT that same undated release"
+    )
+
+
+def test_filter_item_version_self_reference_at_playground_type(
+    memory_session,
+):
+    """``filter_item_version`` has the same self-reference gap as above."""
+    from dpmcore.dpm_xl.utils.filters import filter_item_version
+    from dpmcore.orm.release_sort_order import load_release_sort_orders
+
+    session = memory_session
+    session.add_all(
+        [
+            Release(release_id=1, code="4.2", date=date(2025, 10, 31)),
+            Release(
+                release_id=9999,
+                code="Playground",
+                date=date(1970, 1, 1),
+                type="playground",
+            ),
+            Item(item_id=42, name="Property name"),
+            Category(category_id=1, code="C1"),
+            ItemCategory(
+                item_id=42,
+                start_release_id=1,
+                end_release_id=9999,
+                category_id=1,
+                signature="prop:42",
+            ),
+        ]
+    )
+    session.commit()
+
+    sort_orders = load_release_sort_orders(session)
+    ref_sort_order = resolve_sort_order(session, 9999)
+    assert ref_sort_order == sort_orders[9999]
+
+    q = session.query(ItemCategory).filter(
+        filter_item_version(
+            sort_orders,
+            ref_sort_order,
+            ItemCategory.start_release_id,
+            ItemCategory.end_release_id,
+        )
+    )
+    item_ids = {ic.item_id for ic in q.all()}
+    assert item_ids == {42}, (
+        "ItemCategory ends at the perpetual release itself — querying AT "
+        "that same release must not treat it as closed"
+    )

--- a/tests/integration/releases/test_release_sort_order.py
+++ b/tests/integration/releases/test_release_sort_order.py
@@ -43,13 +43,18 @@ from dpmcore.services.hierarchy import HierarchyService
 
 
 def test_compute_sort_order_from_date() -> None:
-    assert compute_sort_order(date(2025, 3, 4)) == date(2025, 3, 4).toordinal()
+    assert (
+        compute_sort_order(date(2025, 3, 4), None)
+        == date(2025, 3, 4).toordinal()
+    )
     # Earlier date sorts before a later one.
-    assert compute_sort_order(date(2024, 1, 1)) < compute_sort_order(
-        date(2024, 6, 1)
+    assert compute_sort_order(date(2024, 1, 1), None) < compute_sort_order(
+        date(2024, 6, 1), None
     )
     # An undated (unpublished) release sorts after every real date.
-    assert compute_sort_order(None) > compute_sort_order(date(9999, 12, 31))
+    assert compute_sort_order(None, None) > compute_sort_order(
+        date(9999, 12, 31), None
+    )
 
 
 def test_compute_sort_order_is_monotone_in_date() -> None:
@@ -63,7 +68,7 @@ def test_compute_sort_order_is_monotone_in_date() -> None:
         date(2025, 10, 31),
         date(2026, 2, 15),
     ]
-    orders = [compute_sort_order(d) for d in dates]
+    orders = [compute_sort_order(d, None) for d in dates]
     assert orders == sorted(orders)
     # Distinct dates → distinct keys, so no tiebreak is ever needed.
     assert len(set(orders)) == len(orders)
@@ -540,9 +545,9 @@ def test_compute_sort_order_playground_type_ignores_its_date() -> None:
     """A ``"playground"``-typed release sorts latest despite an early date."""
     assert compute_sort_order(
         date(1970, 1, 1), "playground"
-    ) == compute_sort_order(None)
+    ) == compute_sort_order(None, None)
     assert compute_sort_order(date(1970, 1, 1), "playground") > (
-        compute_sort_order(date(2026, 12, 31))
+        compute_sort_order(date(2026, 12, 31), None)
     )
 
 

--- a/tests/integration/releases/test_release_sort_order.py
+++ b/tests/integration/releases/test_release_sort_order.py
@@ -872,7 +872,5 @@ def test_resolve_explicit_release_self_reference_at_playground_type(
     session.commit()
 
     svc = ASTGeneratorService(session)
-    release_row = svc._resolve_explicit_release(
-        "Playground", mv, "MOD", "1.0"
-    )
+    release_row = svc._resolve_explicit_release("Playground", mv, "MOD", "1.0")
     assert release_row.release_id == 9999

--- a/tests/integration/services/test_scope_release_axis.py
+++ b/tests/integration/services/test_scope_release_axis.py
@@ -58,7 +58,7 @@ def _ordered_releases(session):
     """All releases, sorted by date sort order (not the opaque ID)."""
     return sorted(
         session.query(Release).all(),
-        key=lambda r: compute_sort_order(r.date) or 0,
+        key=lambda r: compute_sort_order(r.date, None) or 0,
     )
 
 
@@ -70,7 +70,7 @@ def _release_sort_by_id(session):
     crash with a ``TypeError`` (``int <= None``) instead of failing clearly.
     """
     sort_by_id = {
-        r.release_id: compute_sort_order(r.date)
+        r.release_id: compute_sort_order(r.date, None)
         for r in session.query(Release).all()
     }
     assert all(v is not None for v in sort_by_id.values()), (
@@ -236,7 +236,7 @@ def test_scope_matches_eba_persisted_scope_per_release(fixture_session):
 
     saw_fallback = False
     for rel in _ordered_releases(session):
-        target_sort = compute_sort_order(rel.date)
+        target_sort = compute_sort_order(rel.date, None)
         base = {
             vid
             for vid, mv in versions.items()
@@ -309,7 +309,7 @@ def test_scoped_versions_are_backward_only_and_not_single_day(fixture_session):
     for code in codes:
         expression = _latest_expression(session, code)
         for rel in releases:
-            target_sort = compute_sort_order(rel.date)
+            target_sort = compute_sort_order(rel.date, None)
             result = svc.calculate_from_expression(
                 expression=expression, release_code=rel.code
             )

--- a/tests/unit/migration/test_migration_service.py
+++ b/tests/unit/migration/test_migration_service.py
@@ -365,6 +365,26 @@ class TestRenameWithMetadata:
         assert result.database_path is not None
         assert "Playground" in result.database_path.name
 
+    def test_dated_playground_current_release_is_latest(self, tmp_path):
+        db_path = tmp_path / "dpm.db"
+        engine = create_engine(f"sqlite:///{db_path}", future=True)
+        service = MigrationService(engine)
+
+        csv_dir = tmp_path / "csv"
+        csv_dir.mkdir()
+        # Same as above, but with a NOT NULL placeholder date instead of None.
+        (csv_dir / "Release.csv").write_text(
+            "ReleaseID,Code,Date,Type,IsCurrent\n"
+            "1,4.2,2026-01-01,,1\n"
+            "2,Playground,1970-01-01,playground,1\n",
+            encoding="utf-8",
+        )
+
+        result = service.migrate_from_csv_dir(str(csv_dir))
+
+        assert result.database_path is not None
+        assert "Playground" in result.database_path.name
+
     def test_sanitises_unsafe_characters_in_release_code(self, tmp_path):
         db_path = tmp_path / "dpm.db"
         engine = create_engine(f"sqlite:///{db_path}", future=True)

--- a/tests/unit/server/test_structure_release.py
+++ b/tests/unit/server/test_structure_release.py
@@ -316,3 +316,49 @@ class TestQueryReleasesUndatedIsLatest:
                 "4.2.1",
                 "4.2",
             ]
+
+
+class TestQueryReleasesDatedPlaygroundTypeIsLatest:
+    """A "playground"-typed release ranks latest despite a real date.
+
+    Mirrors ``TestQueryReleasesUndatedIsLatest`` for schemas where
+    ``Release.Date`` is ``NOT NULL`` (e.g. DPM Refit): the perpetual
+    working release cannot leave ``date`` empty, so it is marked via
+    ``type="playground"`` instead, typically with an early placeholder
+    date such as 1970-01-01. That date must not rank it as the oldest
+    release.
+    """
+
+    def test_dated_playground_type_is_latest(self, engine):
+        from dpmcore.services.structure import StructureService
+
+        with Session(engine) as session:
+            session.add_all(
+                [
+                    Release(release_id=1, code="4.2", date=date(2025, 10, 31)),
+                    Release(
+                        release_id=2, code="4.2.1", date=date(2026, 2, 15)
+                    ),
+                    Release(
+                        release_id=9999,
+                        code="Playground",
+                        date=date(1970, 1, 1),
+                        type="playground",
+                    ),
+                ]
+            )
+            session.commit()
+            svc = StructureService(session)
+
+            latest, _ = svc.query_releases(latest=True)
+            assert [r["code"] for r in latest] == ["Playground"]
+
+            all_rows, total = svc.query_releases()
+            assert total == 3
+            # Latest first: dated Playground (by type, not by its 1970
+            # date), then 4.2.1, then 4.2.
+            assert [r["code"] for r in all_rows] == [
+                "Playground",
+                "4.2.1",
+                "4.2",
+            ]

--- a/tests/unit/services/test_ast_generator.py
+++ b/tests/unit/services/test_ast_generator.py
@@ -746,8 +746,9 @@ class TestLatestReleaseInWindow:
         svc, _, _ = _bare_svc()
         svc.session = MagicMock()
         mv = SimpleNamespace(start_release_id=42, end_release_id=None)
-        # resolve_sort_order issues session.query(Release.date).filter(
-        # Release.release_id == ...).first(); no matching Release row
+        # resolve_sort_order issues session.query(Release.date,
+        # Release.type).filter(Release.release_id == ...).first(); no
+        # matching Release row
         # (first() returns None) has no sort order, so the helper raises.
         # An undated release, by contrast, resolves to the latest sentinel.
         svc.session.query.return_value.filter.return_value.first.return_value = (  # noqa: E501
@@ -765,7 +766,7 @@ class TestLatestReleaseInWindow:
         # Two resolve_sort_order calls: first returns a dated release,
         # second finds no Release row so the end-bound resolver raises.
         svc.session.query.return_value.filter.return_value.first.side_effect = [  # noqa: E501
-            (date(2024, 1, 1),),
+            (date(2024, 1, 1), None),
             None,
         ]
         with pytest.raises(


### PR DESCRIPTION
Fixes #295 

## Summary

Schemas with `Release.Date` NOT NULL mark their perpetual "always open" release via `Release.Type = "playground"` instead, with a meaningless placeholder date (e.g. `1970-01-01`). dpmcore compared that date literally, so it ranked as the oldest release instead of the latest. Any row "still open" via that sentinel looked closed, and disappeared from queries at the real current release.

- `compute_sort_order` (and every caller that loads `Release.date`) now also takes `Release.type`; a type in `_NON_CHRONOLOGICAL_TYPES` (currently just `"playground"`) sorts as latest regardless of its literal date.
- `filter_by_release` now also treats a row ending at any "always latest" release (undated or non-chronological) as open when queried at that same release.
- `filter_item_version` had the identical self-reference gap (same pattern, used by `HierarchyService` for versioned `ItemCategory`/`Item`). Not covered by the original report, but reachable the same way. Fixed identically.

## Checklist

- [X] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [X] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [X] Documentation updated (if applicable)

## Impact / Risk

- Breaking changes? (public API / CLI / REST endpoints / Django models)
- Database schema or migration concerns?
- Notes for release/changelog?

## Notes

<!-- Follow-ups, TODOs, or anything reviewers should know. -->
