### PR TITLE
Resolve row/column ranges by code value, not table display order

### DIFF
--- a/src/dpmcore/dpm_xl/model_queries.py
+++ b/src/dpmcore/dpm_xl/model_queries.py
@@ -25,6 +25,7 @@ from sqlalchemy.orm import aliased
 from dpmcore.dpm_xl.utils.filters import filter_by_release
 from dpmcore.dpm_xl.utils.range_resolution import (
     build_axis_order_map,
+    build_axis_value_map,
     resolve_range_codes,
 )
 from dpmcore.orm.glossary import (
@@ -1903,13 +1904,16 @@ def _build_axis_order_map(
 ) -> dict[str, int] | None:
     """Build ``{code: order}`` for one axis from a code/order frame.
 
-    Thin ``DataFrame`` adapter over
-    :func:`~dpmcore.dpm_xl.utils.range_resolution.build_axis_order_map`:
-    returns ``None`` when the axis is not fully ordered — the order column is
-    absent, some present code lacks an order, or a code carries two different
-    orders — so the caller falls back to string comparison for that whole axis.
+    Prefers each code's own numeric value over its stored display order,
+    since some tables show a code out of numeric sequence. Returns ``None`` when neither is
+    usable, so the caller falls back to string comparison for that whole axis.
     """
-    if code_col not in data.columns or order_col not in data.columns:
+    if code_col not in data.columns:
+        return None
+    value_map = build_axis_value_map(data[code_col])
+    if value_map:
+        return value_map
+    if order_col not in data.columns:
         return None
     return build_axis_order_map(data[code_col], data[order_col])
 

--- a/src/dpmcore/dpm_xl/utils/data_handlers.py
+++ b/src/dpmcore/dpm_xl/utils/data_handlers.py
@@ -5,17 +5,11 @@ import pandas as pd
 
 from dpmcore.dpm_xl.utils.range_resolution import (
     build_axis_order_map,
+    build_axis_value_map,
     sort_by_order,
 )
 from dpmcore.dpm_xl.utils.tokens import *
 from dpmcore.errors import SemanticError
-
-# Stored-order column that carries the display order for each *_code column.
-_ORDER_COLUMN = {
-    ROW_CODE: ROW_ORDER,
-    COLUMN_CODE: COLUMN_ORDER,
-    SHEET_CODE: SHEET_ORDER,
-}
 
 
 def _raise_cells_not_found(
@@ -97,21 +91,18 @@ def filter_data_by_cell_element(
     """
     if valid_codes is None:
         valid_codes = set(series[element_name])
-    order_col = _ORDER_COLUMN.get(element_name)
-    use_order = (
-        bool(order_map)
-        and order_col is not None
-        and (order_col in series.columns)
-    )
+    use_order = bool(order_map)
 
     def _in_range(lo: str, hi: str) -> "pd.Series[bool]":
         """Boolean mask of ``series`` rows inside the range ``lo``-``hi``."""
-        if use_order and order_map is not None and order_col is not None:
+        if use_order and order_map is not None:
             lo_order = order_map.get(lo)
             hi_order = order_map.get(hi)
             if lo_order is None or hi_order is None or lo_order > hi_order:
                 return pd.Series(False, index=series.index)
-            return series[order_col].between(lo_order, hi_order)
+            return (
+                series[element_name].map(order_map).between(lo_order, hi_order)
+            )
         return series[element_name].between(lo, hi)
 
     if len(cell_elements) == 1 and "-" not in cell_elements[0]:
@@ -200,9 +191,13 @@ def _axis_order_map(
 ) -> dict[str, int] | None:
     """Build ``{code: order}`` for one axis of ``df`` (``None`` if unordered).
 
-    Returns ``None`` when the order column is absent or the axis is not fully
-    ordered, so the caller falls back to string comparison.
+    Prefers each code's numeric value over display order (some tables show a
+    code out of numeric sequence). Falls back to string comparison when
+    neither map is usable.
     """
+    value_map = build_axis_value_map(df[code_col])
+    if value_map:
+        return value_map
     if order_col not in df.columns:
         return None
     return build_axis_order_map(df[code_col], df[order_col])

--- a/src/dpmcore/dpm_xl/utils/range_resolution.py
+++ b/src/dpmcore/dpm_xl/utils/range_resolution.py
@@ -94,6 +94,31 @@ def sort_by_order(
     return ordered + unordered
 
 
+def build_axis_value_map(codes: Iterable[Any]) -> dict[str, int] | None:
+    """Build a ``{code: int}`` map from each code's own numeric value.
+
+    Some tables show a code out of numeric sequence for layout reasons,
+    which breaks range resolution by display order. Callers should prefer
+    this map and fall back to :func:`build_axis_order_map` only when it fails.
+
+    Args:
+        codes: The axis code of each row (may contain ``None``/NaN).
+
+    Returns:
+        ``{code: int(code)}`` when every present code is numeric, else
+        ``None``.
+    """
+    result: dict[str, int] = {}
+    for code in codes:
+        if _is_missing(code):
+            continue
+        key = str(code)
+        if not key.isdigit():
+            return None
+        result[key] = int(key)
+    return result
+
+
 def build_axis_order_map(
     codes: Iterable[Any], orders: Iterable[Any]
 ) -> dict[str, int] | None:

--- a/tests/unit/dpm_xl/test_data_handlers.py
+++ b/tests/unit/dpm_xl/test_data_handlers.py
@@ -259,3 +259,45 @@ class TestGenerateXyzOrdering:
         result = generate_xyz(_xyz_frame(rows, with_order=False))
         x_by_row = {r["row_code"]: r["x"] for r in result}
         assert x_by_row["10"] == 2  # lexicographic: "1","10","11","2",...
+
+
+class TestValueOverridesMisleadingDisplayOrder:
+    """A numeric code's own value beats a misleading display order.
+
+    Regression for real EBA tables (C_35.01, F_04.10, E_09.02, ...) that
+    show a code out of numeric sequence for layout reasons: order-only
+    resolution either sees a valid range as reversed (false ``1-2``) or spans
+    extra codes sitting between the endpoints in display order (false ``1-17``).
+    """
+
+    def test_range_resolves_by_value_when_display_order_disagrees(self):
+        # Column "0110" is numerically highest but shown FIRST (order=1),
+        # C_35.01's real layout -- by order alone, "0030-0110" looks
+        # reversed and would resolve to nothing.
+        data = pd.DataFrame(
+            {
+                "table_code": ["T"] * 3,
+                "row_code": ["0010"] * 3,
+                "column_code": ["0110", "0030", "0070"],
+                "sheet_code": ["0000"] * 3,
+                "column_order": [1, 2, 3],
+            }
+        )
+        result = filter_all_data(data, "T", ["0010"], ["0030-0110"], ["0000"])
+        assert sorted(result["column_code"]) == ["0030", "0070", "0110"]
+
+    def test_range_does_not_over_include_by_misleading_order(self):
+        # "0381" is inside 0300-0381 but shown LAST (order=6), after
+        # "0390"/"0400"/"0410" -- E_09.02's real layout. By order alone the
+        # range isn't reversed, so it would wrongly span those three too.
+        data = pd.DataFrame(
+            {
+                "table_code": ["T"] * 6,
+                "row_code": ["0300", "0301", "0390", "0400", "0410", "0381"],
+                "column_code": ["0010"] * 6,
+                "sheet_code": ["0000"] * 6,
+                "row_order": [1, 2, 3, 4, 5, 6],
+            }
+        )
+        result = filter_all_data(data, "T", ["0300-0381"], ["0010"], ["0000"])
+        assert sorted(result["row_code"]) == ["0300", "0301", "0381"]

--- a/tests/unit/dpm_xl/test_range_resolution.py
+++ b/tests/unit/dpm_xl/test_range_resolution.py
@@ -9,6 +9,7 @@ import math
 
 from dpmcore.dpm_xl.utils.range_resolution import (
     build_axis_order_map,
+    build_axis_value_map,
     resolve_range_codes,
     sort_by_order,
 )
@@ -108,3 +109,31 @@ class TestBuildAxisOrderMap:
             "r1": 1,
             "r2": 2,
         }
+
+
+class TestBuildAxisValueMap:
+    """A code's own numeric value, preferred over stored display order.
+
+    Some tables show a code out of numeric sequence for layout reasons
+    (e.g. the highest column code displayed first), which breaks range
+    resolution by ``TableVersionHeader.Order``. When every code on the
+    axis is a plain integer string, its own value is a more reliable
+    ordering key.
+    """
+
+    def test_zero_padded_and_non_padded_codes_parse_to_their_value(self):
+        assert build_axis_value_map(["0010", "0002", "11"]) == {
+            "0010": 10,
+            "0002": 2,
+            "11": 11,
+        }
+
+    def test_non_numeric_code_returns_none(self):
+        # One non-numeric code (e.g. an alphabetic memo code) makes the
+        # whole axis unusable -- falls back to order/text comparison.
+        assert build_axis_value_map(["0010", "TOTAL"]) is None
+
+    def test_missing_codes_are_skipped(self):
+        # A cell that lacks this axis (e.g. no sheets) carries a null code.
+        result = build_axis_value_map(["0010", None, math.nan])
+        assert result == {"0010": 10}


### PR DESCRIPTION
Closes #316 

## Summary

Adds `build_axis_value_map`, which builds `{code: int(code)}` from each code's own numeric value. Both `_build_axis_order_map` (model_queries.py) and `_axis_order_map` (data_handlers.py) now prefer it over the stored display order, falling back to display order only for non-numeric or mixed-width axes. Also fixes `_in_range` in `filter_data_by_cell_element`, which computed its bounds from `order_map` but then filtered on the raw stored-order column, a different value scale once `order_map` can hold numeric values.

## Checklist

- [X] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [X] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [ ] Documentation updated (if applicable)

## Impact / Risk

- Breaking changes? (public API / CLI / REST endpoints / Django models)
- Database schema or migration concerns?
- Notes for release/changelog?

## Notes

<!-- Follow-ups, TODOs, or anything reviewers should know. -->
