### PR TITLE
fix(mssql): compare booleans with == instead of IS

### DIFF
--- a/src/dpmcore/dpm_xl/model_queries.py
+++ b/src/dpmcore/dpm_xl/model_queries.py
@@ -1400,7 +1400,7 @@ class ViewDatapointsQuery:
                 TableVersionCell,
                 and_(
                     TableVersionCell.table_vid == TableVersion.table_vid,
-                    TableVersionCell.is_void.is_(False),
+                    TableVersionCell.is_void == False,  # noqa: E712
                 ),
             )
             .outerjoin(

--- a/src/dpmcore/loaders/migration.py
+++ b/src/dpmcore/loaders/migration.py
@@ -389,7 +389,7 @@ class MigrationService:
                     Release.date,
                     Release.type,
                     Release.release_id,
-                ).where(Release.is_current.is_(True))
+                ).where(Release.is_current == True)  # noqa: E712
             ).all()
             code = _latest_code(rows)
             if code is None:

--- a/src/dpmcore/services/structure.py
+++ b/src/dpmcore/services/structure.py
@@ -2284,7 +2284,7 @@ class StructureService:
                 ItemCategory.code,
             )
             .join(Item, Item.item_id == ItemCategory.item_id)
-            .filter(Item.is_property.is_(True))
+            .filter(Item.is_property == True)  # noqa: E712
         )
         rows = chunked_in(base, ItemCategory.item_id, property_ids)
         out: Dict[int, List[Tuple[int, Optional[int], str]]] = defaultdict(
@@ -2460,7 +2460,7 @@ class StructureService:
             .outerjoin(
                 DataType, DataType.data_type_id == Property.data_type_id
             )
-            .filter(Item.is_property.is_(True))
+            .filter(Item.is_property == True)  # noqa: E712
         )
 
         owners = None if params.is_owner_wildcard else params.owners
@@ -2594,7 +2594,7 @@ class StructureService:
                 Category,
                 Category.category_id == PropertyCategory.category_id,
             )
-            .filter(Category.is_enumerated.is_(True))
+            .filter(Category.is_enumerated == True)  # noqa: E712
         )
         pc_q = filter_by_release(
             pc_q,


### PR DESCRIPTION
Closes #305 

## Summary

`.is_(True)`/`.is_(False)` on a `Boolean` column compiles to `IS 1`/`IS 0` on `mssql+pyodbc`, invalid T-SQL (`IS` only accepts `NULL`/`NOT NULL` there).

Replaced with `== True`/`== False` at the 5 affected call sites.
## Checklist

- [X] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [X] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [ ] Documentation updated (if applicable)

## Impact / Risk

- Breaking changes? (public API / CLI / REST endpoints / Django models)
- Database schema or migration concerns?
- Notes for release/changelog?

## Notes

<!-- Follow-ups, TODOs, or anything reviewers should know. -->
