### PR TITLE
feat(semantic): expose operations_data and validate precondition links

### DIFF
--- a/src/dpmcore/dpm_xl/model_queries.py
+++ b/src/dpmcore/dpm_xl/model_queries.py
@@ -620,6 +620,61 @@ class TableVersionQuery:
             )
         return query.first() is not None
 
+    @staticmethod
+    def get_abstract_table_codes(
+        session: "Session",
+        table_codes: Sequence[str],
+        release_id: int | None,
+    ) -> dict[str, str]:
+        """Map each table code to its abstract-table code.
+
+        ``abstract_table_id`` is a FK to the abstract ``Table``, not a
+        specific version. Falls back to the table's own code if it has
+        none, or none open at ``release_id``.
+
+        Args:
+            session: SQLAlchemy session.
+            table_codes: Table version codes to resolve.
+            release_id: Release filter, applied to both the requested
+                tables and their abstract tables independently.
+
+        Returns:
+            ``{table_code: abstract_table_code}``, one entry per code in
+            ``table_codes`` that actually resolves to a table version.
+        """
+        if not table_codes:
+            return {}
+        rows = filter_by_release(
+            session.query(
+                TableVersion.code,
+                TableVersion.abstract_table_id,
+            ).filter(TableVersion.code.in_(list(table_codes))),
+            TableVersion.start_release_id,
+            TableVersion.end_release_id,
+            release_id,
+        ).all()
+        abstract_table_ids = {
+            abstract_table_id
+            for _code, abstract_table_id in rows
+            if abstract_table_id is not None
+        }
+        abstract_code_by_table_id: dict[int, str] = {}
+        if abstract_table_ids:
+            abstract_code_by_table_id = dict(
+                filter_by_release(
+                    session.query(
+                        TableVersion.table_id, TableVersion.code
+                    ).filter(TableVersion.table_id.in_(abstract_table_ids)),
+                    TableVersion.start_release_id,
+                    TableVersion.end_release_id,
+                    release_id,
+                ).all()
+            )
+        return {
+            code: abstract_code_by_table_id.get(abstract_table_id, code)
+            for code, abstract_table_id in rows
+        }
+
 
 # ------------------------------------------------------------------ #
 # Operator / OperatorArgument queries

--- a/src/dpmcore/dpm_xl/model_queries.py
+++ b/src/dpmcore/dpm_xl/model_queries.py
@@ -697,11 +697,16 @@ class TableVersionQuery:
                 children_by_table_id.setdefault(abstract_table_id, set()).add(
                     child_code
                 )
-        return {
-            code: {code}
-            | children_by_table_id.get(table_id_by_code.get(code), set())
-            for code in codes
-        }
+        result: dict[str, set[str]] = {}
+        for code in codes:
+            table_id = table_id_by_code.get(code)
+            children = (
+                children_by_table_id.get(table_id, set())
+                if table_id is not None
+                else set()
+            )
+            result[code] = {code} | children
+        return result
 
 
 class TableGroupQuery:

--- a/src/dpmcore/dpm_xl/model_queries.py
+++ b/src/dpmcore/dpm_xl/model_queries.py
@@ -1171,7 +1171,7 @@ class ModuleVersionQuery:
             release_id: Optional release filter.
             include_ghosts: When True, skip the ghost-fallback
                 substitution and return the raw release-covering rows,
-                ghosts included. Leave False for scope computation, 
+                ghosts included. Leave False for scope computation,
                 where a ghost has no reporting period of its own.
 
         Returns:

--- a/src/dpmcore/dpm_xl/model_queries.py
+++ b/src/dpmcore/dpm_xl/model_queries.py
@@ -982,6 +982,25 @@ def _vids_filter(vids: Sequence[int]) -> Callable[[Any], Any]:
     return apply
 
 
+def _resolve_covering(
+    build_query: Callable[[Callable[[Any], Any]], Any],
+    materialize: Callable[[Any], list[Any]],
+    cols: list[str],
+    release_id: int | None,
+) -> pd.DataFrame:
+    """Release-filtered module versions, ghosts included as-is.
+
+    A ghost is still a real module version covering the release window;
+    it only lacks a distinct reporting period, which matters for scope
+    resolution (see :func:`_resolve_with_ghost_fallback`) but not for a
+    plain "does this belong to a live module version" check.
+    """
+    return pd.DataFrame(
+        materialize(build_query(_release_filter(release_id))),
+        columns=cols,
+    )
+
+
 def _resolve_with_ghost_fallback(
     session: "Session",
     build_query: Callable[[Callable[[Any], Any]], Any],
@@ -1015,10 +1034,7 @@ def _resolve_with_ghost_fallback(
         DataFrame of resolved module versions, ghosts replaced by their
         prior non-collapsed fallback where one exists.
     """
-    covering = pd.DataFrame(
-        materialize(build_query(_release_filter(release_id))),
-        columns=cols,
-    )
+    covering = _resolve_covering(build_query, materialize, cols, release_id)
     # Without a target release there is no "prior" to fall back to;
     # keep the historical behaviour of simply dropping ghosts.
     if release_id is None or covering.empty:
@@ -1145,6 +1161,7 @@ class ModuleVersionQuery:
         session: "Session",
         table_codes: Sequence[str],
         release_id: int | None = None,
+        include_ghosts: bool = False,
     ) -> pd.DataFrame:
         """Query modules by table codes.
 
@@ -1152,6 +1169,10 @@ class ModuleVersionQuery:
             session: SQLAlchemy session.
             table_codes: List of table codes.
             release_id: Optional release filter.
+            include_ghosts: When True, skip the ghost-fallback
+                substitution and return the raw release-covering rows,
+                ghosts included. Leave False for scope computation, 
+                where a ghost has no reporting period of its own.
 
         Returns:
             DataFrame with module version info.
@@ -1201,6 +1222,10 @@ class ModuleVersionQuery:
         def materialize(query: Any) -> list[Any]:
             return chunked_in(query, TableVersion.code, table_codes)
 
+        if include_ghosts:
+            return _resolve_covering(
+                build_query, materialize, cols, release_id
+            )
         return _resolve_with_ghost_fallback(
             session, build_query, materialize, cols, release_id
         )
@@ -1210,6 +1235,7 @@ class ModuleVersionQuery:
         session: "Session",
         precondition_items: Sequence[str],
         release_id: int | None = None,
+        include_ghosts: bool = False,
     ) -> pd.DataFrame:
         """Query modules for precondition items.
 
@@ -1217,6 +1243,10 @@ class ModuleVersionQuery:
             session: SQLAlchemy session.
             precondition_items: Filing indicator codes.
             release_id: Optional release filter.
+            include_ghosts: When True, skip the ghost-fallback
+                substitution and return the raw release-covering rows,
+                ghosts included. Leave False for scope computation,
+                where a ghost has no reporting period of its own.
 
         Returns:
             DataFrame with module version info.
@@ -1271,6 +1301,10 @@ class ModuleVersionQuery:
         def materialize(query: Any) -> list[Any]:
             return query.all()
 
+        if include_ghosts:
+            return _resolve_covering(
+                build_query, materialize, cols, release_id
+            )
         return _resolve_with_ghost_fallback(
             session, build_query, materialize, cols, release_id
         )

--- a/src/dpmcore/dpm_xl/model_queries.py
+++ b/src/dpmcore/dpm_xl/model_queries.py
@@ -677,6 +677,60 @@ class TableVersionQuery:
             for code, abstract_table_id in rows
         }
 
+    @staticmethod
+    def get_concrete_table_codes(
+        session: "Session",
+        codes: Sequence[str],
+        release_id: int | None,
+    ) -> dict[str, set[str]]:
+        """Expand each code to itself plus any concrete tables under it.
+
+        Module composition only links concrete tables, so an abstract
+        code needs its concrete children to find any module.
+
+        Args:
+            session: SQLAlchemy session.
+            codes: Table codes to expand.
+            release_id: Release filter, applied independently to the
+                requested codes and their concrete children.
+
+        Returns:
+            ``{code: {code, *concrete_children}}``, one entry per code.
+        """
+        if not codes:
+            return {}
+        table_id_by_code = dict(
+            filter_by_release(
+                session.query(
+                    TableVersion.code, TableVersion.table_id
+                ).filter(TableVersion.code.in_(list(codes))),
+                TableVersion.start_release_id,
+                TableVersion.end_release_id,
+                release_id,
+            ).all()
+        )
+        table_ids = {
+            tid for tid in table_id_by_code.values() if tid is not None
+        }
+        children_by_table_id: dict[int, set[str]] = {}
+        if table_ids:
+            for abstract_table_id, child_code in filter_by_release(
+                session.query(
+                    TableVersion.abstract_table_id, TableVersion.code
+                ).filter(TableVersion.abstract_table_id.in_(table_ids)),
+                TableVersion.start_release_id,
+                TableVersion.end_release_id,
+                release_id,
+            ).all():
+                children_by_table_id.setdefault(
+                    abstract_table_id, set()
+                ).add(child_code)
+        return {
+            code: {code}
+            | children_by_table_id.get(table_id_by_code.get(code), set())
+            for code in codes
+        }
+
 
 class TableGroupQuery:
     """Query helpers around the TableGroup/TableGroupComposition models."""

--- a/src/dpmcore/dpm_xl/model_queries.py
+++ b/src/dpmcore/dpm_xl/model_queries.py
@@ -701,9 +701,9 @@ class TableVersionQuery:
             return {}
         table_id_by_code = dict(
             filter_by_release(
-                session.query(
-                    TableVersion.code, TableVersion.table_id
-                ).filter(TableVersion.code.in_(list(codes))),
+                session.query(TableVersion.code, TableVersion.table_id).filter(
+                    TableVersion.code.in_(list(codes))
+                ),
                 TableVersion.start_release_id,
                 TableVersion.end_release_id,
                 release_id,
@@ -722,9 +722,9 @@ class TableVersionQuery:
                 TableVersion.end_release_id,
                 release_id,
             ).all():
-                children_by_table_id.setdefault(
-                    abstract_table_id, set()
-                ).add(child_code)
+                children_by_table_id.setdefault(abstract_table_id, set()).add(
+                    child_code
+                )
         return {
             code: {code}
             | children_by_table_id.get(table_id_by_code.get(code), set())

--- a/src/dpmcore/errors.py
+++ b/src/dpmcore/errors.py
@@ -346,6 +346,23 @@ centralised_messages: Dict[str, str] = {
         " to use Property Constraint."
     ),
     "7-2": ("Found a Variable Reference, please check expression"),
+    # Precondition-operation
+    "7-3": (
+        "Precondition related to this operation does not belong to"
+        " any draft module. Precondition variable ID:"
+        " {precondition_variable_ids}."
+    ),
+    "7-4": (
+        "Precondition related to this operation has different"
+        " tables. Precondition tables: {precondition_tables},"
+        " operation abstract tables: {operation_tables}."
+    ),
+    "7-5": (
+        "Precondition related to this operation has variables on"
+        " other modules. Precondition modules:"
+        " {precondition_modules}, operation modules:"
+        " {operation_modules}."
+    ),
 }
 
 

--- a/src/dpmcore/services/_precondition_codes.py
+++ b/src/dpmcore/services/_precondition_codes.py
@@ -23,7 +23,7 @@ answers:
 from __future__ import annotations
 
 import logging
-from typing import Any, List, Optional, Set
+from typing import Any, Callable, List, Optional, Set
 
 logger = logging.getLogger(__name__)
 
@@ -163,3 +163,47 @@ def required_precondition_codes(ast: Any) -> List[str]:
         )
         return []
     return [c for c in extract_precondition_codes(ast) if c in required]
+
+
+def _satisfiable(node: Any, is_ok: Callable[[str], bool]) -> bool:
+    """Predicate version of :func:`_mandatory`'s operator handling.
+
+    ``or``/``xor`` holds if either side does, ``not`` contributes nothing,
+    everything else needs every child to hold.
+    """
+    from dpmcore.dpm_xl.utils.tokens import NOT, OR, XOR
+
+    code = _code_of(node)
+    if code is not None:
+        return is_ok(code)
+
+    op = getattr(node, "op", None)
+    left = getattr(node, "left", None)
+    right = getattr(node, "right", None)
+
+    if op == NOT:
+        return True
+    if op in (OR, XOR) and left is not None and right is not None:
+        return _satisfiable(left, is_ok) or _satisfiable(right, is_ok)
+
+    children = _children(node)
+    if not children:
+        return True
+    return all(_satisfiable(child, is_ok) for child in children)
+
+
+def gate_satisfiable(ast: Any, is_ok: Callable[[str], bool]) -> bool:
+    """Whether a precondition gate can still be satisfied.
+
+    ``is_ok`` judges a leaf code; codes it has no opinion on should return
+    ``True``. ``{v_A} or {v_B}`` needs just one side to pass. Any walk
+    failure returns ``True``, matching :func:`required_precondition_codes`.
+    """
+    try:
+        return _satisfiable(ast, is_ok)
+    except Exception:
+        logger.exception(
+            "Failed to evaluate precondition gate satisfiability; "
+            "continuing without raising.",
+        )
+        return True

--- a/src/dpmcore/services/semantic.py
+++ b/src/dpmcore/services/semantic.py
@@ -750,10 +750,21 @@ class SemanticService:
         table_ok: Callable[[str], bool],
         release_id: Optional[int],
     ) -> None:
-        """Raise ``7-5`` when the gate's modules don't fit (``7-4`` passed)."""
+        """Raise ``7-5`` when the gate's modules don't fit (``7-4`` passed).
+
+        A gate code matched at the abstract level is expanded to its
+        concrete children first, since module composition never links
+        an abstract table directly.
+        """
+        concrete_by_code = TableVersionQuery.get_concrete_table_codes(
+            self.session, list(precondition_tables), release_id
+        )
+        concrete_precondition_tables: set[str] = set().union(
+            *concrete_by_code.values()
+        )
         precondition_modules_df = ModuleVersionQuery.get_from_table_codes(
             self.session,
-            list(precondition_tables),
+            list(concrete_precondition_tables),
             release_id,
             include_ghosts=True,
         )
@@ -768,14 +779,23 @@ class SemanticService:
             if not operand_modules_df.empty
             else set()
         )
-        precondition_modules_by_table: dict[str, set[str]] = {}
+        modules_by_concrete_table: dict[str, set[str]] = {}
         if not precondition_modules_df.empty:
             for table_code, group in precondition_modules_df.groupby(
                 "TableCode"
             ):
-                precondition_modules_by_table[str(table_code)] = set(
+                modules_by_concrete_table[str(table_code)] = set(
                     group["ModuleCode"]
                 )
+        precondition_modules_by_table: dict[str, set[str]] = {
+            code: set().union(
+                *(
+                    modules_by_concrete_table.get(concrete, set())
+                    for concrete in concretes
+                )
+            )
+            for code, concretes in concrete_by_code.items()
+        }
 
         def module_ok(code: str) -> bool:
             if code not in precondition_abstract_by_table:

--- a/src/dpmcore/services/semantic.py
+++ b/src/dpmcore/services/semantic.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field, replace
-from typing import TYPE_CHECKING, Any, Optional, cast
+from typing import TYPE_CHECKING, Any, Callable, Optional, cast
 
 from sqlalchemy import func
 
@@ -30,7 +30,10 @@ from dpmcore.orm.operations import (
 from dpmcore.orm.query_utils import chunked_in
 from dpmcore.orm.variables import VariableVersion
 from dpmcore.services._parameters import merge_parameters
-from dpmcore.services._precondition_codes import required_precondition_codes
+from dpmcore.services._precondition_codes import (
+    extract_precondition_codes,
+    gate_satisfiable,
+)
 from dpmcore.services.syntax import SyntaxService
 
 if TYPE_CHECKING:
@@ -320,9 +323,9 @@ class SemanticService:
                 )
             except SemanticError as exc:
                 code = getattr(exc, "code", None)
-                return self._failure(expression, exc, code)
+                return self._precondition_link_failure(result, exc, code)
             except Exception as exc:
-                return self._failure(expression, exc, "UNKNOWN")
+                return self._precondition_link_failure(result, exc, "UNKNOWN")
         return result
 
     # ------------------------------------------------------------------ #
@@ -425,28 +428,53 @@ class SemanticService:
         except Exception as exc:
             return self._failure(expression, exc, "UNKNOWN")
 
-    def _failure(
-        self,
-        expression: str,
-        exc: Exception,
-        error_code: Optional[str],
-    ) -> SemanticResult:
-        """Clear the published per-call state and build a failing result.
+    def _clear_published_state(self) -> None:
+        """Clear per-call state exposed on ``self`` after a failure.
 
-        ``ast`` is cleared alongside ``oc_*``; leaving the previous call's AST
-        readable after a failure invited consumers to act on stale state.
+        Leaving the previous call's AST/``oc_*`` readable after a failure
+        invited consumers to act on stale state.
         """
         self.ast = None
         self.oc_data = None
         self.oc_tables = None
         self.oc_parameters = None
         self.oc_operations_data = None
+
+    def _failure(
+        self,
+        expression: str,
+        exc: Exception,
+        error_code: Optional[str],
+    ) -> SemanticResult:
+        """Clear the published per-call state and build a failing result."""
+        self._clear_published_state()
         return SemanticResult(
             is_valid=False,
             error_message=str(exc),
             error_code=error_code,
             expression=expression,
             error_source="expression",
+        )
+
+    def _precondition_link_failure(
+        self,
+        result: SemanticResult,
+        exc: Exception,
+        error_code: Optional[str],
+    ) -> SemanticResult:
+        """Fail result over a precondition-link mismatch.
+
+        Unlike :meth:`_failure`, ``expression``/gate already validated, so
+        the existing halves survive and ``error_source`` is
+        ``"precondition"`` rather than ``"expression"``.
+        """
+        self._clear_published_state()
+        return replace(
+            result,
+            is_valid=False,
+            error_message=str(exc),
+            error_code=error_code,
+            error_source="precondition",
         )
 
     def _resolution_failure(
@@ -577,8 +605,8 @@ class SemanticService:
         and its tables/modules fit the current expression's (``7-4``/
         ``7-5``). Nothing to check against (malformed, closed, or an
         unresolved ``precondition_operation_vid``) is skipped, not
-        raised. Only codes ``required_precondition_codes`` deems
-        mandatory count, so ``{v_A} or {v_B}`` needs just one side.
+        raised. An ``or``/``xor`` only fails a check when every side
+        does, so ``{v_A} or {v_B}`` needs just one side to pass.
         """
         row = filter_by_release(
             self.session.query(OperationVersion.expression).filter(
@@ -594,28 +622,28 @@ class SemanticService:
             precondition_ast = self._syntax.parse(row[0])
         except Exception:
             return
-        required_codes = set(required_precondition_codes(precondition_ast))
-        if not required_codes:
+        if not extract_precondition_codes(precondition_ast):
             return
         self._check_precondition_filing_indicators(
-            precondition_operation_vid, required_codes, release_id
+            precondition_operation_vid, precondition_ast, release_id
         )
-        self._check_precondition_tables(required_codes, release_id)
+        self._check_precondition_tables(precondition_ast, release_id)
 
     def _check_precondition_filing_indicators(
         self,
         precondition_operation_vid: int,
-        required_codes: set[str],
+        precondition_ast: Any,
         release_id: Optional[int],
     ) -> None:
-        """Raise ``7-3`` if a required filing indicator has gone stale.
+        """Raise ``7-3`` when the gate can no longer be satisfied.
 
-        Not a parameter of any module open at ``release_id``. Codes that
-        are not filing indicators (value conditions, plain variables) are
-        ignored. Not scope-relevant.
+        A code that is not a filing indicator (value condition, plain
+        variable) always counts as live. An ``or``/``xor`` of filing
+        indicators only fails once every side has gone stale.
         """
+        all_codes = set(extract_precondition_codes(precondition_ast))
         filing_indicator_codes = ModuleVersionQuery.get_filing_indicator_codes(
-            self.session, required_codes
+            self.session, all_codes
         )
         if not filing_indicator_codes:
             return
@@ -626,48 +654,54 @@ class SemanticService:
             include_ghosts=True,
         )
         live_codes = set(modules_df["Code"]) if not modules_df.empty else set()
-        if not filing_indicator_codes.issubset(live_codes):
-            variable_ids = sorted(
-                {
-                    vid
-                    for (vid,) in self.session.query(
-                        OperandReference.variable_id
-                    )
-                    .join(
-                        OperationNode,
-                        OperandReference.node_id == OperationNode.node_id,
-                    )
-                    .join(
-                        VariableVersion,
-                        OperandReference.variable_id
-                        == VariableVersion.variable_id,
-                    )
-                    .filter(
-                        OperationNode.operation_vid
-                        == precondition_operation_vid,
-                        VariableVersion.code.in_(filing_indicator_codes),
-                    )
-                    .distinct()
-                    .all()
-                }
-            )
-            raise SemanticError(
-                "7-3",
-                precondition_variable_ids=", ".join(
-                    str(vid) for vid in variable_ids
-                ),
-            )
+        stale_codes = filing_indicator_codes - live_codes
+        if not stale_codes:
+            return
+
+        def is_live(code: str) -> bool:
+            return code not in stale_codes
+
+        if gate_satisfiable(precondition_ast, is_live):
+            return
+
+        variable_ids = sorted(
+            {
+                vid
+                for (vid,) in self.session.query(OperandReference.variable_id)
+                .join(
+                    OperationNode,
+                    OperandReference.node_id == OperationNode.node_id,
+                )
+                .join(
+                    VariableVersion,
+                    OperandReference.variable_id
+                    == VariableVersion.variable_id,
+                )
+                .filter(
+                    OperationNode.operation_vid == precondition_operation_vid,
+                    VariableVersion.code.in_(stale_codes),
+                )
+                .distinct()
+                .all()
+            }
+        )
+        raise SemanticError(
+            "7-3",
+            precondition_variable_ids=(
+                ", ".join(str(vid) for vid in variable_ids)
+                if variable_ids
+                else ", ".join(sorted(stale_codes))
+            ),
+        )
 
     def _check_precondition_tables(
-        self, required_codes: set[str], release_id: Optional[int]
+        self, precondition_ast: Any, release_id: Optional[int]
     ) -> None:
-        """Raise ``7-4``/``7-5`` when the link's own tables don't fit.
+        """Raise ``7-4``/``7-5`` when the gate's tables/modules don't fit.
 
-        ``required_codes`` may include non-table codes (a value condition
-        like ``{v_BM} = 'G-SIB'`` yields ``BM``); ``get_abstract_table_codes``
-        filters those out and canonicalizes the rest to their abstract
-        parent, so both sides of the ``7-4`` comparison match. Skipped
-        when either side has no table to compare.
+        A code with no table (a value condition like ``{v_BM} = 'G-SIB'``)
+        never blocks the gate. An ``or``/``xor`` of table codes only
+        fails once every side mismatches, mirroring the ``7-3`` check.
         """
         operand_tables = list(self.oc_tables.keys()) if self.oc_tables else []
         if not operand_tables:
@@ -677,25 +711,46 @@ class SemanticService:
         )
         operand_abstract_tables = set(abstract_by_table.values())
 
+        all_codes = extract_precondition_codes(precondition_ast)
         precondition_abstract_by_table = (
             TableVersionQuery.get_abstract_table_codes(
-                self.session, list(required_codes), release_id
+                self.session, all_codes, release_id
             )
         )
         if not precondition_abstract_by_table:
             return
         precondition_tables = set(precondition_abstract_by_table.keys())
-        precondition_abstract_tables = set(
-            precondition_abstract_by_table.values()
-        )
 
-        if not precondition_abstract_tables.issubset(operand_abstract_tables):
+        def table_ok(code: str) -> bool:
+            abstract = precondition_abstract_by_table.get(code)
+            return abstract is None or abstract in operand_abstract_tables
+
+        if not gate_satisfiable(precondition_ast, table_ok):
             raise SemanticError(
                 "7-4",
                 precondition_tables=", ".join(sorted(precondition_tables)),
                 operation_tables=", ".join(sorted(operand_abstract_tables)),
             )
 
+        self._check_precondition_modules(
+            precondition_ast,
+            precondition_tables,
+            precondition_abstract_by_table,
+            operand_tables,
+            table_ok,
+            release_id,
+        )
+
+    def _check_precondition_modules(
+        self,
+        precondition_ast: Any,
+        precondition_tables: set[str],
+        precondition_abstract_by_table: dict[str, str],
+        operand_tables: list[str],
+        table_ok: Callable[[str], bool],
+        release_id: Optional[int],
+    ) -> None:
+        """Raise ``7-5`` when the gate's modules don't fit (``7-4`` passed)."""
         precondition_modules_df = ModuleVersionQuery.get_from_table_codes(
             self.session,
             list(precondition_tables),
@@ -708,17 +763,33 @@ class SemanticService:
             release_id,
             include_ghosts=True,
         )
-        precondition_modules = (
-            set(precondition_modules_df["ModuleCode"])
-            if not precondition_modules_df.empty
-            else set()
-        )
         operand_modules = (
             set(operand_modules_df["ModuleCode"])
             if not operand_modules_df.empty
             else set()
         )
-        if not precondition_modules.issubset(operand_modules):
+        precondition_modules_by_table: dict[str, set[str]] = {}
+        if not precondition_modules_df.empty:
+            for table_code, group in precondition_modules_df.groupby(
+                "TableCode"
+            ):
+                precondition_modules_by_table[str(table_code)] = set(
+                    group["ModuleCode"]
+                )
+
+        def module_ok(code: str) -> bool:
+            if code not in precondition_abstract_by_table:
+                return True
+            modules = precondition_modules_by_table.get(code, set())
+            return bool(modules & operand_modules)
+
+        def fits(code: str) -> bool:
+            return table_ok(code) and module_ok(code)
+
+        if not gate_satisfiable(precondition_ast, fits):
+            precondition_modules: set[str] = set()
+            for modules in precondition_modules_by_table.values():
+                precondition_modules |= modules
             raise SemanticError(
                 "7-5",
                 precondition_modules=", ".join(sorted(precondition_modules)),

--- a/src/dpmcore/services/semantic.py
+++ b/src/dpmcore/services/semantic.py
@@ -14,19 +14,23 @@ from dpmcore.dpm_xl.ast.nodes import (
     parameter_default_value,
 )
 from dpmcore.dpm_xl.ast.operands import OperandsChecking
-from dpmcore.dpm_xl.model_queries import ModuleVersionQuery
+from dpmcore.dpm_xl.model_queries import ModuleVersionQuery, TableVersionQuery
 from dpmcore.dpm_xl.semantic_analyzer import InputAnalyzer
-from dpmcore.dpm_xl.utils.filters import resolve_release_id
+from dpmcore.dpm_xl.utils.filters import filter_by_release, resolve_release_id
 from dpmcore.dpm_xl.warning_collector import collect_warnings
 from dpmcore.errors import SemanticError
 from dpmcore.orm.infrastructure import Release
 from dpmcore.orm.operations import (
+    OperandReference,
+    OperationNode,
     OperationScope,
     OperationScopeComposition,
     OperationVersion,
 )
 from dpmcore.orm.query_utils import chunked_in
+from dpmcore.orm.variables import VariableVersion
 from dpmcore.services._parameters import merge_parameters
+from dpmcore.services._precondition_codes import extract_precondition_codes
 from dpmcore.services.syntax import SyntaxService
 
 if TYPE_CHECKING:
@@ -230,6 +234,7 @@ class SemanticService:
         release_code: Optional[str] = None,
         *,
         precondition_expression: Optional[str] = None,
+        precondition_operation_vid: Optional[int] = None,
     ) -> SemanticResult:
         """Full semantic validation of *expression* and its optional gate.
 
@@ -274,6 +279,13 @@ class SemanticService:
                 ``None``, the result is exactly as before this argument
                 existed: ``precondition`` is ``None`` and ``is_valid``
                 describes ``expression`` alone.
+            precondition_operation_vid: Optional VID of a separately
+                persisted ``OperationVersion`` gating this one (its
+                ``precondition_operation_vid`` self-FK), distinct from
+                ``precondition_expression``. Cross-checked against the
+                current module scope when ``expression`` is valid
+                (``7-3``/``7-4``/``7-5``); a VID with nothing to check
+                against is accepted.
         """
         try:
             resolved = self._resolve_release(release_id, release_code)
@@ -288,17 +300,30 @@ class SemanticService:
             )
 
         if precondition_expression is None:
-            return self._validate_resolved(expression, resolved)
-
-        # Gate first, main expression last: the trailing ``self.ast`` /
-        # ``self.oc_*`` must describe the main expression (see docstring).
-        precondition = _as_gate_verdict(
-            self._validate_resolved(
-                precondition_expression, resolved, as_precondition=True
+            result = self._validate_resolved(expression, resolved)
+        else:
+            # Gate first, main expression last: the trailing ``self.ast`` /
+            # ``self.oc_*`` must describe the main expression (see
+            # docstring).
+            precondition = _as_gate_verdict(
+                self._validate_resolved(
+                    precondition_expression, resolved, as_precondition=True
+                )
             )
-        )
-        main = self._validate_resolved(expression, resolved)
-        return self._combine(main, self._cross_check(main, precondition))
+            main = self._validate_resolved(expression, resolved)
+            result = self._combine(main, self._cross_check(main, precondition))
+
+        if result.is_valid and precondition_operation_vid is not None:
+            try:
+                self._check_precondition_link(
+                    precondition_operation_vid, resolved
+                )
+            except SemanticError as exc:
+                code = getattr(exc, "code", None)
+                return self._failure(expression, exc, code)
+            except Exception as exc:
+                return self._failure(expression, exc, "UNKNOWN")
+        return result
 
     # ------------------------------------------------------------------ #
     # Internals
@@ -536,6 +561,138 @@ class SemanticService:
             release_id=release_id,
             release_code=release_code,
         ).is_valid
+
+    # ------------------------------------------------------------------ #
+    # Precondition-operation link (``precondition_operation_vid``)
+    # ------------------------------------------------------------------ #
+
+    def _check_precondition_link(
+        self, precondition_operation_vid: int, release_id: Optional[int]
+    ) -> None:
+        """Cross-check an externally-linked precondition operation.
+
+        Its persisted filing-indicator variables must still be live
+        (``7-3``), and its own expression's tables/modules must fit the
+        current expression's (``7-4``/``7-5``).
+        """
+        self._check_precondition_filing_indicators(
+            precondition_operation_vid, release_id
+        )
+        expression_row = (
+            self.session.query(OperationVersion.expression)
+            .filter(
+                OperationVersion.operation_vid == precondition_operation_vid
+            )
+            .first()
+        )
+        if expression_row is not None and expression_row[0]:
+            self._check_precondition_tables(expression_row[0], release_id)
+
+    def _check_precondition_filing_indicators(
+        self, precondition_operation_vid: int, release_id: Optional[int]
+    ) -> None:
+        """Raise ``7-3`` if a referenced filing indicator has gone stale.
+
+        Not a parameter of any module open at ``release_id``.
+        Non-filing-indicator variables are ignored (not scope-relevant).
+        """
+        variable_ids = sorted(
+            {
+                vid
+                for (vid,) in self.session.query(OperandReference.variable_id)
+                .join(
+                    OperationNode,
+                    OperandReference.node_id == OperationNode.node_id,
+                )
+                .filter(
+                    OperationNode.operation_vid == precondition_operation_vid,
+                    OperandReference.variable_id.isnot(None),
+                )
+                .distinct()
+                .all()
+            }
+        )
+        if not variable_ids:
+            return
+        codes = {
+            code
+            for (code,) in filter_by_release(
+                self.session.query(VariableVersion.code).filter(
+                    VariableVersion.variable_id.in_(variable_ids)
+                ),
+                VariableVersion.start_release_id,
+                VariableVersion.end_release_id,
+                release_id,
+            ).all()
+        }
+        filing_indicator_codes = ModuleVersionQuery.get_filing_indicator_codes(
+            self.session, codes
+        )
+        if not filing_indicator_codes:
+            return
+        modules_df = ModuleVersionQuery.get_precondition_module_versions(
+            self.session, list(filing_indicator_codes), release_id
+        )
+        live_codes = set(modules_df["Code"]) if not modules_df.empty else set()
+        if not filing_indicator_codes.issubset(live_codes):
+            raise SemanticError(
+                "7-3",
+                precondition_variable_ids=", ".join(
+                    str(vid) for vid in variable_ids
+                ),
+            )
+
+    def _check_precondition_tables(
+        self, precondition_expression: str, release_id: Optional[int]
+    ) -> None:
+        """Raise ``7-4``/``7-5`` when the link's own items don't fit.
+
+        A malformed expression is skipped, not raised. Uses
+        ``extract_precondition_codes`` since dpmcore's parser produces
+        ``VarRef``, not ``PreconditionItem``, for these references.
+        """
+        try:
+            precondition_ast = self._syntax.parse(precondition_expression)
+        except Exception:
+            return
+        precondition_items = extract_precondition_codes(precondition_ast)
+        if not precondition_items:
+            return
+
+        operand_tables = list(self.oc_tables.keys()) if self.oc_tables else []
+        abstract_by_table = TableVersionQuery.get_abstract_table_codes(
+            self.session, operand_tables, release_id
+        )
+        operand_abstract_tables = set(abstract_by_table.values())
+        if not set(precondition_items).issubset(operand_abstract_tables):
+            raise SemanticError(
+                "7-4",
+                precondition_tables=", ".join(precondition_items),
+                operation_tables=", ".join(sorted(operand_abstract_tables)),
+            )
+
+        precondition_modules_df = ModuleVersionQuery.get_from_table_codes(
+            self.session, precondition_items, release_id
+        )
+        operand_modules_df = ModuleVersionQuery.get_from_table_codes(
+            self.session, operand_tables, release_id
+        )
+        precondition_modules = (
+            set(precondition_modules_df["ModuleCode"])
+            if not precondition_modules_df.empty
+            else set()
+        )
+        operand_modules = (
+            set(operand_modules_df["ModuleCode"])
+            if not operand_modules_df.empty
+            else set()
+        )
+        if not precondition_modules.issubset(operand_modules):
+            raise SemanticError(
+                "7-5",
+                precondition_modules=", ".join(sorted(precondition_modules)),
+                operation_modules=", ".join(sorted(operand_modules)),
+            )
 
     # ------------------------------------------------------------------ #
     # Scope-wide parameter consistency (against persisted operations)

--- a/src/dpmcore/services/semantic.py
+++ b/src/dpmcore/services/semantic.py
@@ -783,9 +783,7 @@ class SemanticService:
             else set()
         )
         modules_by_concrete_table: dict[str, set[str]] = {}
-        for table_code, group in precondition_modules_df.groupby(
-            "TableCode"
-        ):
+        for table_code, group in precondition_modules_df.groupby("TableCode"):
             modules_by_concrete_table[str(table_code)] = set(
                 group["ModuleCode"]
             )

--- a/src/dpmcore/services/semantic.py
+++ b/src/dpmcore/services/semantic.py
@@ -217,6 +217,7 @@ class SemanticService:
         self.oc_data: Any = None
         self.oc_tables: Any = None
         self.oc_parameters: tuple[ParameterInfo, ...] | None = None
+        self.oc_operations_data: Any = None
 
     # ------------------------------------------------------------------ #
     # Public API
@@ -256,7 +257,8 @@ class SemanticService:
           bound across them must declare one type.
 
         The halves are evaluated gate-first, so the per-call state this service
-        publishes (``ast``, ``oc_data``, ``oc_tables``, ``oc_parameters``)
+        publishes (``ast``, ``oc_data``, ``oc_tables``, ``oc_parameters``,
+        ``oc_operations_data``)
         describes the *main* expression when the call returns — what existing
         consumers of this method already rely on.
 
@@ -364,6 +366,7 @@ class SemanticService:
                 self.oc_data = oc.data
                 self.oc_tables = oc.tables
                 self.oc_parameters = _parameters_from_oc(oc)
+                self.oc_operations_data = oc.operations_data
 
                 analyzer = InputAnalyzer(expression)
                 analyzer.data = oc.data
@@ -410,6 +413,7 @@ class SemanticService:
         self.oc_data = None
         self.oc_tables = None
         self.oc_parameters = None
+        self.oc_operations_data = None
         return SemanticResult(
             is_valid=False,
             error_message=str(exc),

--- a/src/dpmcore/services/semantic.py
+++ b/src/dpmcore/services/semantic.py
@@ -633,7 +633,10 @@ class SemanticService:
         if not filing_indicator_codes:
             return
         modules_df = ModuleVersionQuery.get_precondition_module_versions(
-            self.session, list(filing_indicator_codes), release_id
+            self.session,
+            list(filing_indicator_codes),
+            release_id,
+            include_ghosts=True,
         )
         live_codes = set(modules_df["Code"]) if not modules_df.empty else set()
         if not filing_indicator_codes.issubset(live_codes):
@@ -674,10 +677,16 @@ class SemanticService:
             )
 
         precondition_modules_df = ModuleVersionQuery.get_from_table_codes(
-            self.session, precondition_items, release_id
+            self.session,
+            precondition_items,
+            release_id,
+            include_ghosts=True,
         )
         operand_modules_df = ModuleVersionQuery.get_from_table_codes(
-            self.session, operand_tables, release_id
+            self.session,
+            operand_tables,
+            release_id,
+            include_ghosts=True,
         )
         precondition_modules = (
             set(precondition_modules_df["ModuleCode"])

--- a/src/dpmcore/services/semantic.py
+++ b/src/dpmcore/services/semantic.py
@@ -768,6 +768,9 @@ class SemanticService:
             release_id,
             include_ghosts=True,
         )
+        if precondition_modules_df.empty:
+            # Nothing to check against
+            return
         operand_modules_df = ModuleVersionQuery.get_from_table_codes(
             self.session,
             operand_tables,
@@ -780,13 +783,12 @@ class SemanticService:
             else set()
         )
         modules_by_concrete_table: dict[str, set[str]] = {}
-        if not precondition_modules_df.empty:
-            for table_code, group in precondition_modules_df.groupby(
-                "TableCode"
-            ):
-                modules_by_concrete_table[str(table_code)] = set(
-                    group["ModuleCode"]
-                )
+        for table_code, group in precondition_modules_df.groupby(
+            "TableCode"
+        ):
+            modules_by_concrete_table[str(table_code)] = set(
+                group["ModuleCode"]
+            )
         precondition_modules_by_table: dict[str, set[str]] = {
             code: set().union(
                 *(

--- a/src/dpmcore/services/semantic.py
+++ b/src/dpmcore/services/semantic.py
@@ -30,7 +30,7 @@ from dpmcore.orm.operations import (
 from dpmcore.orm.query_utils import chunked_in
 from dpmcore.orm.variables import VariableVersion
 from dpmcore.services._parameters import merge_parameters
-from dpmcore.services._precondition_codes import extract_precondition_codes
+from dpmcore.services._precondition_codes import required_precondition_codes
 from dpmcore.services.syntax import SyntaxService
 
 if TYPE_CHECKING:
@@ -573,62 +573,49 @@ class SemanticService:
     ) -> None:
         """Cross-check an externally-linked precondition operation.
 
-        Its persisted filing-indicator variables must still be live
-        (``7-3``), and its own expression's tables/modules must fit the
-        current expression's (``7-4``/``7-5``).
+        Checks its filing-indicator variables are still live (``7-3``)
+        and its tables/modules fit the current expression's (``7-4``/
+        ``7-5``). Nothing to check against (malformed, closed, or an
+        unresolved ``precondition_operation_vid``) is skipped, not
+        raised. Only codes ``required_precondition_codes`` deems
+        mandatory count, so ``{v_A} or {v_B}`` needs just one side.
         """
-        self._check_precondition_filing_indicators(
-            precondition_operation_vid, release_id
-        )
-        expression_row = (
-            self.session.query(OperationVersion.expression)
-            .filter(
+        row = filter_by_release(
+            self.session.query(OperationVersion.expression).filter(
                 OperationVersion.operation_vid == precondition_operation_vid
-            )
-            .first()
+            ),
+            OperationVersion.start_release_id,
+            OperationVersion.end_release_id,
+            release_id,
+        ).first()
+        if row is None or not row[0]:
+            return
+        try:
+            precondition_ast = self._syntax.parse(row[0])
+        except Exception:
+            return
+        required_codes = set(required_precondition_codes(precondition_ast))
+        if not required_codes:
+            return
+        self._check_precondition_filing_indicators(
+            precondition_operation_vid, required_codes, release_id
         )
-        if expression_row is not None and expression_row[0]:
-            self._check_precondition_tables(expression_row[0], release_id)
+        self._check_precondition_tables(required_codes, release_id)
 
     def _check_precondition_filing_indicators(
-        self, precondition_operation_vid: int, release_id: Optional[int]
+        self,
+        precondition_operation_vid: int,
+        required_codes: set[str],
+        release_id: Optional[int],
     ) -> None:
-        """Raise ``7-3`` if a referenced filing indicator has gone stale.
+        """Raise ``7-3`` if a required filing indicator has gone stale.
 
-        Not a parameter of any module open at ``release_id``.
-        Non-filing-indicator variables are ignored (not scope-relevant).
+        Not a parameter of any module open at ``release_id``. Codes that
+        are not filing indicators (value conditions, plain variables) are
+        ignored. Not scope-relevant.
         """
-        variable_ids = sorted(
-            {
-                vid
-                for (vid,) in self.session.query(OperandReference.variable_id)
-                .join(
-                    OperationNode,
-                    OperandReference.node_id == OperationNode.node_id,
-                )
-                .filter(
-                    OperationNode.operation_vid == precondition_operation_vid,
-                    OperandReference.variable_id.isnot(None),
-                )
-                .distinct()
-                .all()
-            }
-        )
-        if not variable_ids:
-            return
-        codes = {
-            code
-            for (code,) in filter_by_release(
-                self.session.query(VariableVersion.code).filter(
-                    VariableVersion.variable_id.in_(variable_ids)
-                ),
-                VariableVersion.start_release_id,
-                VariableVersion.end_release_id,
-                release_id,
-            ).all()
-        }
         filing_indicator_codes = ModuleVersionQuery.get_filing_indicator_codes(
-            self.session, codes
+            self.session, required_codes
         )
         if not filing_indicator_codes:
             return
@@ -640,6 +627,30 @@ class SemanticService:
         )
         live_codes = set(modules_df["Code"]) if not modules_df.empty else set()
         if not filing_indicator_codes.issubset(live_codes):
+            variable_ids = sorted(
+                {
+                    vid
+                    for (vid,) in self.session.query(
+                        OperandReference.variable_id
+                    )
+                    .join(
+                        OperationNode,
+                        OperandReference.node_id == OperationNode.node_id,
+                    )
+                    .join(
+                        VariableVersion,
+                        OperandReference.variable_id
+                        == VariableVersion.variable_id,
+                    )
+                    .filter(
+                        OperationNode.operation_vid
+                        == precondition_operation_vid,
+                        VariableVersion.code.in_(filing_indicator_codes),
+                    )
+                    .distinct()
+                    .all()
+                }
+            )
             raise SemanticError(
                 "7-3",
                 precondition_variable_ids=", ".join(
@@ -648,37 +659,46 @@ class SemanticService:
             )
 
     def _check_precondition_tables(
-        self, precondition_expression: str, release_id: Optional[int]
+        self, required_codes: set[str], release_id: Optional[int]
     ) -> None:
-        """Raise ``7-4``/``7-5`` when the link's own items don't fit.
+        """Raise ``7-4``/``7-5`` when the link's own tables don't fit.
 
-        A malformed expression is skipped, not raised. Uses
-        ``extract_precondition_codes`` since dpmcore's parser produces
-        ``VarRef``, not ``PreconditionItem``, for these references.
+        ``required_codes`` may include non-table codes (a value condition
+        like ``{v_BM} = 'G-SIB'`` yields ``BM``); ``get_abstract_table_codes``
+        filters those out and canonicalizes the rest to their abstract
+        parent, so both sides of the ``7-4`` comparison match. Skipped
+        when either side has no table to compare.
         """
-        try:
-            precondition_ast = self._syntax.parse(precondition_expression)
-        except Exception:
-            return
-        precondition_items = extract_precondition_codes(precondition_ast)
-        if not precondition_items:
-            return
-
         operand_tables = list(self.oc_tables.keys()) if self.oc_tables else []
+        if not operand_tables:
+            return
         abstract_by_table = TableVersionQuery.get_abstract_table_codes(
             self.session, operand_tables, release_id
         )
         operand_abstract_tables = set(abstract_by_table.values())
-        if not set(precondition_items).issubset(operand_abstract_tables):
+
+        precondition_abstract_by_table = (
+            TableVersionQuery.get_abstract_table_codes(
+                self.session, list(required_codes), release_id
+            )
+        )
+        if not precondition_abstract_by_table:
+            return
+        precondition_tables = set(precondition_abstract_by_table.keys())
+        precondition_abstract_tables = set(
+            precondition_abstract_by_table.values()
+        )
+
+        if not precondition_abstract_tables.issubset(operand_abstract_tables):
             raise SemanticError(
                 "7-4",
-                precondition_tables=", ".join(precondition_items),
+                precondition_tables=", ".join(sorted(precondition_tables)),
                 operation_tables=", ".join(sorted(operand_abstract_tables)),
             )
 
         precondition_modules_df = ModuleVersionQuery.get_from_table_codes(
             self.session,
-            precondition_items,
+            list(precondition_tables),
             release_id,
             include_ghosts=True,
         )

--- a/tests/integration/services/test_precondition_operation_link.py
+++ b/tests/integration/services/test_precondition_operation_link.py
@@ -88,7 +88,7 @@ def test_filing_indicator_not_in_any_module_raises_7_3(memory_session):
 
 
 def test_non_filing_indicator_variable_is_ignored(memory_session):
-    # "fact"-typed variable: not scope-relevant, ignored despite no module.
+    # "fact" variable, not scope-relevant: ignored despite no module.
     memory_session.add_all(
         [
             Release(release_id=1, code="3.4", date=datetime.date(2022, 12, 1)),
@@ -134,6 +134,280 @@ def test_operation_with_no_operand_references_is_a_noop(memory_session):
     svc._check_precondition_link(502, release_id=1)  # no raise
 
 
+def _seed_two_filing_indicators(session, *, first_live, second_live):
+    session.add_all(
+        [
+            Release(release_id=1, code="3.4", date=datetime.date(2022, 12, 1)),
+            Variable(variable_id=10, type="filingindicator"),
+            VariableVersion(
+                variable_vid=10,
+                variable_id=10,
+                code="OR_A",
+                start_release_id=1,
+                end_release_id=None,
+            ),
+            Variable(variable_id=11, type="filingindicator"),
+            VariableVersion(
+                variable_vid=11,
+                variable_id=11,
+                code="OR_B",
+                start_release_id=1,
+                end_release_id=None,
+            ),
+            OperationVersion(
+                operation_vid=700,
+                expression="{v_OR_A} or {v_OR_B}",
+                start_release_id=1,
+                end_release_id=None,
+            ),
+            OperationNode(node_id=10, operation_vid=700),
+            OperandReference(
+                operand_reference_id=10, node_id=10, variable_id=10
+            ),
+            OperationNode(node_id=11, operation_vid=700),
+            OperandReference(
+                operand_reference_id=11, node_id=11, variable_id=11
+            ),
+        ]
+    )
+    if first_live:
+        session.add_all(
+            [
+                ModuleVersion(
+                    module_vid=400,
+                    module_id=10,
+                    code="M_OR_A",
+                    version_number="1.0",
+                    start_release_id=1,
+                    end_release_id=None,
+                    from_reference_date=datetime.date(2023, 6, 30),
+                    to_reference_date=None,
+                ),
+                ModuleParameters(module_vid=400, variable_vid=10),
+            ]
+        )
+    if second_live:
+        session.add_all(
+            [
+                ModuleVersion(
+                    module_vid=401,
+                    module_id=11,
+                    code="M_OR_B",
+                    version_number="1.0",
+                    start_release_id=1,
+                    end_release_id=None,
+                    from_reference_date=datetime.date(2023, 6, 30),
+                    to_reference_date=None,
+                ),
+                ModuleParameters(module_vid=401, variable_vid=11),
+            ]
+        )
+    session.flush()
+
+
+def test_or_gate_passes_when_only_one_side_is_live(memory_session):
+    _seed_two_filing_indicators(
+        memory_session, first_live=False, second_live=True
+    )
+    svc = _svc(memory_session)
+
+    svc._check_precondition_link(700, release_id=1)  # no raise
+
+
+def test_or_gate_raises_7_3_when_both_sides_are_stale(memory_session):
+    _seed_two_filing_indicators(
+        memory_session, first_live=False, second_live=False
+    )
+    svc = _svc(memory_session)
+
+    with pytest.raises(SemanticError) as exc_info:
+        svc._check_precondition_link(700, release_id=1)
+    assert exc_info.value.code == "7-3"
+    assert "10" in str(exc_info.value)
+    assert "11" in str(exc_info.value)
+
+
+def test_and_gate_7_3_message_lists_only_the_stale_side(memory_session):
+    # AND needs both sides. The message must name only the stale one.
+    memory_session.add_all(
+        [
+            Release(release_id=1, code="3.4", date=datetime.date(2022, 12, 1)),
+            Variable(variable_id=20, type="filingindicator"),
+            VariableVersion(
+                variable_vid=20,
+                variable_id=20,
+                code="AND_A",
+                start_release_id=1,
+                end_release_id=None,
+            ),
+            Variable(variable_id=21, type="filingindicator"),
+            VariableVersion(
+                variable_vid=21,
+                variable_id=21,
+                code="AND_B",
+                start_release_id=1,
+                end_release_id=None,
+            ),
+            OperationVersion(
+                operation_vid=701,
+                expression="{v_AND_A} and {v_AND_B}",
+                start_release_id=1,
+                end_release_id=None,
+            ),
+            OperationNode(node_id=20, operation_vid=701),
+            OperandReference(
+                operand_reference_id=20, node_id=20, variable_id=20
+            ),
+            OperationNode(node_id=21, operation_vid=701),
+            OperandReference(
+                operand_reference_id=21, node_id=21, variable_id=21
+            ),
+            # Only AND_B is live in an open module. AND_A stays stale.
+            ModuleVersion(
+                module_vid=402,
+                module_id=20,
+                code="M_AND_B",
+                version_number="1.0",
+                start_release_id=1,
+                end_release_id=None,
+                from_reference_date=datetime.date(2023, 6, 30),
+                to_reference_date=None,
+            ),
+            ModuleParameters(module_vid=402, variable_vid=21),
+        ]
+    )
+    memory_session.flush()
+    svc = _svc(memory_session)
+
+    with pytest.raises(SemanticError) as exc_info:
+        svc._check_precondition_link(701, release_id=1)
+    assert exc_info.value.code == "7-3"
+    assert "20" in str(exc_info.value)
+    assert "21" not in str(exc_info.value)
+
+
+def _seed_two_filing_indicators_xor(session, *, first_live, second_live):
+    session.add_all(
+        [
+            Release(release_id=1, code="3.4", date=datetime.date(2022, 12, 1)),
+            Variable(variable_id=12, type="filingindicator"),
+            VariableVersion(
+                variable_vid=12,
+                variable_id=12,
+                code="XOR_A",
+                start_release_id=1,
+                end_release_id=None,
+            ),
+            Variable(variable_id=13, type="filingindicator"),
+            VariableVersion(
+                variable_vid=13,
+                variable_id=13,
+                code="XOR_B",
+                start_release_id=1,
+                end_release_id=None,
+            ),
+            OperationVersion(
+                operation_vid=703,
+                expression="{v_XOR_A} xor {v_XOR_B}",
+                start_release_id=1,
+                end_release_id=None,
+            ),
+            OperationNode(node_id=12, operation_vid=703),
+            OperandReference(
+                operand_reference_id=12, node_id=12, variable_id=12
+            ),
+            OperationNode(node_id=13, operation_vid=703),
+            OperandReference(
+                operand_reference_id=13, node_id=13, variable_id=13
+            ),
+        ]
+    )
+    if first_live:
+        session.add_all(
+            [
+                ModuleVersion(
+                    module_vid=403,
+                    module_id=12,
+                    code="M_XOR_A",
+                    version_number="1.0",
+                    start_release_id=1,
+                    end_release_id=None,
+                    from_reference_date=datetime.date(2023, 6, 30),
+                    to_reference_date=None,
+                ),
+                ModuleParameters(module_vid=403, variable_vid=12),
+            ]
+        )
+    if second_live:
+        session.add_all(
+            [
+                ModuleVersion(
+                    module_vid=404,
+                    module_id=13,
+                    code="M_XOR_B",
+                    version_number="1.0",
+                    start_release_id=1,
+                    end_release_id=None,
+                    from_reference_date=datetime.date(2023, 6, 30),
+                    to_reference_date=None,
+                ),
+                ModuleParameters(module_vid=404, variable_vid=13),
+            ]
+        )
+    session.flush()
+
+
+def test_xor_gate_passes_when_only_one_side_is_live(memory_session):
+    # xor takes the same branch as or in gate_satisfiable.
+    _seed_two_filing_indicators_xor(
+        memory_session, first_live=False, second_live=True
+    )
+    svc = _svc(memory_session)
+
+    svc._check_precondition_link(703, release_id=1)  # no raise
+
+
+def test_xor_gate_raises_7_3_when_both_sides_are_stale(memory_session):
+    _seed_two_filing_indicators_xor(
+        memory_session, first_live=False, second_live=False
+    )
+    svc = _svc(memory_session)
+
+    with pytest.raises(SemanticError) as exc_info:
+        svc._check_precondition_link(703, release_id=1)
+    assert exc_info.value.code == "7-3"
+
+
+def test_7_3_falls_back_to_the_stale_code_without_node_rows(memory_session):
+    # No OperationNode rows, so the message falls back to the stale code.
+    memory_session.add_all(
+        [
+            Release(release_id=1, code="3.4", date=datetime.date(2022, 12, 1)),
+            Variable(variable_id=30, type="filingindicator"),
+            VariableVersion(
+                variable_vid=30,
+                variable_id=30,
+                code="NO_NODES",
+                start_release_id=1,
+                end_release_id=None,
+            ),
+            OperationVersion(
+                operation_vid=702,
+                expression="{v_NO_NODES}",
+                start_release_id=1,
+                end_release_id=None,
+            ),
+        ]
+    )
+    memory_session.flush()
+    svc = _svc(memory_session)
+
+    with pytest.raises(SemanticError) as exc_info:
+        svc._check_precondition_link(702, release_id=1)
+    assert exc_info.value.code == "7-3"
+    assert "NO_NODES" in str(exc_info.value)
+
+
 def test_unknown_precondition_operation_vid_is_a_noop(memory_session):
     memory_session.add(
         Release(release_id=1, code="3.4", date=datetime.date(2022, 12, 1))
@@ -163,13 +437,10 @@ def _seed_precondition_operation(session, operation_vid, expression):
 
 
 def _seed_tables(session, *, fi_shares_operand_module: bool):
-    """Table T1 (module M1), abstract table FI_X, distractor table UNRELATED.
+    """T1 (module M1) with abstract table FI_X. UNRELATED matches neither.
 
-    ``fi_shares_operand_module=True`` puts FI_X in M1 too (both checks
-    pass); otherwise FI_X is only in module M2 (7-5 must fail). UNRELATED
-    is a real table that is not part of any module composition, used to
-    prove a precondition table that doesn't match T1's abstract table
-    still raises 7-4 once it is a genuine table code.
+    ``fi_shares_operand_module=True`` puts FI_X in M1 too, so 7-5 passes.
+    Otherwise FI_X sits only in M2, so 7-5 fails.
     """
     session.add_all(
         [
@@ -268,6 +539,64 @@ def test_matching_table_but_different_module_raises_7_5(memory_session):
 
     with pytest.raises(SemanticError) as exc_info:
         svc._check_precondition_link(602, release_id=1)
+    assert exc_info.value.code == "7-5"
+
+
+def test_or_gate_passes_7_4_when_one_table_matches(memory_session):
+    _seed_tables(memory_session, fi_shares_operand_module=True)
+    _seed_precondition_operation(
+        memory_session, 605, "{v_UNRELATED} or {v_FI_X}"
+    )
+    memory_session.flush()
+    svc = _svc(memory_session)
+    svc.oc_tables = {"T1": {}}
+
+    svc._check_precondition_link(605, release_id=1)  # no raise
+
+
+def test_or_gate_raises_7_4_when_both_tables_mismatch(memory_session):
+    _seed_tables(memory_session, fi_shares_operand_module=True)
+    memory_session.add_all(
+        [
+            Table(table_id=4),
+            TableVersion(
+                table_vid=40,
+                code="UNRELATED2",
+                table_id=4,
+                abstract_table_id=None,
+                start_release_id=1,
+                end_release_id=None,
+            ),
+        ]
+    )
+    memory_session.flush()
+    _seed_precondition_operation(
+        memory_session, 606, "{v_UNRELATED} or {v_UNRELATED2}"
+    )
+    memory_session.flush()
+    svc = _svc(memory_session)
+    svc.oc_tables = {"T1": {}}
+
+    with pytest.raises(SemanticError) as exc_info:
+        svc._check_precondition_link(606, release_id=1)
+    assert exc_info.value.code == "7-4"
+
+
+def test_or_gate_raises_7_5_when_the_matching_tables_module_differs(
+    memory_session,
+):
+    # FI_X passes 7-4 but sits only in M2, and UNRELATED never matches on
+    # table, so no branch fits both table and module and 7-5 must fire.
+    _seed_tables(memory_session, fi_shares_operand_module=False)
+    _seed_precondition_operation(
+        memory_session, 607, "{v_UNRELATED} or {v_FI_X}"
+    )
+    memory_session.flush()
+    svc = _svc(memory_session)
+    svc.oc_tables = {"T1": {}}
+
+    with pytest.raises(SemanticError) as exc_info:
+        svc._check_precondition_link(607, release_id=1)
     assert exc_info.value.code == "7-5"
 
 

--- a/tests/integration/services/test_precondition_operation_link.py
+++ b/tests/integration/services/test_precondition_operation_link.py
@@ -42,7 +42,12 @@ def _seed_filing_indicator(session, *, indicator_in_open_module: bool):
                 start_release_id=1,
                 end_release_id=None,
             ),
-            OperationVersion(operation_vid=500, expression="{v_C_02.00}"),
+            OperationVersion(
+                operation_vid=500,
+                expression="{v_C_02.00}",
+                start_release_id=1,
+                end_release_id=None,
+            ),
             OperationNode(node_id=1, operation_vid=500),
             OperandReference(operand_reference_id=1, node_id=1, variable_id=1),
         ]
@@ -70,7 +75,7 @@ def test_filing_indicator_in_open_module_passes(memory_session):
     _seed_filing_indicator(memory_session, indicator_in_open_module=True)
     svc = _svc(memory_session)
 
-    svc._check_precondition_filing_indicators(500, release_id=1)  # no raise
+    svc._check_precondition_link(500, release_id=1)  # no raise
 
 
 def test_filing_indicator_not_in_any_module_raises_7_3(memory_session):
@@ -78,7 +83,7 @@ def test_filing_indicator_not_in_any_module_raises_7_3(memory_session):
     svc = _svc(memory_session)
 
     with pytest.raises(SemanticError) as exc_info:
-        svc._check_precondition_filing_indicators(500, release_id=1)
+        svc._check_precondition_link(500, release_id=1)
     assert exc_info.value.code == "7-3"
 
 
@@ -95,7 +100,12 @@ def test_non_filing_indicator_variable_is_ignored(memory_session):
                 start_release_id=1,
                 end_release_id=None,
             ),
-            OperationVersion(operation_vid=501, expression="{v_V_FACT}"),
+            OperationVersion(
+                operation_vid=501,
+                expression="{v_V_FACT}",
+                start_release_id=1,
+                end_release_id=None,
+            ),
             OperationNode(node_id=2, operation_vid=501),
             OperandReference(operand_reference_id=2, node_id=2, variable_id=2),
         ]
@@ -103,20 +113,25 @@ def test_non_filing_indicator_variable_is_ignored(memory_session):
     memory_session.flush()
     svc = _svc(memory_session)
 
-    svc._check_precondition_filing_indicators(501, release_id=1)  # no raise
+    svc._check_precondition_link(501, release_id=1)  # no raise
 
 
 def test_operation_with_no_operand_references_is_a_noop(memory_session):
     memory_session.add_all(
         [
             Release(release_id=1, code="3.4", date=datetime.date(2022, 12, 1)),
-            OperationVersion(operation_vid=502, expression="1 + 1"),
+            OperationVersion(
+                operation_vid=502,
+                expression="1 + 1",
+                start_release_id=1,
+                end_release_id=None,
+            ),
         ]
     )
     memory_session.flush()
     svc = _svc(memory_session)
 
-    svc._check_precondition_filing_indicators(502, release_id=1)  # no raise
+    svc._check_precondition_link(502, release_id=1)  # no raise
 
 
 def test_unknown_precondition_operation_vid_is_a_noop(memory_session):
@@ -134,17 +149,34 @@ def test_unknown_precondition_operation_vid_is_a_noop(memory_session):
 # --------------------------------------------------------------------- #
 
 
+def _seed_precondition_operation(session, operation_vid, expression):
+    session.add_all(
+        [
+            OperationVersion(
+                operation_vid=operation_vid,
+                expression=expression,
+                start_release_id=1,
+                end_release_id=None,
+            ),
+        ]
+    )
+
+
 def _seed_tables(session, *, fi_shares_operand_module: bool):
-    """Table T1 (module M1), abstract table FI_X.
+    """Table T1 (module M1), abstract table FI_X, distractor table UNRELATED.
 
     ``fi_shares_operand_module=True`` puts FI_X in M1 too (both checks
-    pass); otherwise FI_X is only in module M2 (7-5 must fail).
+    pass); otherwise FI_X is only in module M2 (7-5 must fail). UNRELATED
+    is a real table that is not part of any module composition, used to
+    prove a precondition table that doesn't match T1's abstract table
+    still raises 7-4 once it is a genuine table code.
     """
     session.add_all(
         [
             Release(release_id=1, code="3.4", date=datetime.date(2022, 12, 1)),
             Table(table_id=1),
             Table(table_id=2),
+            Table(table_id=3),
             TableVersion(
                 table_vid=10,
                 code="T1",
@@ -157,6 +189,14 @@ def _seed_tables(session, *, fi_shares_operand_module: bool):
                 table_vid=20,
                 code="FI_X",
                 table_id=2,
+                abstract_table_id=None,
+                start_release_id=1,
+                end_release_id=None,
+            ),
+            TableVersion(
+                table_vid=30,
+                code="UNRELATED",
+                table_id=3,
                 abstract_table_id=None,
                 start_release_id=1,
                 end_release_id=None,
@@ -197,44 +237,57 @@ def _seed_tables(session, *, fi_shares_operand_module: bool):
 
 def test_matching_table_and_module_passes(memory_session):
     _seed_tables(memory_session, fi_shares_operand_module=True)
+    _seed_precondition_operation(memory_session, 600, "{v_FI_X}")
+    memory_session.flush()
     svc = _svc(memory_session)
     svc.oc_tables = {"T1": {}}
 
-    svc._check_precondition_tables("{v_FI_X}", release_id=1)  # no raise
+    svc._check_precondition_link(600, release_id=1)  # no raise
 
 
 def test_precondition_code_not_among_operand_abstract_tables_raises_7_4(
     memory_session,
 ):
     _seed_tables(memory_session, fi_shares_operand_module=True)
+    _seed_precondition_operation(memory_session, 601, "{v_UNRELATED}")
+    memory_session.flush()
     svc = _svc(memory_session)
     svc.oc_tables = {"T1": {}}
 
     with pytest.raises(SemanticError) as exc_info:
-        svc._check_precondition_tables("{v_UNRELATED}", release_id=1)
+        svc._check_precondition_link(601, release_id=1)
     assert exc_info.value.code == "7-4"
 
 
 def test_matching_table_but_different_module_raises_7_5(memory_session):
     _seed_tables(memory_session, fi_shares_operand_module=False)
+    _seed_precondition_operation(memory_session, 602, "{v_FI_X}")
+    memory_session.flush()
     svc = _svc(memory_session)
     svc.oc_tables = {"T1": {}}
 
     with pytest.raises(SemanticError) as exc_info:
-        svc._check_precondition_tables("{v_FI_X}", release_id=1)
+        svc._check_precondition_link(602, release_id=1)
     assert exc_info.value.code == "7-5"
 
 
 def test_expression_with_no_precondition_codes_is_a_noop(memory_session):
     _seed_tables(memory_session, fi_shares_operand_module=True)
+    _seed_precondition_operation(memory_session, 603, "1 + 1")
+    memory_session.flush()
     svc = _svc(memory_session)
     svc.oc_tables = {"T1": {}}
 
-    svc._check_precondition_tables("1 + 1", release_id=1)  # no raise
+    svc._check_precondition_link(603, release_id=1)  # no raise
 
 
 def test_malformed_precondition_expression_is_a_noop(memory_session):
+    memory_session.add(
+        Release(release_id=1, code="3.4", date=datetime.date(2022, 12, 1))
+    )
+    _seed_precondition_operation(memory_session, 604, "{{{not valid dpm-xl")
+    memory_session.flush()
     svc = _svc(memory_session)
     svc.oc_tables = {"T1": {}}
 
-    svc._check_precondition_tables("{{{not valid dpm-xl", release_id=1)
+    svc._check_precondition_link(604, release_id=1)  # no raise

--- a/tests/integration/services/test_precondition_operation_link.py
+++ b/tests/integration/services/test_precondition_operation_link.py
@@ -727,6 +727,59 @@ def test_abstract_precondition_code_still_raises_7_5_on_real_mismatch(
     assert exc_info.value.code == "7-5"
 
 
+def test_precondition_table_with_no_module_anywhere_is_a_noop(memory_session):
+    # FI_ORPHAN has no children and is never a module member.
+    memory_session.add_all(
+        [
+            Release(release_id=1, code="3.4", date=datetime.date(2022, 12, 1)),
+            Table(table_id=200),
+            Table(table_id=201),
+            Table(table_id=210),
+            TableVersion(
+                table_vid=2100,
+                code="ROOT2",
+                table_id=210,
+                abstract_table_id=None,
+                start_release_id=1,
+                end_release_id=None,
+            ),
+            TableVersion(
+                table_vid=2000,
+                code="T1",
+                table_id=200,
+                abstract_table_id=210,
+                start_release_id=1,
+                end_release_id=None,
+            ),
+            TableVersion(
+                table_vid=2010,
+                code="FI_ORPHAN",
+                table_id=201,
+                abstract_table_id=210,
+                start_release_id=1,
+                end_release_id=None,
+            ),
+            ModuleVersion(
+                module_vid=2000,
+                module_id=200,
+                code="M1",
+                version_number="1.0",
+                start_release_id=1,
+                end_release_id=None,
+            ),
+            ModuleVersionComposition(
+                module_vid=2000, table_id=200, table_vid=2000
+            ),
+        ]
+    )
+    _seed_precondition_operation(memory_session, 802, "{v_FI_ORPHAN}")
+    memory_session.flush()
+    svc = _svc(memory_session)
+    svc.oc_tables = {"T1": {}}
+
+    svc._check_precondition_link(802, release_id=1)  # no raise
+
+
 def test_expression_with_no_precondition_codes_is_a_noop(memory_session):
     _seed_tables(memory_session, fi_shares_operand_module=True)
     _seed_precondition_operation(memory_session, 603, "1 + 1")

--- a/tests/integration/services/test_precondition_operation_link.py
+++ b/tests/integration/services/test_precondition_operation_link.py
@@ -1,0 +1,240 @@
+import datetime
+
+import pytest
+
+from dpmcore.errors import SemanticError
+from dpmcore.orm.infrastructure import Release
+from dpmcore.orm.operations import (
+    OperandReference,
+    OperationNode,
+    OperationVersion,
+)
+from dpmcore.orm.packaging import (
+    ModuleParameters,
+    ModuleVersion,
+    ModuleVersionComposition,
+)
+from dpmcore.orm.rendering import Table, TableVersion
+from dpmcore.orm.variables import Variable, VariableVersion
+from dpmcore.services.semantic import SemanticService
+
+pytestmark = pytest.mark.integration
+
+
+def _svc(session):
+    return SemanticService(session=session)
+
+
+# --------------------------------------------------------------------- #
+# _check_precondition_filing_indicators (error 7-3)
+# --------------------------------------------------------------------- #
+
+
+def _seed_filing_indicator(session, *, indicator_in_open_module: bool):
+    session.add_all(
+        [
+            Release(release_id=1, code="3.4", date=datetime.date(2022, 12, 1)),
+            Variable(variable_id=1, type="filingindicator"),
+            VariableVersion(
+                variable_vid=1,
+                variable_id=1,
+                code="C_02.00",
+                start_release_id=1,
+                end_release_id=None,
+            ),
+            OperationVersion(operation_vid=500, expression="{v_C_02.00}"),
+            OperationNode(node_id=1, operation_vid=500),
+            OperandReference(operand_reference_id=1, node_id=1, variable_id=1),
+        ]
+    )
+    if indicator_in_open_module:
+        session.add_all(
+            [
+                ModuleVersion(
+                    module_vid=100,
+                    module_id=1,
+                    code="COREP_OF",
+                    version_number="1.0",
+                    start_release_id=1,
+                    end_release_id=None,
+                    from_reference_date=datetime.date(2023, 6, 30),
+                    to_reference_date=None,
+                ),
+                ModuleParameters(module_vid=100, variable_vid=1),
+            ]
+        )
+    session.flush()
+
+
+def test_filing_indicator_in_open_module_passes(memory_session):
+    _seed_filing_indicator(memory_session, indicator_in_open_module=True)
+    svc = _svc(memory_session)
+
+    svc._check_precondition_filing_indicators(500, release_id=1)  # no raise
+
+
+def test_filing_indicator_not_in_any_module_raises_7_3(memory_session):
+    _seed_filing_indicator(memory_session, indicator_in_open_module=False)
+    svc = _svc(memory_session)
+
+    with pytest.raises(SemanticError) as exc_info:
+        svc._check_precondition_filing_indicators(500, release_id=1)
+    assert exc_info.value.code == "7-3"
+
+
+def test_non_filing_indicator_variable_is_ignored(memory_session):
+    # "fact"-typed variable: not scope-relevant, ignored despite no module.
+    memory_session.add_all(
+        [
+            Release(release_id=1, code="3.4", date=datetime.date(2022, 12, 1)),
+            Variable(variable_id=2, type="fact"),
+            VariableVersion(
+                variable_vid=2,
+                variable_id=2,
+                code="V_FACT",
+                start_release_id=1,
+                end_release_id=None,
+            ),
+            OperationVersion(operation_vid=501, expression="{v_V_FACT}"),
+            OperationNode(node_id=2, operation_vid=501),
+            OperandReference(operand_reference_id=2, node_id=2, variable_id=2),
+        ]
+    )
+    memory_session.flush()
+    svc = _svc(memory_session)
+
+    svc._check_precondition_filing_indicators(501, release_id=1)  # no raise
+
+
+def test_operation_with_no_operand_references_is_a_noop(memory_session):
+    memory_session.add_all(
+        [
+            Release(release_id=1, code="3.4", date=datetime.date(2022, 12, 1)),
+            OperationVersion(operation_vid=502, expression="1 + 1"),
+        ]
+    )
+    memory_session.flush()
+    svc = _svc(memory_session)
+
+    svc._check_precondition_filing_indicators(502, release_id=1)  # no raise
+
+
+def test_unknown_precondition_operation_vid_is_a_noop(memory_session):
+    memory_session.add(
+        Release(release_id=1, code="3.4", date=datetime.date(2022, 12, 1))
+    )
+    memory_session.flush()
+    svc = _svc(memory_session)
+
+    svc._check_precondition_link(999999, release_id=1)  # no raise
+
+
+# --------------------------------------------------------------------- #
+# _check_precondition_tables (errors 7-4 / 7-5)
+# --------------------------------------------------------------------- #
+
+
+def _seed_tables(session, *, fi_shares_operand_module: bool):
+    """Table T1 (module M1), abstract table FI_X.
+
+    ``fi_shares_operand_module=True`` puts FI_X in M1 too (both checks
+    pass); otherwise FI_X is only in module M2 (7-5 must fail).
+    """
+    session.add_all(
+        [
+            Release(release_id=1, code="3.4", date=datetime.date(2022, 12, 1)),
+            Table(table_id=1),
+            Table(table_id=2),
+            TableVersion(
+                table_vid=10,
+                code="T1",
+                table_id=1,
+                abstract_table_id=2,
+                start_release_id=1,
+                end_release_id=None,
+            ),
+            TableVersion(
+                table_vid=20,
+                code="FI_X",
+                table_id=2,
+                abstract_table_id=None,
+                start_release_id=1,
+                end_release_id=None,
+            ),
+            ModuleVersion(
+                module_vid=200,
+                module_id=1,
+                code="M1",
+                version_number="1.0",
+                start_release_id=1,
+                end_release_id=None,
+            ),
+            ModuleVersionComposition(module_vid=200, table_id=1, table_vid=10),
+        ]
+    )
+    if fi_shares_operand_module:
+        session.add(
+            ModuleVersionComposition(module_vid=200, table_id=2, table_vid=20)
+        )
+    else:
+        session.add_all(
+            [
+                ModuleVersion(
+                    module_vid=300,
+                    module_id=2,
+                    code="M2",
+                    version_number="1.0",
+                    start_release_id=1,
+                    end_release_id=None,
+                ),
+                ModuleVersionComposition(
+                    module_vid=300, table_id=2, table_vid=20
+                ),
+            ]
+        )
+    session.flush()
+
+
+def test_matching_table_and_module_passes(memory_session):
+    _seed_tables(memory_session, fi_shares_operand_module=True)
+    svc = _svc(memory_session)
+    svc.oc_tables = {"T1": {}}
+
+    svc._check_precondition_tables("{v_FI_X}", release_id=1)  # no raise
+
+
+def test_precondition_code_not_among_operand_abstract_tables_raises_7_4(
+    memory_session,
+):
+    _seed_tables(memory_session, fi_shares_operand_module=True)
+    svc = _svc(memory_session)
+    svc.oc_tables = {"T1": {}}
+
+    with pytest.raises(SemanticError) as exc_info:
+        svc._check_precondition_tables("{v_UNRELATED}", release_id=1)
+    assert exc_info.value.code == "7-4"
+
+
+def test_matching_table_but_different_module_raises_7_5(memory_session):
+    _seed_tables(memory_session, fi_shares_operand_module=False)
+    svc = _svc(memory_session)
+    svc.oc_tables = {"T1": {}}
+
+    with pytest.raises(SemanticError) as exc_info:
+        svc._check_precondition_tables("{v_FI_X}", release_id=1)
+    assert exc_info.value.code == "7-5"
+
+
+def test_expression_with_no_precondition_codes_is_a_noop(memory_session):
+    _seed_tables(memory_session, fi_shares_operand_module=True)
+    svc = _svc(memory_session)
+    svc.oc_tables = {"T1": {}}
+
+    svc._check_precondition_tables("1 + 1", release_id=1)  # no raise
+
+
+def test_malformed_precondition_expression_is_a_noop(memory_session):
+    svc = _svc(memory_session)
+    svc.oc_tables = {"T1": {}}
+
+    svc._check_precondition_tables("{{{not valid dpm-xl", release_id=1)

--- a/tests/integration/services/test_precondition_operation_link.py
+++ b/tests/integration/services/test_precondition_operation_link.py
@@ -437,10 +437,13 @@ def _seed_precondition_operation(session, operation_vid, expression):
 
 
 def _seed_tables(session, *, fi_shares_operand_module: bool):
-    """T1 (module M1) with abstract table FI_X. UNRELATED matches neither.
+    """T1 (module M1) and FI_X are siblings under abstract ROOT, not
+    parent and child, so T1 can't leak into FI_X's children and
+    trivially pass the module check against itself.
 
-    ``fi_shares_operand_module=True`` puts FI_X in M1 too, so 7-5 passes.
-    Otherwise FI_X sits only in M2, so 7-5 fails.
+    UNRELATED matches neither. ``fi_shares_operand_module=True`` puts
+    FI_X in M1 too, so 7-5 passes; otherwise FI_X sits only in M2, so
+    7-5 fails.
     """
     session.add_all(
         [
@@ -448,11 +451,20 @@ def _seed_tables(session, *, fi_shares_operand_module: bool):
             Table(table_id=1),
             Table(table_id=2),
             Table(table_id=3),
+            Table(table_id=5),
+            TableVersion(
+                table_vid=50,
+                code="ROOT",
+                table_id=5,
+                abstract_table_id=None,
+                start_release_id=1,
+                end_release_id=None,
+            ),
             TableVersion(
                 table_vid=10,
                 code="T1",
                 table_id=1,
-                abstract_table_id=2,
+                abstract_table_id=5,
                 start_release_id=1,
                 end_release_id=None,
             ),
@@ -460,7 +472,7 @@ def _seed_tables(session, *, fi_shares_operand_module: bool):
                 table_vid=20,
                 code="FI_X",
                 table_id=2,
-                abstract_table_id=None,
+                abstract_table_id=5,
                 start_release_id=1,
                 end_release_id=None,
             ),
@@ -597,6 +609,121 @@ def test_or_gate_raises_7_5_when_the_matching_tables_module_differs(
 
     with pytest.raises(SemanticError) as exc_info:
         svc._check_precondition_link(607, release_id=1)
+    assert exc_info.value.code == "7-5"
+
+
+def _seed_abstract_precondition_table(session, *, child_shares_operand_module):
+    """T1 and FI_ABS are siblings under ROOT; only FI_ABS's concrete
+    child FI_V1 carries a module. ``child_shares_operand_module=True``
+    puts FI_V1 in M1 too, so 7-5 passes; otherwise FI_V1 sits only in
+    M2, so 7-5 fails.
+    """
+    session.add_all(
+        [
+            Release(release_id=1, code="3.4", date=datetime.date(2022, 12, 1)),
+            Table(table_id=100),
+            Table(table_id=101),
+            Table(table_id=102),
+            Table(table_id=110),
+            TableVersion(
+                table_vid=1100,
+                code="ROOT",
+                table_id=110,
+                abstract_table_id=None,
+                start_release_id=1,
+                end_release_id=None,
+            ),
+            TableVersion(
+                table_vid=1000,
+                code="T1",
+                table_id=100,
+                abstract_table_id=110,
+                start_release_id=1,
+                end_release_id=None,
+            ),
+            TableVersion(
+                table_vid=1010,
+                code="FI_ABS",
+                table_id=101,
+                abstract_table_id=110,
+                start_release_id=1,
+                end_release_id=None,
+            ),
+            TableVersion(
+                table_vid=1020,
+                code="FI_V1",
+                table_id=102,
+                abstract_table_id=101,
+                start_release_id=1,
+                end_release_id=None,
+            ),
+            ModuleVersion(
+                module_vid=1000,
+                module_id=100,
+                code="M1",
+                version_number="1.0",
+                start_release_id=1,
+                end_release_id=None,
+            ),
+            ModuleVersionComposition(
+                module_vid=1000, table_id=100, table_vid=1000
+            ),
+        ]
+    )
+    if child_shares_operand_module:
+        session.add(
+            ModuleVersionComposition(
+                module_vid=1000, table_id=102, table_vid=1020
+            )
+        )
+    else:
+        session.add_all(
+            [
+                ModuleVersion(
+                    module_vid=1001,
+                    module_id=101,
+                    code="M2",
+                    version_number="1.0",
+                    start_release_id=1,
+                    end_release_id=None,
+                ),
+                ModuleVersionComposition(
+                    module_vid=1001, table_id=102, table_vid=1020
+                ),
+            ]
+        )
+    session.flush()
+
+
+def test_abstract_precondition_code_resolves_modules_via_concrete_child(
+    memory_session,
+):
+    # FI_ABS carries no module itself, but FI_V1 shares the operand's.
+    _seed_abstract_precondition_table(
+        memory_session, child_shares_operand_module=True
+    )
+    _seed_precondition_operation(memory_session, 800, "{v_FI_ABS}")
+    memory_session.flush()
+    svc = _svc(memory_session)
+    svc.oc_tables = {"T1": {}}
+
+    svc._check_precondition_link(800, release_id=1)  # no raise
+
+
+def test_abstract_precondition_code_still_raises_7_5_on_real_mismatch(
+    memory_session,
+):
+    # FI_ABS's only concrete child, FI_V1, sits only in M2.
+    _seed_abstract_precondition_table(
+        memory_session, child_shares_operand_module=False
+    )
+    _seed_precondition_operation(memory_session, 801, "{v_FI_ABS}")
+    memory_session.flush()
+    svc = _svc(memory_session)
+    svc.oc_tables = {"T1": {}}
+
+    with pytest.raises(SemanticError) as exc_info:
+        svc._check_precondition_link(801, release_id=1)
     assert exc_info.value.code == "7-5"
 
 

--- a/tests/unit/services/test_semantic_precondition.py
+++ b/tests/unit/services/test_semantic_precondition.py
@@ -402,12 +402,14 @@ class TestPublishedState:
         svc = _svc()
         svc.ast = "stale"
         svc.oc_tables = {"T": {}}
+        svc.oc_operations_data = "stale"
         result = svc._failure("expr", ValueError("boom"), "UNKNOWN")
         assert not result.is_valid
         # ``ast`` used to survive a failure, leaving stale state readable.
         assert svc.ast is None
         assert svc.oc_tables is None
         assert svc.oc_parameters is None
+        assert svc.oc_operations_data is None
 
 
 class TestIsValidShortcut:

--- a/tests/unit/services/test_semantic_precondition_link.py
+++ b/tests/unit/services/test_semantic_precondition_link.py
@@ -85,8 +85,75 @@ class TestLinkFailurePropagates:
         assert not result.is_valid
         assert result.error_code == "7-3"
         assert result.expression == "main"
+        assert result.error_source == "precondition"
         # A link failure clears published state like any other failure.
         assert svc.ast is None
+
+    def test_a_failing_link_check_preserves_the_expression_halves(
+        self, monkeypatch
+    ):
+        svc = _svc()
+        ok_with_warning = SemanticResult(
+            is_valid=True,
+            error_message=None,
+            error_code=None,
+            expression="main",
+            warning="deprecated syntax",
+        )
+        _stub(
+            svc,
+            monkeypatch,
+            result=ok_with_warning,
+            link_error=SemanticError(
+                "7-4", precondition_tables="A", operation_tables="B"
+            ),
+        )
+        result = svc.validate("main", precondition_operation_vid=7)
+        assert not result.is_valid
+        assert result.error_code == "7-4"
+        assert result.error_source == "precondition"
+        # The expression already validated. Its warning isn't lost.
+        assert result.warning == "deprecated syntax"
+
+    def test_a_failing_link_check_preserves_the_precondition_verdict(
+        self, monkeypatch
+    ):
+        # A real precondition_expression makes _combine populate
+        # result.precondition before the link check runs.
+        svc = _svc()
+        gate_result = SemanticResult(
+            is_valid=True,
+            error_message=None,
+            error_code=None,
+            expression="gate",
+            warning="gate warning",
+        )
+        monkeypatch.setattr(svc, "_resolve_release", lambda *a, **k: 42)
+
+        def _validate_resolved(expression, release_id, as_precondition=False):
+            return gate_result if as_precondition else _ok("main")
+
+        monkeypatch.setattr(svc, "_validate_resolved", _validate_resolved)
+
+        def _check_precondition_link(precondition_operation_vid, release_id):
+            raise SemanticError("7-3", precondition_variable_ids="1")
+
+        monkeypatch.setattr(
+            svc, "_check_precondition_link", _check_precondition_link
+        )
+
+        result = svc.validate(
+            "main",
+            precondition_expression="gate",
+            precondition_operation_vid=7,
+        )
+        assert not result.is_valid
+        assert result.error_code == "7-3"
+        assert result.error_source == "precondition"
+        # The gate's own verdict survives instead of being wiped.
+        assert result.precondition is not None
+        assert result.precondition.is_valid
+        assert result.warning == "Precondition: gate warning"
 
     def test_a_passing_link_check_leaves_the_expression_result_untouched(
         self, monkeypatch

--- a/tests/unit/services/test_semantic_precondition_link.py
+++ b/tests/unit/services/test_semantic_precondition_link.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from dpmcore.errors import SemanticError
+from dpmcore.services.semantic import SemanticResult, SemanticService
+
+
+def _svc() -> SemanticService:
+    # session is unused: every DB-touching step is stubbed per test.
+    return SemanticService(session=None)  # type: ignore[arg-type]
+
+
+def _ok(expression: str) -> SemanticResult:
+    return SemanticResult(
+        is_valid=True,
+        error_message=None,
+        error_code=None,
+        expression=expression,
+    )
+
+
+def _stub(svc, monkeypatch, result=None, link_error=None, link_calls=None):
+    monkeypatch.setattr(svc, "_resolve_release", lambda *a, **k: 42)
+    monkeypatch.setattr(
+        svc, "_validate_resolved", lambda *a, **k: result or _ok("main")
+    )
+
+    def _check_precondition_link(precondition_operation_vid, release_id):
+        if link_calls is not None:
+            link_calls.append((precondition_operation_vid, release_id))
+        if link_error is not None:
+            raise link_error
+
+    monkeypatch.setattr(
+        svc, "_check_precondition_link", _check_precondition_link
+    )
+
+
+class TestNotRequested:
+    def test_no_vid_never_calls_the_link_check(self, monkeypatch):
+        svc = _svc()
+        calls = []
+        _stub(svc, monkeypatch, link_calls=calls)
+        result = svc.validate("main")
+        assert result.is_valid
+        assert calls == []
+
+
+class TestRunsOnlyWhenExpressionIsValid:
+    def test_skipped_when_expression_itself_is_invalid(self, monkeypatch):
+        svc = _svc()
+        bad = SemanticResult(
+            is_valid=False,
+            error_message="broken",
+            error_code="1-2",
+            expression="main",
+        )
+        calls = []
+        _stub(svc, monkeypatch, result=bad, link_calls=calls)
+        result = svc.validate("main", precondition_operation_vid=7)
+        assert not result.is_valid
+        assert result.error_code == "1-2"
+        assert calls == []
+
+    def test_runs_with_the_resolved_release_when_expression_is_valid(
+        self, monkeypatch
+    ):
+        svc = _svc()
+        calls = []
+        _stub(svc, monkeypatch, link_calls=calls)
+        result = svc.validate("main", precondition_operation_vid=7)
+        assert result.is_valid
+        assert calls == [(7, 42)]
+
+
+class TestLinkFailurePropagates:
+    def test_a_failing_link_check_fails_the_result(self, monkeypatch):
+        svc = _svc()
+        svc.ast = "stale"
+        _stub(
+            svc,
+            monkeypatch,
+            link_error=SemanticError("7-3", precondition_variable_ids="1, 2"),
+        )
+        result = svc.validate("main", precondition_operation_vid=7)
+        assert not result.is_valid
+        assert result.error_code == "7-3"
+        assert result.expression == "main"
+        # A link failure clears published state like any other failure.
+        assert svc.ast is None
+
+    def test_a_passing_link_check_leaves_the_expression_result_untouched(
+        self, monkeypatch
+    ):
+        svc = _svc()
+        _stub(svc, monkeypatch)
+        result = svc.validate("main", precondition_operation_vid=7)
+        assert result.is_valid
+        assert result.expression == "main"
+
+    def test_a_non_semantic_error_is_also_caught(self, monkeypatch):
+        # e.g. a DB connectivity error mid-check: validate() never raises.
+        svc = _svc()
+        _stub(svc, monkeypatch, link_error=ValueError("boom"))
+        result = svc.validate("main", precondition_operation_vid=7)
+        assert not result.is_valid
+        assert result.error_code == "UNKNOWN"


### PR DESCRIPTION
Closes #302

## Summary

Adds `oc_operations_data` to `SemanticService` and a new `precondition_operation_vid` argument to `validate()`, with the two checks it needs (`7-3`/`7-4`/`7-5`).

- `services/semantic.py`: publish `oc_operations_data` (mirrors `oc_data`/`oc_tables`/`oc_parameters`). Added `precondition_operation_vid` param and `_check_precondition_link`
- `dpm_xl/model_queries.py`: new `TableVersionQuery.get_abstract_table_codes`.
- `errors.py`: new `7-3`/`7-4`/`7-5` messages.

## Checklist

- [X] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [X] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [] Documentation updated (if applicable)

## Impact / Risk

- Breaking changes? (public API / CLI / REST endpoints / Django models)
- Database schema or migration concerns?
- Notes for release/changelog?

## Notes

<!-- Follow-ups, TODOs, or anything reviewers should know. -->
