### PR TITLE
feat(dpm_xl): serialize set operators under a single SetOp class name

### DIFF
--- a/src/dpmcore/dpm_xl/ast/nodes.py
+++ b/src/dpmcore/dpm_xl/ast/nodes.py
@@ -1230,6 +1230,10 @@ class TemporaryIdentifier(AST):
         return {"class_name": self.__class__.__name__, "value": self.value}
 
 
+# The set-operator family below defines no ``toJSON``: the whole family is
+# serialized by ``ASTToJSONVisitor`` under a single ``SetOp`` class name with
+# the operands in one positional array, so the wire shape lives there and
+# nowhere else.
 class SetOfOp(AST):
     """AST node for set_of(expression), projects a Recordset's fact values to a ScalarSet."""
 
@@ -1244,13 +1248,6 @@ class SetOfOp(AST):
         )
 
     __repr__ = __str__
-
-    def toJSON(self) -> dict[str, Any]:
-        return {
-            "class_name": self.__class__.__name__,
-            "op": self.op,
-            "operand": self.operand,
-        }
 
 
 class UnionSetOp(AST):
@@ -1268,13 +1265,6 @@ class UnionSetOp(AST):
 
     __repr__ = __str__
 
-    def toJSON(self) -> dict[str, Any]:
-        return {
-            "class_name": self.__class__.__name__,
-            "op": self.op,
-            "operands": self.operands,
-        }
-
 
 class IntersectSetOp(AST):
     """AST node for intersect(s1, s2, …), variadic set intersection."""
@@ -1290,13 +1280,6 @@ class IntersectSetOp(AST):
         )
 
     __repr__ = __str__
-
-    def toJSON(self) -> dict[str, Any]:
-        return {
-            "class_name": self.__class__.__name__,
-            "op": self.op,
-            "operands": self.operands,
-        }
 
 
 class SetdiffOp(AST):
@@ -1318,14 +1301,6 @@ class SetdiffOp(AST):
 
     __repr__ = __str__
 
-    def toJSON(self) -> dict[str, Any]:
-        return {
-            "class_name": self.__class__.__name__,
-            "op": self.op,
-            "left": self.left,
-            "right": self.right,
-        }
-
 
 class SymdiffOp(AST):
     """AST node for symdiff(left, right), elements in exactly one of left or right."""
@@ -1346,14 +1321,6 @@ class SymdiffOp(AST):
 
     __repr__ = __str__
 
-    def toJSON(self) -> dict[str, Any]:
-        return {
-            "class_name": self.__class__.__name__,
-            "op": self.op,
-            "left": self.left,
-            "right": self.right,
-        }
-
 
 class CountSetOp(AST):
     """AST node for count(setExpression), cardinality of a ScalarSet."""
@@ -1369,13 +1336,6 @@ class CountSetOp(AST):
         )
 
     __repr__ = __str__
-
-    def toJSON(self) -> dict[str, Any]:
-        return {
-            "class_name": self.__class__.__name__,
-            "op": self.op,
-            "operand": self.operand,
-        }
 
 
 class ParameterRef(AST):

--- a/src/dpmcore/dpm_xl/utils/serialization.py
+++ b/src/dpmcore/dpm_xl/utils/serialization.py
@@ -625,30 +625,17 @@ class ASTToJSONVisitor(NodeVisitor):
     visit_IntersectSetOp = visit_UnionSetOp
     visit_SymdiffOp = visit_SetdiffOp
 
-    def visit_CountSetOp(self, node: Any) -> NodeDict:
-        """Visit legacy ``CountSetOp`` nodes as a ``count`` aggregation.
-
-        ``count`` is not a set operator — it returns the set's
-        cardinality as a Scalar — and its dedicated grammar rule was
-        dropped in MR !74, so ``count(...)`` now parses to an
-        ``AggregationOp``. The class survives only for externally built
-        ASTs, so emit the ``AggregationOp`` shape the parser would have
-        produced rather than let ``generic_visit`` invent a
-        ``CountSetOp`` class name the consumer schema rejects.
-
-        Args:
-            node: The legacy ``CountSetOp`` AST node.
-
-        Returns:
-            dict: The serialized ``AggregationOp`` node.
-        """
-        return {
-            "class_name": "AggregationOp",
-            "op": node.op,
-            "operand": self.visit(node.operand),
-            "grouping_clause": None,
-            "analytic_clause": None,
-        }
+    # ``count`` is not a set operator — it returns the set's cardinality
+    # as a Scalar — and its dedicated grammar rule was dropped in MR !74,
+    # so ``count(...)`` now parses to an ``AggregationOp``. The legacy
+    # class survives only for externally built ASTs, so alias it to the
+    # ``AggregationOp`` handler: it carries ``op``/``operand`` and no
+    # grouping or analytic clause, which is exactly what that handler's
+    # ``hasattr`` checks already emit (both clauses null). Aliasing keeps
+    # the parser shape and the legacy shape from drifting apart, and
+    # stops ``generic_visit`` inventing a ``CountSetOp`` class name the
+    # consumer schema rejects.
+    visit_CountSetOp = visit_AggregationOp
 
     def visit_ParExpr(self, node: Any) -> NodeDict:
         """Visit ParExpr nodes."""

--- a/src/dpmcore/dpm_xl/utils/serialization.py
+++ b/src/dpmcore/dpm_xl/utils/serialization.py
@@ -584,47 +584,48 @@ class ASTToJSONVisitor(NodeVisitor):
             "children": [self.visit(child) for child in node.children],
         }
 
+    def _visit_set_op(self, node: Any, operands: list[Any]) -> NodeDict:
+        """Emit a set operator under the shared ``SetOp`` class name.
+
+        The whole family shares one class name discriminated by ``op``,
+        with the operands in a single positional array: ``set_of``
+        carries one, ``union``/``intersect`` two or more, and
+        ``setdiff``/``symdiff`` exactly two in left-then-right order
+        (significant for ``setdiff``). The arity is fixed by the
+        grammar, so it needs no validating downstream.
+
+        Args:
+            node: The set operator AST node.
+            operands: Its operands, in emission order.
+
+        Returns:
+            dict: The serialized ``SetOp`` node.
+        """
+        return {
+            "class_name": "SetOp",
+            "op": node.op,
+            "operands": [self.visit(operand) for operand in operands],
+        }
+
     def visit_SetOfOp(self, node: Any) -> NodeDict:
         """Visit SetOfOp nodes (``set_of(recordset)``)."""
-        return {
-            "class_name": "SetOfOp",
-            "op": node.op,
-            "operand": self.visit(node.operand),
-        }
+        return self._visit_set_op(node, [node.operand])
 
     def visit_UnionSetOp(self, node: Any) -> NodeDict:
         """Visit UnionSetOp nodes (variadic ``union(...)``)."""
-        return {
-            "class_name": "UnionSetOp",
-            "op": node.op,
-            "operands": [self.visit(operand) for operand in node.operands],
-        }
+        return self._visit_set_op(node, node.operands)
 
     def visit_IntersectSetOp(self, node: Any) -> NodeDict:
         """Visit IntersectSetOp nodes (variadic ``intersect(...)``)."""
-        return {
-            "class_name": "IntersectSetOp",
-            "op": node.op,
-            "operands": [self.visit(operand) for operand in node.operands],
-        }
+        return self._visit_set_op(node, node.operands)
 
     def visit_SetdiffOp(self, node: Any) -> NodeDict:
         """Visit SetdiffOp nodes (``setdiff(left, right)``)."""
-        return {
-            "class_name": "SetdiffOp",
-            "op": node.op,
-            "left": self.visit(node.left),
-            "right": self.visit(node.right),
-        }
+        return self._visit_set_op(node, [node.left, node.right])
 
     def visit_SymdiffOp(self, node: Any) -> NodeDict:
         """Visit SymdiffOp nodes (``symdiff(left, right)``)."""
-        return {
-            "class_name": "SymdiffOp",
-            "op": node.op,
-            "left": self.visit(node.left),
-            "right": self.visit(node.right),
-        }
+        return self._visit_set_op(node, [node.left, node.right])
 
     def visit_ParExpr(self, node: Any) -> NodeDict:
         """Visit ParExpr nodes."""

--- a/src/dpmcore/dpm_xl/utils/serialization.py
+++ b/src/dpmcore/dpm_xl/utils/serialization.py
@@ -615,17 +615,40 @@ class ASTToJSONVisitor(NodeVisitor):
         """Visit UnionSetOp nodes (variadic ``union(...)``)."""
         return self._visit_set_op(node, node.operands)
 
-    def visit_IntersectSetOp(self, node: Any) -> NodeDict:
-        """Visit IntersectSetOp nodes (variadic ``intersect(...)``)."""
-        return self._visit_set_op(node, node.operands)
-
     def visit_SetdiffOp(self, node: Any) -> NodeDict:
         """Visit SetdiffOp nodes (``setdiff(left, right)``)."""
         return self._visit_set_op(node, [node.left, node.right])
 
-    def visit_SymdiffOp(self, node: Any) -> NodeDict:
-        """Visit SymdiffOp nodes (``symdiff(left, right)``)."""
-        return self._visit_set_op(node, [node.left, node.right])
+    # ``intersect`` carries the same operand attribute and arity as
+    # ``union``, and ``symdiff`` the same as ``setdiff``. Dispatch is by
+    # method name, so an alias is the whole handler.
+    visit_IntersectSetOp = visit_UnionSetOp
+    visit_SymdiffOp = visit_SetdiffOp
+
+    def visit_CountSetOp(self, node: Any) -> NodeDict:
+        """Visit legacy ``CountSetOp`` nodes as a ``count`` aggregation.
+
+        ``count`` is not a set operator — it returns the set's
+        cardinality as a Scalar — and its dedicated grammar rule was
+        dropped in MR !74, so ``count(...)`` now parses to an
+        ``AggregationOp``. The class survives only for externally built
+        ASTs, so emit the ``AggregationOp`` shape the parser would have
+        produced rather than let ``generic_visit`` invent a
+        ``CountSetOp`` class name the consumer schema rejects.
+
+        Args:
+            node: The legacy ``CountSetOp`` AST node.
+
+        Returns:
+            dict: The serialized ``AggregationOp`` node.
+        """
+        return {
+            "class_name": "AggregationOp",
+            "op": node.op,
+            "operand": self.visit(node.operand),
+            "grouping_clause": None,
+            "analytic_clause": None,
+        }
 
     def visit_ParExpr(self, node: Any) -> NodeDict:
         """Visit ParExpr nodes."""

--- a/tests/unit/ast/test_set_operators.py
+++ b/tests/unit/ast/test_set_operators.py
@@ -230,6 +230,28 @@ def _serialize_expr(expression: str) -> dict:
     return result["children"][0]
 
 
+def _set_values(node: dict) -> list:
+    """Constant values of a serialized ``Set`` literal, in order."""
+    return [child["value"] for child in node["children"]]
+
+
+def _class_names(node) -> set:
+    """Every ``class_name`` in a serialized payload, at any depth."""
+    if isinstance(node, dict):
+        names = set()
+        if "class_name" in node:
+            names.add(node["class_name"])
+        for value in node.values():
+            names |= _class_names(value)
+        return names
+    if isinstance(node, list):
+        names = set()
+        for item in node:
+            names |= _class_names(item)
+        return names
+    return set()
+
+
 def test_ast_to_json_serializes_empty_set_literal():
     node = _serialize_expr("{tT1, r001} in {}")
     assert node["class_name"] == "BinOp"
@@ -252,15 +274,16 @@ def test_ast_to_json_serializes_non_empty_set_literal():
 def test_ast_to_json_serializes_set_of_op():
     node = _serialize_expr("{tT1, r001} in set_of({tT2, r001-010})")
     right = node["right"]
-    assert right["class_name"] == "SetOfOp"
+    assert right["class_name"] == "SetOp"
     assert right["op"] == "set_of"
-    assert isinstance(right["operand"], dict)
+    assert len(right["operands"]) == 1
+    assert isinstance(right["operands"][0], dict)
 
 
 def test_ast_to_json_serializes_union_variadic():
     node = _serialize_expr("{tT1, r001} in union({1, 2}, {3, 4}, {5, 6})")
     right = node["right"]
-    assert right["class_name"] == "UnionSetOp"
+    assert right["class_name"] == "SetOp"
     assert right["op"] == "union"
     assert len(right["operands"]) == 3
     for operand in right["operands"]:
@@ -270,38 +293,73 @@ def test_ast_to_json_serializes_union_variadic():
 def test_ast_to_json_serializes_intersect():
     node = _serialize_expr("{tT1, r001} in intersect({1, 2, 3}, {2, 3, 4})")
     right = node["right"]
-    assert right["class_name"] == "IntersectSetOp"
+    assert right["class_name"] == "SetOp"
     assert right["op"] == "intersect"
     assert len(right["operands"]) == 2
 
 
 def test_ast_to_json_serializes_setdiff():
-    node = _serialize_expr("{tT1, r001} in setdiff({1, 2, 3}, {3})")
+    """``setdiff`` is not commutative: operands stay left-then-right."""
+    node = _serialize_expr("{tT1, r001} in setdiff({1, 2, 3}, {9})")
     right = node["right"]
-    assert right["class_name"] == "SetdiffOp"
+    assert right["class_name"] == "SetOp"
     assert right["op"] == "setdiff"
-    assert right["left"]["class_name"] == "Set"
-    assert right["right"]["class_name"] == "Set"
+    assert len(right["operands"]) == 2
+    left_operand, right_operand = right["operands"]
+    assert left_operand["class_name"] == "Set"
+    assert _set_values(left_operand) == [1, 2, 3]
+    assert right_operand["class_name"] == "Set"
+    assert _set_values(right_operand) == [9]
 
 
 def test_ast_to_json_serializes_symdiff():
-    node = _serialize_expr("{tT1, r001} in symdiff({1, 2}, {2, 3})")
+    node = _serialize_expr("{tT1, r001} in symdiff({1, 2}, {8, 9})")
     right = node["right"]
-    assert right["class_name"] == "SymdiffOp"
+    assert right["class_name"] == "SetOp"
     assert right["op"] == "symdiff"
-    assert right["left"]["class_name"] == "Set"
-    assert right["right"]["class_name"] == "Set"
+    assert len(right["operands"]) == 2
+    left_operand, right_operand = right["operands"]
+    assert _set_values(left_operand) == [1, 2]
+    assert _set_values(right_operand) == [8, 9]
 
 
 def test_ast_to_json_preserves_nested_set_operators():
-    """A nested ``setdiff(union(...), ...)`` expression must round-trip with
-    every intermediate ``class_name`` intact — not just the outermost node.
+    """A nested ``setdiff(union(...), ...)`` expression must serialize as
+    ``SetOp`` at every level, with the inner operator in first position.
     """
     node = _serialize_expr(
         "{tT1, r001} in setdiff(union({1, 2}, {3, 4}), {5})"
     )
     outer = node["right"]
-    assert outer["class_name"] == "SetdiffOp"
-    inner = outer["left"]
-    assert inner["class_name"] == "UnionSetOp"
+    assert outer["class_name"] == "SetOp"
+    assert outer["op"] == "setdiff"
+    inner = outer["operands"][0]
+    assert inner["class_name"] == "SetOp"
+    assert inner["op"] == "union"
     assert len(inner["operands"]) == 2
+    assert _set_values(outer["operands"][1]) == [5]
+
+
+def test_ast_to_json_emits_no_per_operator_set_class_names():
+    """None of the old per-operator names survives, at any depth."""
+    node = _serialize_expr(
+        "{tT1, r001} in union("
+        "set_of({tT2, r001-010}), "
+        "intersect({1, 2}, {2, 3}), "
+        "setdiff({4, 5}, {5}), "
+        "symdiff({6}, {7})"
+        ")"
+    )
+    names = _class_names(node)
+    assert names.isdisjoint(
+        {
+            "SetOfOp",
+            "UnionSetOp",
+            "IntersectSetOp",
+            "SetdiffOp",
+            "SymdiffOp",
+        }
+    )
+    assert "SetOp" in names
+    # ``Set`` literals are untouched by the collapse.
+    assert "Set" in names

--- a/tests/unit/ast/test_set_operators.py
+++ b/tests/unit/ast/test_set_operators.py
@@ -34,9 +34,6 @@ def test_set_of_op_node():
     node = SetOfOp(operand=operand)
     assert node.op == "set_of"
     assert node.operand is operand
-    j = node.toJSON()
-    assert j["class_name"] == "SetOfOp"
-    assert "operand" in j
 
 
 def test_union_set_op_node():
@@ -44,10 +41,7 @@ def test_union_set_op_node():
     s2 = Set(children=[])
     node = UnionSetOp(operands=[s1, s2])
     assert node.op == "union"
-    assert len(node.operands) == 2
-    j = node.toJSON()
-    assert j["class_name"] == "UnionSetOp"
-    assert "operands" in j
+    assert node.operands == [s1, s2]
 
 
 def test_intersect_set_op_node():
@@ -55,8 +49,7 @@ def test_intersect_set_op_node():
     s2 = Set(children=[])
     node = IntersectSetOp(operands=[s1, s2])
     assert node.op == "intersect"
-    j = node.toJSON()
-    assert j["class_name"] == "IntersectSetOp"
+    assert node.operands == [s1, s2]
 
 
 def test_setdiff_op_node():
@@ -66,10 +59,6 @@ def test_setdiff_op_node():
     assert node.op == "setdiff"
     assert node.left is s1
     assert node.right is s2
-    j = node.toJSON()
-    assert j["class_name"] == "SetdiffOp"
-    assert "left" in j
-    assert "right" in j
 
 
 def test_symdiff_op_node():
@@ -77,8 +66,8 @@ def test_symdiff_op_node():
     s2 = Set(children=[])
     node = SymdiffOp(left=s1, right=s2)
     assert node.op == "symdiff"
-    j = node.toJSON()
-    assert j["class_name"] == "SymdiffOp"
+    assert node.left is s1
+    assert node.right is s2
 
 
 def test_count_set_op_node():
@@ -86,9 +75,25 @@ def test_count_set_op_node():
     node = CountSetOp(operand=s)
     assert node.op == "count"
     assert node.operand is s
-    j = node.toJSON()
-    assert j["class_name"] == "CountSetOp"
-    assert "operand" in j
+
+
+def test_set_operator_nodes_define_no_own_to_json():
+    """The wire shape lives in ``ASTToJSONVisitor``, nowhere else.
+
+    A ``toJSON`` on any of these classes would be a second, divergent
+    serialization of the same node that no code path reaches (they are
+    ``AST`` subclasses, so ``serialize_ast`` always routes them through
+    the visitor), so re-adding one is a bug, not a feature.
+    """
+    for cls in (
+        SetOfOp,
+        UnionSetOp,
+        IntersectSetOp,
+        SetdiffOp,
+        SymdiffOp,
+        CountSetOp,
+    ):
+        assert "toJSON" not in vars(cls), f"{cls.__name__} redefines toJSON"
 
 
 # ---------------------------------------------------------------------------
@@ -220,7 +225,10 @@ def test_existing_literal_set_still_works():
 # and these nodes were silently dropped from the enriched AST payload.
 # ---------------------------------------------------------------------------
 
-from dpmcore.dpm_xl.utils.serialization import ASTToJSONVisitor  # noqa: E402
+from dpmcore.dpm_xl.utils.serialization import (  # noqa: E402
+    ASTToJSONVisitor,
+    serialize_ast,
+)
 
 
 def _serialize_expr(expression: str) -> dict:
@@ -230,9 +238,25 @@ def _serialize_expr(expression: str) -> dict:
     return result["children"][0]
 
 
-def _set_values(node: dict) -> list:
-    """Constant values of a serialized ``Set`` literal, in order."""
-    return [child["value"] for child in node["children"]]
+def _assert_set_op(node: dict, op: str, arity: int) -> list:
+    """Assert a node's ``SetOp`` wire shape and return its operands.
+
+    The consumer schema is ``additionalProperties: false``, so the exact
+    key set is part of the contract: a stray ``left``/``right``/
+    ``operand`` left alongside ``operands`` is a hard rejection
+    downstream, not a tolerated extra.
+    """
+    assert set(node) == {"class_name", "op", "operands"}
+    assert node["class_name"] == "SetOp"
+    assert node["op"] == op
+    assert len(node["operands"]) == arity
+    return node["operands"]
+
+
+def _assert_set_literal(node: dict, values: list) -> None:
+    """Assert a serialized ``Set`` literal holds exactly ``values``."""
+    assert node["class_name"] == "Set"
+    assert [child["value"] for child in node["children"]] == values
 
 
 def _class_names(node) -> set:
@@ -273,54 +297,39 @@ def test_ast_to_json_serializes_non_empty_set_literal():
 
 def test_ast_to_json_serializes_set_of_op():
     node = _serialize_expr("{tT1, r001} in set_of({tT2, r001-010})")
-    right = node["right"]
-    assert right["class_name"] == "SetOp"
-    assert right["op"] == "set_of"
-    assert len(right["operands"]) == 1
-    assert isinstance(right["operands"][0], dict)
+    ops = _assert_set_op(node["right"], "set_of", 1)
+    assert ops[0]["class_name"] == "VarID"
 
 
 def test_ast_to_json_serializes_union_variadic():
     node = _serialize_expr("{tT1, r001} in union({1, 2}, {3, 4}, {5, 6})")
-    right = node["right"]
-    assert right["class_name"] == "SetOp"
-    assert right["op"] == "union"
-    assert len(right["operands"]) == 3
-    for operand in right["operands"]:
-        assert operand["class_name"] == "Set"
+    ops = _assert_set_op(node["right"], "union", 3)
+    expected = [[1, 2], [3, 4], [5, 6]]
+    for operand, values in zip(ops, expected, strict=True):
+        _assert_set_literal(operand, values)
 
 
 def test_ast_to_json_serializes_intersect():
     node = _serialize_expr("{tT1, r001} in intersect({1, 2, 3}, {2, 3, 4})")
-    right = node["right"]
-    assert right["class_name"] == "SetOp"
-    assert right["op"] == "intersect"
-    assert len(right["operands"]) == 2
+    ops = _assert_set_op(node["right"], "intersect", 2)
+    _assert_set_literal(ops[0], [1, 2, 3])
+    _assert_set_literal(ops[1], [2, 3, 4])
 
 
 def test_ast_to_json_serializes_setdiff():
     """``setdiff`` is not commutative: operands stay left-then-right."""
     node = _serialize_expr("{tT1, r001} in setdiff({1, 2, 3}, {9})")
-    right = node["right"]
-    assert right["class_name"] == "SetOp"
-    assert right["op"] == "setdiff"
-    assert len(right["operands"]) == 2
-    left_operand, right_operand = right["operands"]
-    assert left_operand["class_name"] == "Set"
-    assert _set_values(left_operand) == [1, 2, 3]
-    assert right_operand["class_name"] == "Set"
-    assert _set_values(right_operand) == [9]
+    ops = _assert_set_op(node["right"], "setdiff", 2)
+    _assert_set_literal(ops[0], [1, 2, 3])
+    _assert_set_literal(ops[1], [9])
 
 
 def test_ast_to_json_serializes_symdiff():
+    """Operand order and identity are pinned exactly as for ``setdiff``."""
     node = _serialize_expr("{tT1, r001} in symdiff({1, 2}, {8, 9})")
-    right = node["right"]
-    assert right["class_name"] == "SetOp"
-    assert right["op"] == "symdiff"
-    assert len(right["operands"]) == 2
-    left_operand, right_operand = right["operands"]
-    assert _set_values(left_operand) == [1, 2]
-    assert _set_values(right_operand) == [8, 9]
+    ops = _assert_set_op(node["right"], "symdiff", 2)
+    _assert_set_literal(ops[0], [1, 2])
+    _assert_set_literal(ops[1], [8, 9])
 
 
 def test_ast_to_json_preserves_nested_set_operators():
@@ -330,14 +339,9 @@ def test_ast_to_json_preserves_nested_set_operators():
     node = _serialize_expr(
         "{tT1, r001} in setdiff(union({1, 2}, {3, 4}), {5})"
     )
-    outer = node["right"]
-    assert outer["class_name"] == "SetOp"
-    assert outer["op"] == "setdiff"
-    inner = outer["operands"][0]
-    assert inner["class_name"] == "SetOp"
-    assert inner["op"] == "union"
-    assert len(inner["operands"]) == 2
-    assert _set_values(outer["operands"][1]) == [5]
+    outer = _assert_set_op(node["right"], "setdiff", 2)
+    _assert_set_op(outer[0], "union", 2)
+    _assert_set_literal(outer[1], [5])
 
 
 def test_ast_to_json_emits_no_per_operator_set_class_names():
@@ -363,3 +367,47 @@ def test_ast_to_json_emits_no_per_operator_set_class_names():
     assert "SetOp" in names
     # ``Set`` literals are untouched by the collapse.
     assert "Set" in names
+
+
+# ---------------------------------------------------------------------------
+# ``serialize_ast`` is the entry point ``ASTGeneratorService`` builds scripts
+# with, and it does more than the visitor: it expands ``with`` scopes first
+# and returns the root expression node directly. The shape has to hold there,
+# not just under a bare ``ASTToJSONVisitor().visit()``.
+# ---------------------------------------------------------------------------
+
+
+def test_serialize_ast_emits_set_op_at_the_public_entry_point():
+    payload = serialize_ast(
+        SyntaxService().parse("{tT1, r001} in setdiff({1, 2}, {3})")
+    )
+    assert payload["class_name"] == "BinOp"
+    ops = _assert_set_op(payload["right"], "setdiff", 2)
+    _assert_set_literal(ops[0], [1, 2])
+    _assert_set_literal(ops[1], [3])
+
+
+def test_serialize_ast_emits_set_op_for_with_scoped_expression():
+    """``with`` scopes are expanded by reconstructing the nodes."""
+    payload = serialize_ast(
+        SyntaxService().parse("with {tT1} : {r001} in union({1, 2}, {3})")
+    )
+    ops = _assert_set_op(payload["right"], "union", 2)
+    _assert_set_literal(ops[0], [1, 2])
+    _assert_set_literal(ops[1], [3])
+
+
+def test_serialize_ast_maps_legacy_count_set_op_to_aggregation():
+    """``count`` is an aggregation, not a set operator.
+
+    ``CountSetOp`` lost its grammar rule in MR !74 and survives only for
+    externally built ASTs, so it must serialize exactly as the parser's
+    ``count(...)`` does instead of falling through to ``generic_visit``
+    and emitting a class name the consumer schema rejects.
+    """
+    operand = Set(children=[Constant(type_="Integer", value=1)])
+    legacy = serialize_ast(CountSetOp(operand=operand))
+    parsed = serialize_ast(SyntaxService().parse("count({1}) = 1"))
+    assert legacy == parsed["left"]
+    assert legacy["class_name"] == "AggregationOp"
+    assert legacy["op"] == "count"


### PR DESCRIPTION
## Summary

Serialized scripts gave each set operator its own `class_name` mirroring the internal AST class — `SetOfOp`, `UnionSetOp`, `IntersectSetOp`, `SetdiffOp`, `SymdiffOp` — and carried the operands under three different fields: `operand` for `set_of`, `operands` for `union`/`intersect`, `left` plus `right` for `setdiff`/`symdiff`. The per-operator name only repeated what `op` already said, and it left the family as the only outlier in a serializer where `BinOp`, `UnaryOp`, `AggregationOp` and `ComplexNumericOp` are all generic class names discriminated by `op`.

All five now serialize as `SetOp` with a single positional `operands` array:

```json
{"class_name": "SetOp", "op": "set_of",    "operands": [{...}]}
{"class_name": "SetOp", "op": "union",     "operands": [{...}, {...}, {...}]}
{"class_name": "SetOp", "op": "intersect", "operands": [{...}, {...}]}
{"class_name": "SetOp", "op": "setdiff",   "operands": [{...}, {...}]}
{"class_name": "SetOp", "op": "symdiff",   "operands": [{...}, {...}]}
```

`setdiff` and `symdiff` become positional: `operands[0]` is the former `left`, `operands[1]` the former `right`. Order is significant for `setdiff`, so it is preserved on emission and asserted with asymmetric operands in the tests. Set literals are untouched — `{"class_name": "Set", "children": [...]}` — and `count(set)` still serializes as `{"class_name": "AggregationOp", "op": "count"}`.

The array length needs no validating downstream: the grammar fixes the arity of each operator and rejects anything else at parse time, so `set_of(a, b)`, `union(a)` and `setdiff(a, b, c)` can never reach a script.

Internal AST class names and their `left`/`right`/`operand`/`operands` attributes stay as they are. They are dpmcore-internal, and renaming them would ripple into the constructor, semantic analyzer, template and ML generation for no gain on the wire. The operation-node path resolves operators by symbol rather than by class name, so it needs no change.

Fixes #314.

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [ ] Documentation updated (if applicable)

## Impact / Risk

- Breaking changes? (public API / CLI / REST endpoints / Django models)
- Database schema or migration concerns?
- Notes for release/changelog?

## Notes

<!-- Follow-ups, TODOs, or anything reviewers should know. -->
