### PR TITLE
fix(scope): drop cross-module scopes dominated by an intra-module scope

### DIFF
--- a/src/dpmcore/dpm_xl/utils/scopes_calculator.py
+++ b/src/dpmcore/dpm_xl/utils/scopes_calculator.py
@@ -272,6 +272,13 @@ class OperationScopeService:
             if len(intra_modules):
                 self.process_repeated(intra_modules, modules_info_dataframe)
 
+            # An intra module evaluates the operation on its own, so any
+            # combination that merely wraps partners around it is redundant.
+            # These scopes are emitted by ``process_repeated`` and are
+            # therefore absent from the cross-module candidate set, so they
+            # must be handed to the dominance filter explicitly (Issue #304).
+            intra_sets = [frozenset({vid}) for vid in intra_modules]
+
             required_preconditions = set(precondition_items)
             if cross_modules:
                 if table_codes:
@@ -296,6 +303,7 @@ class OperationScopeService:
                                 required_precondition_codes=(
                                     required_preconditions
                                 ),
+                                dominating_sets=intra_sets,
                             )
                     else:
                         # Complete each partial module into a cross-instance
@@ -312,6 +320,7 @@ class OperationScopeService:
                             modules_dataframe=modules_info_dataframe,
                             required_keys=required_codes,
                             required_precondition_codes=required_preconditions,
+                            dominating_sets=intra_sets,
                         )
                 else:
                     # Table-VID path: supplement any referenced table VID
@@ -327,6 +336,7 @@ class OperationScopeService:
                         modules_dataframe=modules_info_dataframe,
                         required_keys=set(tables_vids),
                         required_precondition_codes=required_preconditions,
+                        dominating_sets=intra_sets,
                     )
 
         return self.get_scopes_with_status()
@@ -506,6 +516,7 @@ class OperationScopeService:
         modules_dataframe: pd.DataFrame,
         required_keys: Iterable[Any] | None = None,
         required_precondition_codes: Iterable[Any] | None = None,
+        dominating_sets: Iterable[frozenset[int]] | None = None,
     ) -> None:
         """Method to calculate OperationScope and OperationScopeComposition tables for a cross module operation
         :param cross_modules: dictionary with table version ids as key and its module version ids as values
@@ -519,6 +530,10 @@ class OperationScopeService:
             indicator) codes; a combination is emitted only if its modules
             collectively report all of them (Issue #120). ``None``/empty
             disables the check.
+        :param dominating_sets: module sets already emitted as scopes by
+            another path -- the intra single-module scopes built by
+            :meth:`process_repeated`. A combination that strictly contains
+            one of them is redundant and is not emitted (Issue #304).
         """
         # Table coverage: each generated combination provides exactly the
         # pool's key set (one module per key), and supplementation in
@@ -640,8 +655,16 @@ class OperationScopeService:
         # two alternative modules that each host the whole referenced table
         # set. Drop such non-minimal supersets so the alternatives surface as
         # separate scopes instead of one bloated multi-module scope.
+        #
+        # ``dominating_sets`` extends the same argument to the intra
+        # single-module scopes: they cover every key on their own but are
+        # emitted elsewhere, so they never appear in ``valid_sets`` and would
+        # otherwise fail to suppress the combinations wrapped around them —
+        # a table shared across modules then yields one redundant cross scope
+        # per sibling hosting it (Issue #304).
+        dominators = valid_sets + list(dominating_sets or [])
         for module_set in valid_sets:
-            if any(other < module_set for other in valid_sets):
+            if any(other < module_set for other in dominators):
                 continue
             operation_scope = self.create_operation_scope(
                 ref_from_by_set[module_set]

--- a/src/dpmcore/services/scope_calculator.py
+++ b/src/dpmcore/services/scope_calculator.py
@@ -551,11 +551,17 @@ class ScopeCalculatorService:
                     release_id=release_id,
                     valid_module_uris=set(),
                 )
+            # The intra claim needs the primary to actually own a
+            # single-module scope. Keying it off ``not is_cross`` instead
+            # declared intra for a module that participates in no scope at
+            # all — it hosts none of the referenced tables (#141). That was
+            # masked while a redundant superset scope kept ``is_cross``
+            # true; dropping those scopes (#304) exposes it.
             return {
                 **empty_result,
                 "intra_instance_validations": (
                     [operation_code]
-                    if operation_code and (not is_cross or primary_has_intra)
+                    if operation_code and primary_has_intra
                     else []
                 ),
                 "alternative_dependencies": alternative_deps,

--- a/tests/integration/services/test_cross_module_classification.py
+++ b/tests/integration/services/test_cross_module_classification.py
@@ -2,8 +2,10 @@
 
 A validation is intra-instance for a module when every table it references
 belongs to that module; cross-instance when the module hosts only some of
-them; and neither when the module hosts none. These tests pin that behaviour
-for the affected validations.
+them *and* no other module hosts them all (#304 — a module that can evaluate
+the validation alone makes every pairing around it redundant); and neither
+when the module hosts none. These tests pin that behaviour for the affected
+validations.
 """
 
 from __future__ import annotations
@@ -12,6 +14,26 @@ import pytest
 from sqlalchemy import text
 
 from dpmcore.services.ast_generator import ASTGeneratorService
+from dpmcore.services.scope_calculator import ScopeCalculatorService
+
+# A validation no single module can evaluate: C_43.00.c is COREP_LR's and
+# C_08.01.a is COREP_OF's, so its scope is genuinely cross-instance and
+# survives the #304 pruning. Used by the #250/#251 regressions below.
+_CROSS_CODE = "v0709_m"
+_CROSS_MODULE = "COREP_LR"
+_CROSS_VERSION = "4.1.0"
+
+# Issue #304, measured against the shipped 4.2.1 fixture DB: C_16.00.b
+# exists only in COREP_OF 3.1.0 (module VID 344) and only up to release
+# 4.0, hence the 3.4 pin.
+_SHARED_TABLE_EXPRESSION = (
+    "if {tC_16.00.b, r0130, c0070} > 0 "
+    "and {tC_00.01, r0020, c0010} = [eba_SC:x7] "
+    "then {p_OPRISKCONS_AMA, string} = 'Y' "
+    "else {p_OPRISKSOLO_AMA, string} = 'Y' endif"
+)
+_SHARED_TABLE_RELEASE = "3.4"
+_COREP_OF_3_1_0 = 344
 
 
 def _latest_expression(session, code: str) -> str:
@@ -55,14 +77,21 @@ def _classify(session, code, module_code, module_version):
         # Both referenced tables belong to the module -> intra in both.
         ("v09808_m", "COREP_OF", "4.1.0", True, False),
         ("v09808_m", "IF_CLASS2", "1.4.0", True, False),
-        # All tables in the primary, secondary requires the primary -> the
-        # legit MIXED case: intra for COREP_OF, cross for IF_CLASS2.
+        # All tables in the primary -> intra for COREP_OF. IF_CLASS2 only
+        # holds a shared subset, so pairing it with COREP_OF adds nothing
+        # COREP_OF cannot do alone: no cross scope survives (#304).
         ("v22973_m", "COREP_OF", "4.1.0", True, False),
-        ("v22973_m", "IF_CLASS2", "1.4.0", False, True),
+        ("v22973_m", "IF_CLASS2", "1.4.0", False, False),
         # v11120_m references I_04.00 (IF_CLASS2-only) and I_05.00 (both
-        # IF_CLASS2 and IF_CLASS3): intra in IF_CLASS2, cross in IF_CLASS3.
+        # IF_CLASS2 and IF_CLASS3): intra in IF_CLASS2. IF_CLASS3 only
+        # duplicates I_05.00, so it is not a dependency either (#304).
         ("v11120_m", "IF_CLASS2", "1.4.0", True, False),
-        ("v11120_m", "IF_CLASS3", "1.4.0", False, True),
+        ("v11120_m", "IF_CLASS3", "1.4.0", False, False),
+        # A genuinely cross-instance validation: C_43.00.c lives in
+        # COREP_LR and C_08.01.a in COREP_OF, so neither module can
+        # evaluate it alone and the cross scope is real.
+        ("v0709_m", "COREP_LR", "4.1.0", False, True),
+        ("v0709_m", "COREP_OF", "4.1.0", False, True),
     ],
 )
 def test_named_classification(
@@ -85,6 +114,25 @@ def test_primary_hosting_no_tables_is_not_intra(fixture_session):
     assert result["intra"] == []
     assert result["cross"] == 0
     assert result["tables"] == []
+
+
+def test_shared_table_yields_only_the_intra_scope(fixture_session):
+    """Regression for #304: a table hosted by many modules must not
+    spawn a cross scope per host when one module already covers the
+    whole expression.
+
+    ``C_00.01`` lives in every COREP module, but only COREP_OF also has
+    ``C_16.00.b`` — so COREP_OF evaluates the expression alone and each
+    ``{sibling, COREP_OF}`` pair is a redundant superset of that scope.
+    """
+    result = ScopeCalculatorService(fixture_session).calculate_from_expression(
+        expression=_SHARED_TABLE_EXPRESSION,
+        release_code=_SHARED_TABLE_RELEASE,
+    )
+    assert not result.has_error, result.error_message
+    assert result.total_scopes == 1
+    assert not result.is_cross_module
+    assert result.module_versions == [_COREP_OF_3_1_0]
 
 
 def _operand_datapoints(node) -> set[str]:
@@ -110,23 +158,23 @@ def test_cross_validation_operands_declared_in_dependency(fixture_session):
     validation — home-module ones included — is declared in the
     ``variables`` map of each module the validation depends on.
     """
-    code = "v22973_m"
+    code = _CROSS_CODE
     expression = _latest_expression(fixture_session, code)
     result = ASTGeneratorService(fixture_session).script(
         expressions=[(expression, code)],
-        module_code="IF_CLASS2",
-        module_version="1.4.0",
+        module_code=_CROSS_MODULE,
+        module_version=_CROSS_VERSION,
     )
     assert result["success"], result["error"]
     module = next(iter(result["enriched_ast"].values()))
     dep_modules = module["dependency_modules"]
-    assert dep_modules, "v22973_m must be cross-instance for IF_CLASS2"
+    assert dep_modules, f"{code} must be cross-instance for {_CROSS_MODULE}"
 
     operands = _operand_datapoints(module["operations"][code]["ast"])
     assert operands, "the validation must reference at least one datapoint"
     home_variables = set(module["variables"])
     assert operands & home_variables, (
-        "v22973_m has home-module operands: they are what #251 was about"
+        f"{code} has home-module operands: they are what #251 was about"
     )
 
     for uri, dep in dep_modules.items():
@@ -138,17 +186,17 @@ def test_dependency_declares_only_referenced_subset(fixture_session):
     """Regression for #250: a dependency module is declared as the subset
     the cross-rules reference, not as the whole module.
     """
-    code = "v22973_m"
+    code = _CROSS_CODE
     expression = _latest_expression(fixture_session, code)
     result = ASTGeneratorService(fixture_session).script(
         expressions=[(expression, code)],
-        module_code="IF_CLASS2",
-        module_version="1.4.0",
+        module_code=_CROSS_MODULE,
+        module_version=_CROSS_VERSION,
     )
     assert result["success"], result["error"]
     module = next(iter(result["enriched_ast"].values()))
     dep_modules = module["dependency_modules"]
-    assert dep_modules, "v22973_m must be cross-instance for IF_CLASS2"
+    assert dep_modules, f"{code} must be cross-instance for {_CROSS_MODULE}"
 
     referenced_tables = set(
         _referenced_tables(module["operations"][code]["ast"])

--- a/tests/unit/dpm_xl/test_scopes_lifecycle.py
+++ b/tests/unit/dpm_xl/test_scopes_lifecycle.py
@@ -585,3 +585,99 @@ class TestCrossModuleCoverage:
         )
         assert len(svc.operation_scopes) == 1
         assert [frozenset(m) for m in members.values()] == [frozenset({20})]
+
+    def test_superset_of_intra_scope_is_dropped(self):
+        """A combination containing an intra module is not emitted.
+
+        Issue #304. ``C_00.01`` is shared by every COREP module while
+        ``C_16.00.b`` lives only in ``COREP_OF`` (344), so ``COREP_OF``
+        covers the expression alone and is routed to the intra scopes.
+        The siblings hold only ``C_00.01``, and supplementing their pool
+        with the sole provider of ``C_16.00.b`` pairs each of them back
+        with ``COREP_OF`` — one redundant superset scope per sibling.
+        Only the intra scope must survive.
+        """
+        rows = [
+            (
+                344,
+                100,
+                "C_00.01",
+                "COREP_OF",
+                "3.1.0",
+                1,
+                None,
+                "2023-06-30",
+                None,
+            ),
+            (
+                344,
+                200,
+                "C_16.00.b",
+                "COREP_OF",
+                "3.1.0",
+                1,
+                None,
+                "2023-06-30",
+                None,
+            ),
+            (
+                338,
+                100,
+                "C_00.01",
+                "COREP_ALM",
+                "3.1.0",
+                1,
+                None,
+                "2023-06-30",
+                None,
+            ),
+            (
+                342,
+                100,
+                "C_00.01",
+                "COREP_LR",
+                "3.1.0",
+                1,
+                None,
+                "2023-06-30",
+                None,
+            ),
+        ]
+        SvcClass = _get_svc_class()
+        svc = SvcClass(session=MagicMock())
+        members = self._capture_scope_sets(svc)
+        svc.extract_module_info = MagicMock(return_value=_make_module_df(rows))
+
+        svc.calculate_operation_scope(
+            tables_vids=[],
+            precondition_items=[],
+            release_id=1,
+            table_codes=["C_00.01", "C_16.00.b"],
+        )
+
+        scope_sets = {frozenset(m) for m in members.values()}
+        assert scope_sets == {frozenset({344})}
+
+    def test_intra_scope_does_not_drop_a_disjoint_combination(self):
+        """An intra scope only dominates combinations it is part of.
+
+        The discriminator between the rule #304 asks for -- drop a
+        combination that strictly *contains* an intra scope -- and the
+        broader "any intra scope suppresses every cross scope" reading.
+        Module 300 covers both keys alone, but 100 and 200 hold one each
+        and genuinely need one another, so ``{100, 200}`` is a real
+        alternative cover and must survive (the #128 invariant).
+        """
+        SvcClass = _get_svc_class()
+        svc = SvcClass(session=MagicMock())
+        members = self._capture_scope_sets(svc)
+        svc.process_cross_module(
+            cross_modules={"A": [100], "B": [200]},
+            modules_dataframe=self._two_provider_df(),
+            required_keys={"A", "B"},
+            dominating_sets=[frozenset({300})],
+        )
+        assert len(svc.operation_scopes) == 1
+        assert [frozenset(m) for m in members.values()] == [
+            frozenset({100, 200})
+        ]

--- a/tests/unit/services/test_prefer_intra.py
+++ b/tests/unit/services/test_prefer_intra.py
@@ -6,6 +6,13 @@ module needs the primary to complete coverage), the primary module's script
 must treat it as intra-instance, while the sibling's script treats it as a
 cross-instance dependency.
 
+Since #304 the engine no longer emits a cross scope that strictly
+contains an intra one, so the exact pairing these tests feed in is not
+reachable from ``OperationScopeService`` any more. The override still
+fires for a cross scope disjoint from the intra module, and these tests
+now pin it as an invariant of ``detect_cross_module_dependencies``
+rather than as an observed engine output.
+
 Imports the service normally (works on Python 3.11+) to avoid the legacy
 ORM-stubbing shim used elsewhere in the suite.
 """

--- a/tests/unit/services/test_scope_calculator.py
+++ b/tests/unit/services/test_scope_calculator.py
@@ -818,6 +818,26 @@ class TestDetectCrossModuleDependencies:
         assert info["intra_instance_validations"] == []
         assert info["cross_instance_dependencies"] == []
 
+    def test_primary_in_no_single_module_scope_is_not_intra(self):
+        # Same as above but the result is not cross-module at all: the
+        # only scope is module 20 on its own. Module 10 hosts none of the
+        # referenced tables, so it is neither intra nor cross (#141).
+        # Keying the intra claim off ``not is_cross`` used to declare it
+        # intra here; #304 removes the redundant superset scopes that
+        # previously kept ``is_cross`` true and hid the hole.
+        svc, SR = self._make_svc()
+        sr = SR(
+            scopes=[_scope([20])],
+            is_cross_module=False,
+        )
+        info = svc.detect_cross_module_dependencies(
+            scope_result=sr,
+            primary_module_vid=10,
+            operation_code="v1234",
+        )
+        assert info["intra_instance_validations"] == []
+        assert info["cross_instance_dependencies"] == []
+
     @staticmethod
     def _mv(vid):
         mv = MagicMock()


### PR DESCRIPTION
## Summary

Fixes #304.

Visible effect on generated scripts, beyond the scope count: false entries in `alternative_dependencies` disappear. Two modules serving different validations were declared interchangeable, so the engine rejected a filing that legitimately provided both ("alternative dependencies were provided simultaneously"). Observed in the ECB `COREP_OF-4.1.0` script at release 4.3, where `corep_le` and `corep_lr` shared no affected operation.

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [ ] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [ ] Documentation updated (if applicable)

## Impact / Risk

- No breaking changes: public API, CLI, REST endpoints and Django models are untouched.
- No database schema or migration changes.
- Release note: generated scripts may contain fewer cross-instance scopes for validations that one module can evaluate on its own. Scopes, `dependency_modules` and `cross_instance_dependencies` of genuinely cross-module validations are unchanged.

## Notes

- The two `model_queries` release-filter commits are shared with #308. Merging that PR first lets this branch rebase cleanly on master.
- Checked against the ECB scripts discussed in ADAM engine issue 684: the release 4.3 `COREP_OF-4.1.0` script keeps its five cross-instance dependencies, the same affected operations and dates, and its 356 intra-instance validations. Only the false alternative group is removed.

