### PR TITLE
Fix/release filter numeric comparison

### DIFF
--- a/src/dpmcore/dpm_xl/model_queries.py
+++ b/src/dpmcore/dpm_xl/model_queries.py
@@ -228,14 +228,11 @@ class ItemCategoryQuery:
         if items:
             query = query.filter(ItemCategory.signature.in_(items))
         if release_id is not None:
-            query = query.filter(
-                and_(
-                    ItemCategory.start_release_id <= release_id,
-                    or_(
-                        ItemCategory.end_release_id > release_id,
-                        ItemCategory.end_release_id.is_(None),
-                    ),
-                )
+            query = filter_by_release(
+                query,
+                start_col=ItemCategory.start_release_id,
+                end_col=ItemCategory.end_release_id,
+                release_id=release_id,
             )
         else:
             query = query.filter(ItemCategory.end_release_id.is_(None))
@@ -344,14 +341,11 @@ class VariableVersionQuery:
             VariableVersion.code == variable_code
         )
         if release_id is not None:
-            query = query.filter(
-                and_(
-                    VariableVersion.start_release_id <= release_id,
-                    or_(
-                        VariableVersion.end_release_id > release_id,
-                        VariableVersion.end_release_id.is_(None),
-                    ),
-                )
+            query = filter_by_release(
+                query,
+                start_col=VariableVersion.start_release_id,
+                end_col=VariableVersion.end_release_id,
+                release_id=release_id,
             )
         else:
             query = query.filter(VariableVersion.end_release_id.is_(None))
@@ -392,16 +386,12 @@ class VariableVersionQuery:
                 _is_filing_indicator(),
             )
         )
-        if release_id is not None:
-            query = query.filter(
-                and_(
-                    VariableVersion.start_release_id <= release_id,
-                    or_(
-                        VariableVersion.end_release_id > release_id,
-                        VariableVersion.end_release_id.is_(None),
-                    ),
-                )
-            )
+        query = filter_by_release(
+            query,
+            start_col=VariableVersion.start_release_id,
+            end_col=VariableVersion.end_release_id,
+            release_id=release_id,
+        )
         return query.first()
 
     @staticmethod
@@ -423,16 +413,12 @@ class VariableVersionQuery:
         query = session.query(VariableVersion.variable_id).filter(
             VariableVersion.code == value
         )
-        if release_id is not None:
-            query = query.filter(
-                and_(
-                    VariableVersion.start_release_id <= release_id,
-                    or_(
-                        VariableVersion.end_release_id > release_id,
-                        VariableVersion.end_release_id.is_(None),
-                    ),
-                )
-            )
+        query = filter_by_release(
+            query,
+            start_col=VariableVersion.start_release_id,
+            end_col=VariableVersion.end_release_id,
+            release_id=release_id,
+        )
         rows = query.all()
         if not rows:
             return None
@@ -510,16 +496,12 @@ class VariableVersionQuery:
             )
             .filter(_is_filing_indicator())
         )
-        if release_id is not None:
-            query = query.filter(
-                and_(
-                    VariableVersion.start_release_id <= release_id,
-                    or_(
-                        VariableVersion.end_release_id > release_id,
-                        VariableVersion.end_release_id.is_(None),
-                    ),
-                )
-            )
+        query = filter_by_release(
+            query,
+            start_col=VariableVersion.start_release_id,
+            end_col=VariableVersion.end_release_id,
+            release_id=release_id,
+        )
         return query.all()
 
 
@@ -610,16 +592,12 @@ class TableVersionQuery:
         query = session.query(TableVersion).filter(
             TableVersion.code == table_code
         )
-        if release_id is not None:
-            query = query.filter(
-                and_(
-                    TableVersion.start_release_id <= release_id,
-                    or_(
-                        TableVersion.end_release_id > release_id,
-                        TableVersion.end_release_id.is_(None),
-                    ),
-                )
-            )
+        query = filter_by_release(
+            query,
+            start_col=TableVersion.start_release_id,
+            end_col=TableVersion.end_release_id,
+            release_id=release_id,
+        )
         return query.first() is not None
 
 

--- a/src/dpmcore/dpm_xl/model_queries.py
+++ b/src/dpmcore/dpm_xl/model_queries.py
@@ -581,17 +581,20 @@ class TableVersionQuery:
             release_id: Release filter.
 
         Returns:
-            True if the table exists.
+            True if the table exists, an unknown release_id resolves to False.
         """
         query = session.query(TableVersion).filter(
             TableVersion.code == table_code
         )
-        query = filter_by_release(
-            query,
-            start_col=TableVersion.start_release_id,
-            end_col=TableVersion.end_release_id,
-            release_id=release_id,
-        )
+        try:
+            query = filter_by_release(
+                query,
+                start_col=TableVersion.start_release_id,
+                end_col=TableVersion.end_release_id,
+                release_id=release_id,
+            )
+        except ValueError:
+            return False
         return query.first() is not None
 
 

--- a/src/dpmcore/dpm_xl/model_queries.py
+++ b/src/dpmcore/dpm_xl/model_queries.py
@@ -450,14 +450,11 @@ class VariableVersionQuery:
             VariableVersion.variable_vid,
         ).filter(VariableVersion.code.in_(codes))
         if release_id is not None:
-            query = query.filter(
-                and_(
-                    VariableVersion.start_release_id <= release_id,
-                    or_(
-                        VariableVersion.end_release_id > release_id,
-                        VariableVersion.end_release_id.is_(None),
-                    ),
-                )
+            query = filter_by_release(
+                query,
+                start_col=VariableVersion.start_release_id,
+                end_col=VariableVersion.end_release_id,
+                release_id=release_id,
             )
         rows = query.all()
         resolved: dict[str, dict[str, int]] = {}

--- a/src/dpmcore/dpm_xl/model_queries.py
+++ b/src/dpmcore/dpm_xl/model_queries.py
@@ -581,20 +581,17 @@ class TableVersionQuery:
             release_id: Release filter.
 
         Returns:
-            True if the table exists, an unknown release_id resolves to False.
+            True if the table exists.
         """
         query = session.query(TableVersion).filter(
             TableVersion.code == table_code
         )
-        try:
-            query = filter_by_release(
-                query,
-                start_col=TableVersion.start_release_id,
-                end_col=TableVersion.end_release_id,
-                release_id=release_id,
-            )
-        except ValueError:
-            return False
+        query = filter_by_release(
+            query,
+            start_col=TableVersion.start_release_id,
+            end_col=TableVersion.end_release_id,
+            release_id=release_id,
+        )
         return query.first() is not None
 
 

--- a/src/dpmcore/dpm_xl/model_queries.py
+++ b/src/dpmcore/dpm_xl/model_queries.py
@@ -542,14 +542,11 @@ class OperationQuery:
             .filter(Operation.code.in_(operation_codes))
         )
         if release_id is not None:
-            query = query.filter(
-                and_(
-                    OperationVersion.start_release_id <= release_id,
-                    or_(
-                        OperationVersion.end_release_id > release_id,
-                        OperationVersion.end_release_id.is_(None),
-                    ),
-                )
+            query = filter_by_release(
+                query,
+                start_col=OperationVersion.start_release_id,
+                end_col=OperationVersion.end_release_id,
+                release_id=release_id,
             )
         results = query.all()
         cols = [

--- a/tests/integration/releases/test_release_sort_order.py
+++ b/tests/integration/releases/test_release_sort_order.py
@@ -23,6 +23,7 @@ from dpmcore.orm.glossary import (
     ItemCategory,
 )
 from dpmcore.orm.infrastructure import Release
+from dpmcore.orm.operations import Operation, OperationVersion
 from dpmcore.orm.packaging import (
     Framework,
     Module,
@@ -965,6 +966,14 @@ def non_monotonic_id_session(memory_session):
                 start_release_id=1010000050,
                 end_release_id=None,
             ),
+            Operation(operation_id=1, code="OP_1"),
+            OperationVersion(
+                operation_vid=1,
+                operation_id=1,
+                expression="1 + 1",
+                start_release_id=1010000050,
+                end_release_id=None,
+            ),
         ]
     )
     session.commit()
@@ -1019,3 +1028,37 @@ def test_check_table_exists_finds_row_introduced_after_playground_id(
     assert (
         TableVersionQuery.check_table_exists(session, "F_20.04", 9999) is True
     )
+
+
+def test_check_table_exists_unknown_release_id_returns_false(
+    non_monotonic_id_session,
+):
+    from dpmcore.dpm_xl.model_queries import TableVersionQuery
+
+    session = non_monotonic_id_session
+    assert (
+        TableVersionQuery.check_table_exists(session, "F_20.04", 424242)
+        is False
+    )
+
+
+def test_get_variable_vids_by_codes_finds_row_introduced_after_playground_id(
+    non_monotonic_id_session,
+):
+    from dpmcore.dpm_xl.model_queries import VariableVersionQuery
+
+    session = non_monotonic_id_session
+    resolved = VariableVersionQuery.get_variable_vids_by_codes(
+        session, ["W_04.10"], 9999
+    )
+    assert resolved == {"W_04.10": {"variable_id": 1, "variable_vid": 1}}
+
+
+def test_get_operations_from_codes_finds_row_introduced_after_playground_id(
+    non_monotonic_id_session,
+):
+    from dpmcore.dpm_xl.model_queries import OperationQuery
+
+    session = non_monotonic_id_session
+    df = OperationQuery.get_operations_from_codes(session, ["OP_1"], 9999)
+    assert list(df["Code"]) == ["OP_1"]

--- a/tests/integration/releases/test_release_sort_order.py
+++ b/tests/integration/releases/test_release_sort_order.py
@@ -930,12 +930,21 @@ def non_monotonic_id_session(memory_session):
     """A row started by release ``4.3`` (id ``1010000050``), which is
     chronologically before but numerically larger than the ``9999``
     ``Playground`` sentinel. Eexposes a raw numeric ``<=`` comparison.
+
+    ``4.3.1`` (id ``1010000099``) is numerically larger than ``4.3`` but
+    dated earlier: a raw id comparison would wrongly include the row at
+    ``4.3.1``, where date-ordering must exclude it.
     """
     session = memory_session
     session.add_all(
         [
             Release(release_id=1, code="4.2", date=date(2025, 10, 31)),
             Release(release_id=1010000050, code="4.3", date=date(2026, 6, 28)),
+            Release(
+                release_id=1010000099,
+                code="4.3.1",
+                date=date(2026, 1, 15),
+            ),
             Release(
                 release_id=9999,
                 code="Playground",
@@ -996,6 +1005,18 @@ def test_check_variable_exists_finds_row_introduced_after_playground_id(
         )
         is True
     )
+    # Release "4.2" predates the row's 4.3 start: must not match.
+    assert (
+        VariableVersionQuery.check_variable_exists(session, "W_04.10", 1)
+        is False
+    )
+    # "4.3.1": numerically later than "4.3" but dated earlier, must not match
+    assert (
+        VariableVersionQuery.check_variable_exists(
+            session, "W_04.10", 1010000099
+        )
+        is False
+    )
 
 
 def test_get_variable_id_finds_row_introduced_after_playground_id(
@@ -1007,6 +1028,13 @@ def test_get_variable_id_finds_row_introduced_after_playground_id(
     assert VariableVersionQuery.get_variable_id(session, "W_04.10", 9999) == [
         1
     ]
+    # Release "4.2" predates the row's 4.3 start: must not match.
+    assert VariableVersionQuery.get_variable_id(session, "W_04.10", 1) is None
+    # "4.3.1": numerically later than "4.3" but dated earlier, must not match
+    assert (
+        VariableVersionQuery.get_variable_id(session, "W_04.10", 1010000099)
+        is None
+    )
 
 
 def test_get_items_finds_row_introduced_after_playground_id(
@@ -1017,6 +1045,14 @@ def test_get_items_finds_row_introduced_after_playground_id(
     session = non_monotonic_id_session
     df = ItemCategoryQuery.get_items(session, ["eba_qEH:qx2005"], 9999)
     assert list(df["Signature"]) == ["eba_qEH:qx2005"]
+    # Release "4.2" predates the row's 4.3 start: must not match.
+    before = ItemCategoryQuery.get_items(session, ["eba_qEH:qx2005"], 1)
+    assert before.empty
+    # "4.3.1": numerically later than "4.3" but dated earlier, must not match
+    earlier_by_date = ItemCategoryQuery.get_items(
+        session, ["eba_qEH:qx2005"], 1010000099
+    )
+    assert earlier_by_date.empty
 
 
 def test_check_table_exists_finds_row_introduced_after_playground_id(
@@ -1027,6 +1063,13 @@ def test_check_table_exists_finds_row_introduced_after_playground_id(
     session = non_monotonic_id_session
     assert (
         TableVersionQuery.check_table_exists(session, "F_20.04", 9999) is True
+    )
+    # Release "4.2" predates the row's 4.3 start: must not match.
+    assert TableVersionQuery.check_table_exists(session, "F_20.04", 1) is False
+    # "4.3.1": numerically later than "4.3" but dated earlier, must not match
+    assert (
+        TableVersionQuery.check_table_exists(session, "F_20.04", 1010000099)
+        is False
     )
 
 
@@ -1050,6 +1093,16 @@ def test_get_variable_vids_by_codes_finds_row_introduced_after_playground_id(
         session, ["W_04.10"], 9999
     )
     assert resolved == {"W_04.10": {"variable_id": 1, "variable_vid": 1}}
+    # Release "4.2" predates the row's 4.3 start: must not match.
+    before = VariableVersionQuery.get_variable_vids_by_codes(
+        session, ["W_04.10"], 1
+    )
+    assert before == {}
+    # "4.3.1": numerically later than "4.3" but dated earlier, must not match
+    earlier_by_date = VariableVersionQuery.get_variable_vids_by_codes(
+        session, ["W_04.10"], 1010000099
+    )
+    assert earlier_by_date == {}
 
 
 def test_get_operations_from_codes_finds_row_introduced_after_playground_id(
@@ -1060,3 +1113,11 @@ def test_get_operations_from_codes_finds_row_introduced_after_playground_id(
     session = non_monotonic_id_session
     df = OperationQuery.get_operations_from_codes(session, ["OP_1"], 9999)
     assert list(df["Code"]) == ["OP_1"]
+    # Release "4.2" predates the row's 4.3 start: must not match.
+    before = OperationQuery.get_operations_from_codes(session, ["OP_1"], 1)
+    assert before.empty
+    # "4.3.1": numerically later than "4.3" but dated earlier, must not match
+    earlier_by_date = OperationQuery.get_operations_from_codes(
+        session, ["OP_1"], 1010000099
+    )
+    assert earlier_by_date.empty

--- a/tests/integration/releases/test_release_sort_order.py
+++ b/tests/integration/releases/test_release_sort_order.py
@@ -1030,16 +1030,14 @@ def test_check_table_exists_finds_row_introduced_after_playground_id(
     )
 
 
-def test_check_table_exists_unknown_release_id_returns_false(
+def test_check_table_exists_unknown_release_id_raises(
     non_monotonic_id_session,
 ):
     from dpmcore.dpm_xl.model_queries import TableVersionQuery
 
     session = non_monotonic_id_session
-    assert (
+    with pytest.raises(ValueError):
         TableVersionQuery.check_table_exists(session, "F_20.04", 424242)
-        is False
-    )
 
 
 def test_get_variable_vids_by_codes_finds_row_introduced_after_playground_id(

--- a/tests/integration/releases/test_release_sort_order.py
+++ b/tests/integration/releases/test_release_sort_order.py
@@ -34,6 +34,7 @@ from dpmcore.orm.release_sort_order import (
     resolve_sort_order,
 )
 from dpmcore.orm.rendering import Table, TableVersion
+from dpmcore.orm.variables import Variable, VariableVersion
 from dpmcore.services.data_dictionary import DataDictionaryService
 from dpmcore.services.hierarchy import HierarchyService
 
@@ -915,3 +916,106 @@ def test_resolve_explicit_release_self_reference_at_playground_type(
     svc = ASTGeneratorService(session)
     release_row = svc._resolve_explicit_release("Playground", mv, "MOD", "1.0")
     assert release_row.release_id == 9999
+
+
+# --------------------------------------------------------------------- #
+# VariableVersionQuery / ItemCategoryQuery / TableVersionQuery
+# release filters must date-order, not numerically compare, release_id
+# --------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def non_monotonic_id_session(memory_session):
+    """A row started by release ``4.3`` (id ``1010000050``), which is
+    chronologically before but numerically larger than the ``9999``
+    ``Playground`` sentinel. Eexposes a raw numeric ``<=`` comparison.
+    """
+    session = memory_session
+    session.add_all(
+        [
+            Release(release_id=1, code="4.2", date=date(2025, 10, 31)),
+            Release(release_id=1010000050, code="4.3", date=date(2026, 6, 28)),
+            Release(
+                release_id=9999,
+                code="Playground",
+                date=date(1970, 1, 1),
+                type="playground",
+            ),
+            Variable(variable_id=1),
+            VariableVersion(
+                variable_id=1,
+                variable_vid=1,
+                code="W_04.10",
+                start_release_id=1010000050,
+                end_release_id=None,
+            ),
+            ItemCategory(
+                item_id=1,
+                signature="eba_qEH:qx2005",
+                code="qx2005",
+                category_id=1,
+                start_release_id=1010000050,
+                end_release_id=None,
+            ),
+            Table(table_id=1),
+            TableVersion(
+                table_vid=1,
+                table_id=1,
+                code="F_20.04",
+                start_release_id=1010000050,
+                end_release_id=None,
+            ),
+        ]
+    )
+    session.commit()
+    return session
+
+
+def test_check_variable_exists_finds_row_introduced_after_playground_id(
+    non_monotonic_id_session,
+):
+    from dpmcore.dpm_xl.model_queries import VariableVersionQuery
+
+    session = non_monotonic_id_session
+    assert (
+        VariableVersionQuery.check_variable_exists(session, "W_04.10", 9999)
+        is True
+    )
+    assert (
+        VariableVersionQuery.check_variable_exists(
+            session, "W_04.10", 1010000050
+        )
+        is True
+    )
+
+
+def test_get_variable_id_finds_row_introduced_after_playground_id(
+    non_monotonic_id_session,
+):
+    from dpmcore.dpm_xl.model_queries import VariableVersionQuery
+
+    session = non_monotonic_id_session
+    assert VariableVersionQuery.get_variable_id(session, "W_04.10", 9999) == [
+        1
+    ]
+
+
+def test_get_items_finds_row_introduced_after_playground_id(
+    non_monotonic_id_session,
+):
+    from dpmcore.dpm_xl.model_queries import ItemCategoryQuery
+
+    session = non_monotonic_id_session
+    df = ItemCategoryQuery.get_items(session, ["eba_qEH:qx2005"], 9999)
+    assert list(df["Signature"]) == ["eba_qEH:qx2005"]
+
+
+def test_check_table_exists_finds_row_introduced_after_playground_id(
+    non_monotonic_id_session,
+):
+    from dpmcore.dpm_xl.model_queries import TableVersionQuery
+
+    session = non_monotonic_id_session
+    assert (
+        TableVersionQuery.check_table_exists(session, "F_20.04", 9999) is True
+    )


### PR DESCRIPTION
Closes #307 

## Summary

Replaces the raw `start_release_id <= release_id` comparison with the date-ordered `filter_by_release` helper (matching `ModuleVersionQuery`) in `VariableVersionQuery.check_variable_exists`/`check_precondition`/`get_variable_id`/`get_all_preconditions`, `ItemCategoryQuery.get_items` and `TableVersionQuery.check_table_exists`. The call sites reachable from `SemanticService.validate()` and scope calculation. `release_id=None` behavior is untouched everywhere.

## Checklist

- [X] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [X] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [ ] Documentation updated (if applicable)

## Impact / Risk

- Breaking changes? (public API / CLI / REST endpoints / Django models)
- Database schema or migration concerns?
- Notes for release/changelog?

## Notes

<!-- Follow-ups, TODOs, or anything reviewers should know. -->
