### PR TITLE
fix(dpm_xl): serialize rank as an AggregationOp discriminated by op

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -19,7 +19,7 @@ description = "Document parameters, class attributes, return types, and variable
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"server\""
+markers = "extra == \"server\" or extra == \"all\""
 files = [
     {file = "annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320"},
     {file = "annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4"},
@@ -32,7 +32,7 @@ description = "Reusable constraint types to use with typing.Annotated"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"server\""
+markers = "extra == \"server\" or extra == \"all\""
 files = [
     {file = "annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53"},
     {file = "annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89"},
@@ -60,7 +60,7 @@ files = [
     {file = "anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708"},
     {file = "anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc"},
 ]
-markers = {main = "extra == \"all\" or extra == \"server\""}
+markers = {main = "extra == \"server\" or extra == \"all\""}
 
 [package.dependencies]
 exceptiongroup = {version = ">=1.0.2", markers = "python_version < \"3.11\""}
@@ -81,7 +81,7 @@ files = [
     {file = "asgiref-3.11.1-py3-none-any.whl", hash = "sha256:e8667a091e69529631969fd45dc268fa79b99c92c5fcdda727757e52146ec133"},
     {file = "asgiref-3.11.1.tar.gz", hash = "sha256:5f184dc43b7e763efe848065441eac62229c9f7b0475f41f80e207a114eda4ce"},
 ]
-markers = {main = "extra == \"all\" or extra == \"django\""}
+markers = {main = "extra == \"django\" or extra == \"all\""}
 
 [package.dependencies]
 typing_extensions = {version = ">=4", markers = "python_version < \"3.11\""}
@@ -343,7 +343,7 @@ description = "Composable command line interface toolkit"
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"server\" or extra == \"cli\""
+markers = "extra == \"server\" or extra == \"all\" or extra == \"cli\""
 files = [
     {file = "click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76"},
     {file = "click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6"},
@@ -363,7 +363,7 @@ files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {main = "(extra == \"all\" or extra == \"server\" or extra == \"cli\") and platform_system == \"Windows\"", dev = "os_name == \"nt\" or sys_platform == \"win32\"", docs = "sys_platform == \"win32\""}
+markers = {main = "(extra == \"server\" or extra == \"all\" or extra == \"cli\") and platform_system == \"Windows\"", dev = "sys_platform == \"win32\" or os_name == \"nt\"", docs = "sys_platform == \"win32\""}
 
 [[package]]
 name = "coverage"
@@ -513,7 +513,7 @@ files = [
     {file = "django-5.2.17-py3-none-any.whl", hash = "sha256:f04fb3b36ee119e1af4fa1d397d5fd6cf12700f49321e84d4f4c642c5b1973db"},
     {file = "django-5.2.17.tar.gz", hash = "sha256:9d4d93be539a18ab80d058eb515900e10951e04c537c5a6b394fc49528d3251f"},
 ]
-markers = {main = "extra == \"all\" or extra == \"django\""}
+markers = {main = "extra == \"django\" or extra == \"all\""}
 
 [package.dependencies]
 asgiref = ">=3.8.1"
@@ -523,28 +523,6 @@ tzdata = {version = "*", markers = "sys_platform == \"win32\""}
 [package.extras]
 argon2 = ["argon2-cffi (>=19.1.0)"]
 bcrypt = ["bcrypt"]
-
-[[package]]
-name = "django"
-version = "6.0.8"
-description = "A high-level Python web framework that encourages rapid development and clean, pragmatic design."
-optional = false
-python-versions = ">=3.12"
-groups = ["dev"]
-markers = "python_version >= \"3.12\""
-files = [
-    {file = "django-6.0.8-py3-none-any.whl", hash = "sha256:9b98b7e1902e0e575ea4f42c175fc9512784f7f2580898286aee3388b322219d"},
-    {file = "django-6.0.8.tar.gz", hash = "sha256:cb0bd962d27fc866f3c514b20aae6a7df56ec80b488f9899da46d675cd051526"},
-]
-
-[package.dependencies]
-asgiref = ">=3.9.1"
-sqlparse = ">=0.5.0"
-tzdata = {version = "*", markers = "sys_platform == \"win32\""}
-
-[package.extras]
-argon2 = ["argon2-cffi (>=23.1.0)"]
-bcrypt = ["bcrypt (>=4.1.1)"]
 
 [[package]]
 name = "django-stubs"
@@ -605,7 +583,7 @@ description = "An implementation of lxml.xmlfile for the standard library"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"export\""
+markers = "extra == \"export\" or extra == \"all\""
 files = [
     {file = "et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa"},
     {file = "et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54"},
@@ -622,7 +600,7 @@ files = [
     {file = "exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598"},
     {file = "exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219"},
 ]
-markers = {main = "(extra == \"all\" or extra == \"server\") and python_version == \"3.10\"", dev = "python_version == \"3.10\""}
+markers = {main = "(extra == \"server\" or extra == \"all\") and python_version == \"3.10\"", dev = "python_version == \"3.10\""}
 
 [package.dependencies]
 typing-extensions = {version = ">=4.6.0", markers = "python_version < \"3.13\""}
@@ -637,7 +615,7 @@ description = "FastAPI framework, high performance, easy to learn, fast to code,
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"server\""
+markers = "extra == \"server\" or extra == \"all\""
 files = [
     {file = "fastapi-0.141.1-py3-none-any.whl", hash = "sha256:bfb91aa2d334c61cb35ba9a116fc123b3d3df31640b801cf57a7a78ec3f603b3"},
     {file = "fastapi-0.141.1.tar.gz", hash = "sha256:e8822fc40db1e1858054d7a949a888695bc9bdce70139178e33bd2871a453ca1"},
@@ -760,7 +738,7 @@ files = [
     {file = "h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"},
     {file = "h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1"},
 ]
-markers = {main = "extra == \"all\" or extra == \"server\""}
+markers = {main = "extra == \"server\" or extra == \"all\""}
 
 [[package]]
 name = "httpcore"
@@ -791,7 +769,7 @@ description = "A collection of framework independent HTTP protocol utils."
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"server\""
+markers = "extra == \"server\" or extra == \"all\""
 files = [
     {file = "httptools-0.8.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:bf3b6f807c8541503cecfbb8a8dffb385640d0d96102f3d112aa8740f9b7c826"},
     {file = "httptools-0.8.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:da684f2e1aa2ee9bdcb083f3f3a68c5956750b375bc5df864d3a5f0c42a40b77"},
@@ -881,7 +859,7 @@ files = [
     {file = "idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5"},
     {file = "idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d"},
 ]
-markers = {main = "extra == \"all\" or extra == \"server\""}
+markers = {main = "extra == \"server\" or extra == \"all\""}
 
 [package.extras]
 all = ["mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
@@ -919,7 +897,7 @@ description = "Read metadata from Python packages"
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
-markers = "python_full_version < \"3.10.2\""
+markers = "python_version == \"3.10\" and python_full_version < \"3.10.2\""
 files = [
     {file = "importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7"},
     {file = "importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc"},
@@ -1077,7 +1055,7 @@ description = "Python port of markdown-it. Markdown parsing, done right!"
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"cli\""
+markers = "extra == \"cli\" or extra == \"all\""
 files = [
     {file = "markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a"},
     {file = "markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49"},
@@ -1201,7 +1179,7 @@ description = "Markdown URL utilities"
 optional = true
 python-versions = ">=3.7"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"cli\""
+markers = "extra == \"cli\" or extra == \"all\""
 files = [
     {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
     {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
@@ -1214,7 +1192,7 @@ description = "Django backend for Microsoft SQL Server"
 optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"django\""
+markers = "extra == \"django\" or extra == \"all\""
 files = [
     {file = "mssql_django-1.8.0-py3-none-any.whl", hash = "sha256:1e97e303477ea228454e76514e544081d6041a5a4383f0c40a9313549d4724f2"},
     {file = "mssql_django-1.8.0.tar.gz", hash = "sha256:023a3d55a85d1d0d9f38d731182c35c2fecbf6bdc7b2464ed7ebf29c9e7bbdb2"},
@@ -1377,90 +1355,7 @@ files = [
     {file = "numpy-2.2.6-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:d042d24c90c41b54fd506da306759e06e568864df8ec17ccc17e9e884634fd00"},
     {file = "numpy-2.2.6.tar.gz", hash = "sha256:e29554e2bef54a90aa5cc07da6ce955accb83f21ab5de01a62c8478897b264fd"},
 ]
-markers = {main = "extra == \"all\" or extra == \"data\" or extra == \"migration\""}
-
-[[package]]
-name = "numpy"
-version = "2.4.6"
-description = "Fundamental package for array computing in Python"
-optional = false
-python-versions = ">=3.11"
-groups = ["dev"]
-markers = "python_version >= \"3.15\""
-files = [
-    {file = "numpy-2.4.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0280e0356c0829a18d9de1cb7eee50ec22ca639878d7240307ca0943d73cd2c4"},
-    {file = "numpy-2.4.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:110f8b71aacb688ec69062bb7f6938a0f8acb01b7c1c4beb453c65b6d234584d"},
-    {file = "numpy-2.4.6-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:4cfe66903cc32a9921a6733d96b19bb6abf310397581bbad89c228f5abaf0ee8"},
-    {file = "numpy-2.4.6-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:8155154c7c691289fe18f510b5d4657c68c67989f293f0535a91360392ff6538"},
-    {file = "numpy-2.4.6-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ab0a9c4ffb1a6d95ef519fe4247dba8eb6b18ad93999f76b7f657039acabd47"},
-    {file = "numpy-2.4.6-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:89cd468399cfd2504718f0ba50e410dca55a170b61a02ad92bb18c8a65186e93"},
-    {file = "numpy-2.4.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c2d37ab77531417474168eb79d6d80b14f821a966818505d03013d0833edb7a8"},
-    {file = "numpy-2.4.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f407cb6b8e9d6d8c626bc73c945db1706035af8fd632295547bf1c9e46d092d6"},
-    {file = "numpy-2.4.6-cp311-cp311-win32.whl", hash = "sha256:ddea102b48f9e339f3948bf22040944184627a30fdf7f858667673b9c5f033c8"},
-    {file = "numpy-2.4.6-cp311-cp311-win_amd64.whl", hash = "sha256:1e254a00cdf42b1e4d5b3d68d33af63268d41340d8885df2ab6470f2e1500147"},
-    {file = "numpy-2.4.6-cp311-cp311-win_arm64.whl", hash = "sha256:ed9749eef4cbd126da3dc1d6bcb3a57f5eb7ac6a6484146bdbf743f552dfc577"},
-    {file = "numpy-2.4.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:001fbb8e08d942dd57599e781f2472269ee7f2755fae407b4f67b2f0b17da3f1"},
-    {file = "numpy-2.4.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ebfb099f8dcf083deef3ac1ca4c1503f387cf76296fcb3816b66f5ecb5f54fdb"},
-    {file = "numpy-2.4.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:3213d622a0283a39a93d188f3cf72b26862df52fbb4ca3697f51705016523d41"},
-    {file = "numpy-2.4.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:357cc07a6d7b0b182ff02249616a03742827ebb1277546b5c7cd7f7620a45698"},
-    {file = "numpy-2.4.6-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f9fb9157b4ce2971008323afe46053787b526ef624fea915b261468a8421a0f"},
-    {file = "numpy-2.4.6-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90f9849678c75fe7afa2d348ac842c168b0a4d3d61919687216dfc547976d853"},
-    {file = "numpy-2.4.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c1a2af6c6ef86344a6b0db6b97834208bf598db514f2b155042439b62605601a"},
-    {file = "numpy-2.4.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e5805d5a22fd19c8ccff10a9561f9df94436b0545619ea579db2d3c35294bce2"},
-    {file = "numpy-2.4.6-cp312-cp312-win32.whl", hash = "sha256:e3eeb0aabd6bd5ce64faae67e9935203a6991b4bc2a485a767fbafb2c5125f45"},
-    {file = "numpy-2.4.6-cp312-cp312-win_amd64.whl", hash = "sha256:d8e8286dd7cea7895157318d1b91cdacac64c479f3cbc8dce548331728484751"},
-    {file = "numpy-2.4.6-cp312-cp312-win_arm64.whl", hash = "sha256:4081eb135ac24158bd51cdfbef16f1c64df7063b1143f24731387137c092bec8"},
-    {file = "numpy-2.4.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:511dbaf848decaaaf4b4ca48032619fb3138710c4bf7da7617765edad1ef96b0"},
-    {file = "numpy-2.4.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bf162abab1c1a736333192707cef898e735a5ca00f38f27eeedf44b39d9e85eb"},
-    {file = "numpy-2.4.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:043191bfa8eab18c776647b62723ac9dddece59743b13f49b2016094129c2b3f"},
-    {file = "numpy-2.4.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:6180d8b35af935aed8ece3a85e0a43f87393ae0ac87c8d2c8bd2c993f7270ef3"},
-    {file = "numpy-2.4.6-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72fbe16c6fac95aedf5937fa873445cec2110be35d8a4e9433d7501fd98dae6b"},
-    {file = "numpy-2.4.6-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a7830bab239b79cda9c08c2da014761cafb48da6150e1da17ac06283f43b6089"},
-    {file = "numpy-2.4.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ef4aea96ce4d3b074422cb4f2f64e216bf9e213004bb58ecfdf50ea02ea8eb9a"},
-    {file = "numpy-2.4.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dfa20cc6ca228e6b155b11da03825975ce66aea520985dbbddf0f2a5a495c605"},
-    {file = "numpy-2.4.6-cp313-cp313-win32.whl", hash = "sha256:56b39e5e0622a09a25bf5baf62f4bcf0cb8a41ae6e2819cf49bbc5a74c083f91"},
-    {file = "numpy-2.4.6-cp313-cp313-win_amd64.whl", hash = "sha256:c4fc99836233ea196540b17ab0983aff60ed07941751930f5f4d05bc3b3b7359"},
-    {file = "numpy-2.4.6-cp313-cp313-win_arm64.whl", hash = "sha256:a7c711e21628b52034bb5ab8d1bce291f752fcc5e92accc615778acee1ff4778"},
-    {file = "numpy-2.4.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:112b06a867b235ef466ed3508ddf0238050df9c727cafb5301ac385b899189a1"},
-    {file = "numpy-2.4.6-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:eaf7fa2de5c0be8ae6ff8e9bea2ccd725e980541244521d8d4b5f3354a27babe"},
-    {file = "numpy-2.4.6-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:7265a2f3d436e54ef9f2b52b5c937e6be778781bd97a590319d7348f1c1ca997"},
-    {file = "numpy-2.4.6-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f74a575920ab21fe304421a3fc28793d82e299cae9eccb37084e9fc7f3617c20"},
-    {file = "numpy-2.4.6-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ede83e07a75dd06bc501566c1eca2afc0d61677c1472ac9ad93fdee6e638a48d"},
-    {file = "numpy-2.4.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:68bb27509ac1b9a3443094260f6326150663b06abe40b73a2f81160623da5b67"},
-    {file = "numpy-2.4.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a0df0043bdb289bde1f62da130d20df23d58b45429f752bc7a8fc5325a225ecd"},
-    {file = "numpy-2.4.6-cp313-cp313t-win32.whl", hash = "sha256:29a287e0cf63ff528da061de6b9f64a4618da591ca1046aafc54062e40ca7eab"},
-    {file = "numpy-2.4.6-cp313-cp313t-win_amd64.whl", hash = "sha256:25c692919ac5a01f170a3bfcd62d745b24fd095c353d50812637d6fcab442e75"},
-    {file = "numpy-2.4.6-cp313-cp313t-win_arm64.whl", hash = "sha256:1e978ec1e8bd0e0e4de6bb75de9d30cbb74db6b6a2bb727618613703ca0167dd"},
-    {file = "numpy-2.4.6-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:06ca2f61ec4385a07a6977c55ba998a4466c123642b4a32694d3128fce18c079"},
-    {file = "numpy-2.4.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:38efbc8de75c7a0fc1ac190162d892787f3f47b57cc291231aafee36b80982b7"},
-    {file = "numpy-2.4.6-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d581b735e177fdcdce6fed8e7e8880a3fb6ee4e3653a3ac6af01c6f4c03effc5"},
-    {file = "numpy-2.4.6-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:0a041d3d761dc3c35cc56ce0351506a02bcbc25f7b169f652435141a17db9096"},
-    {file = "numpy-2.4.6-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40fdc1ae7125e518ea98e53e69a4ebc27e1fd50510c47b7ea130cf21e5e1d42b"},
-    {file = "numpy-2.4.6-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a2c306dea656c12c68f51f4cea133cbe78ca7435eb28c735eac1d3ebe73be6e8"},
-    {file = "numpy-2.4.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:33111801a01c12a8a1e3721f0a9232f8cfc8ae2c6b7098167e6f623c6073f402"},
-    {file = "numpy-2.4.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ae506e6902902557576a26ff33eda8695e7ecb3cb36c3b573a0765dee114ebdb"},
-    {file = "numpy-2.4.6-cp314-cp314-win32.whl", hash = "sha256:aaf159caa35993cb1f56fb9b8e4610d35758e7ca005412eb1daa856a78c9c4b1"},
-    {file = "numpy-2.4.6-cp314-cp314-win_amd64.whl", hash = "sha256:b507f5c4c1d508876d1819b6bf9a49d365b96320b5d4993426b33a23ca4b8261"},
-    {file = "numpy-2.4.6-cp314-cp314-win_arm64.whl", hash = "sha256:6f41ae150c4e32db4f3310cdaf64b1593a03dbabe29eec77fc9b50fe64061df6"},
-    {file = "numpy-2.4.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ece3d2cfe132e7d51f44a832b303895e6f2d499c5e74dfbdb06ee246147a304a"},
-    {file = "numpy-2.4.6-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:e3e5193ef5a3dc73bceee50f7fdc2c90dbb76c42df8d8fae3d1067a583df579e"},
-    {file = "numpy-2.4.6-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:17f9ade344e7d9b464a084d69bcf18fc691cb1db67c62ed80820bf4926d78f0e"},
-    {file = "numpy-2.4.6-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9cd5ffd25db4e7ba6a375693b3fc0fc1791ec636c17db3720da19bde7180ec43"},
-    {file = "numpy-2.4.6-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d92c3819208a60205a12a245c91ad70cb0a85336659b19b834205573ac8456e"},
-    {file = "numpy-2.4.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e85b752a1e912b70eaad4fafbd4d1238007ab221de2009b9a2f5ae7461239895"},
-    {file = "numpy-2.4.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:29cb7f67d10b479ff07c17d33e39f78c07f71c40ef30d63c153d340e96cd3fb4"},
-    {file = "numpy-2.4.6-cp314-cp314t-win32.whl", hash = "sha256:260a5d70215b61ab4fadf5c7baacd64821842975eea312125ed3c39a6391b063"},
-    {file = "numpy-2.4.6-cp314-cp314t-win_amd64.whl", hash = "sha256:81a1cca95ed5bb92aa8b10dd2cdc9a0d3853a50fad926c28b5d7e8ea54389627"},
-    {file = "numpy-2.4.6-cp314-cp314t-win_arm64.whl", hash = "sha256:0c9136e14ed34a9e343a31c533d78a9813a69a3148332bce5e9821cb2f996e66"},
-    {file = "numpy-2.4.6-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:55cced7c52e981362f708ad635198e97a752dfba412cc03c23bbf3bd8d5cd662"},
-    {file = "numpy-2.4.6-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:d6da64deb6b8ed903e7560180a92f2d804ee1ba5eeb849ac2748b8c1aba1f6d7"},
-    {file = "numpy-2.4.6-pp311-pypy311_pp73-macosx_14_0_arm64.whl", hash = "sha256:68a5124b13fa6cc2086764a20005d30bc0548146f7f5322f02fce212ca14317f"},
-    {file = "numpy-2.4.6-pp311-pypy311_pp73-macosx_14_0_x86_64.whl", hash = "sha256:948424b06129ce883307e8cff868c31396d8dc7630a59c61d70d98dbe70f222c"},
-    {file = "numpy-2.4.6-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5dbbdb29840ca3d91ee0fece42fc29278886d908280bfec0a5846c6f901a3eb0"},
-    {file = "numpy-2.4.6-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8ad03c0965fb3c692200e74d458ca28c1dbb4ce96f9a479a8aa041ad5fabca02"},
-    {file = "numpy-2.4.6-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:2803abfebfc990042cd494d8ce2d5f82e9d847af6d35ec486923aa19dbad5e73"},
-    {file = "numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda"},
-]
+markers = {main = "extra == \"migration\" or extra == \"data\" or extra == \"all\""}
 
 [[package]]
 name = "openpyxl"
@@ -1469,7 +1364,7 @@ description = "A Python library to read/write Excel 2010 xlsx/xlsm files"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"export\""
+markers = "extra == \"export\" or extra == \"all\""
 files = [
     {file = "openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2"},
     {file = "openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050"},
@@ -1497,7 +1392,7 @@ description = "Powerful data structures for data analysis, time series, and stat
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"data\" or extra == \"migration\""
+markers = "extra == \"migration\" or extra == \"data\" or extra == \"all\""
 files = [
     {file = "pandas-2.3.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:376c6446ae31770764215a6c937f72d917f214b43560603cd60da6408f183b6c"},
     {file = "pandas-2.3.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e19d192383eab2f4ceb30b412b22ea30690c9e618f78870357ae1d682912015a"},
@@ -1647,7 +1542,7 @@ description = "psycopg2 - Python-PostgreSQL Database Adapter"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"postgres\""
+markers = "extra == \"postgres\" or extra == \"all\""
 files = [
     {file = "psycopg2_binary-2.9.12-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9b818ceff717f98851a64bffd4c5eb5b3059ae280276dcecc52ac658dcf006a4"},
     {file = "psycopg2_binary-2.9.12-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d2fa0d7caca8635c56e373055094eeda3208d901d55dd0ff5abc1d4e47f82b56"},
@@ -1725,7 +1620,7 @@ description = "Data validation using Python type hints"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"server\""
+markers = "extra == \"server\" or extra == \"all\""
 files = [
     {file = "pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba"},
     {file = "pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6"},
@@ -1748,7 +1643,7 @@ description = "Core functionality for Pydantic validation and serialization"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"server\""
+markers = "extra == \"server\" or extra == \"all\""
 files = [
     {file = "pydantic_core-2.46.4-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:a396dcc17e5a0b164dbe026896245a4fa9ff402edca1dff0be3d53a517f74de4"},
     {file = "pydantic_core-2.46.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:da4b951fe36dc7c3a1ccb4e3cd1747c3542b8c9ceede8fc86cae054e764485f5"},
@@ -1886,7 +1781,7 @@ files = [
     {file = "pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"},
     {file = "pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"},
 ]
-markers = {main = "extra == \"all\" or extra == \"cli\""}
+markers = {main = "extra == \"cli\" or extra == \"all\""}
 
 [package.extras]
 windows-terminal = ["colorama (>=0.4.6)"]
@@ -1898,7 +1793,7 @@ description = "DB API module for ODBC"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"django\" or extra == \"sqlserver\""
+markers = "extra == \"django\" or extra == \"all\" or extra == \"sqlserver\""
 files = [
     {file = "pyodbc-5.3.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6682cdec78f1302d0c559422c8e00991668e039ed63dece8bf99ef62173376a5"},
     {file = "pyodbc-5.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9cd3f0a9796b3e1170a9fa168c7e7ca81879142f30e20f46663b882db139b7d2"},
@@ -2092,7 +1987,7 @@ description = "Extensions to the standard Python datetime module"
 optional = true
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"data\" or extra == \"migration\""
+markers = "extra == \"migration\" or extra == \"data\" or extra == \"all\""
 files = [
     {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
     {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
@@ -2108,7 +2003,7 @@ description = "Read key-value pairs from a .env file and set them as environment
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"server\""
+markers = "extra == \"server\" or extra == \"all\""
 files = [
     {file = "python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a"},
     {file = "python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3"},
@@ -2124,7 +2019,7 @@ description = "World timezone definitions, modern and historical"
 optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"django\" or extra == \"data\" or extra == \"migration\""
+markers = "extra == \"django\" or extra == \"all\" or extra == \"migration\" or extra == \"data\""
 files = [
     {file = "pytz-2026.2-py2.py3-none-any.whl", hash = "sha256:04156e608bee23d3792fd45c94ae47fae1036688e75032eea2e3bf0323d1f126"},
     {file = "pytz-2026.2.tar.gz", hash = "sha256:0e60b47b29f21574376f218fe21abc009894a2321ea16c6754f3cad6eb7cdd6a"},
@@ -2137,7 +2032,7 @@ description = "YAML parser and emitter for Python"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"server\""
+markers = "extra == \"server\" or extra == \"all\""
 files = [
     {file = "PyYAML-6.0.3-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:c2514fceb77bc5e7a2f7adfaa1feb2fb311607c9cb518dbc378688ec73d8292f"},
     {file = "PyYAML-6.0.3-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c57bb8c96f6d1808c030b1687b9b5fb476abaa47f0db9c0101f5e9f394e97f4"},
@@ -2243,7 +2138,7 @@ description = "Render rich text, tables, progress bars, syntax highlighting, mar
 optional = true
 python-versions = ">=3.9.0"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"cli\""
+markers = "extra == \"cli\" or extra == \"all\""
 files = [
     {file = "rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb"},
     {file = "rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36"},
@@ -2341,7 +2236,7 @@ description = "Python 2 and 3 compatibility utilities"
 optional = true
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"data\" or extra == \"migration\""
+markers = "extra == \"migration\" or extra == \"data\" or extra == \"all\""
 files = [
     {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
     {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
@@ -2366,7 +2261,7 @@ description = "Python documentation generator"
 optional = false
 python-versions = ">=3.10"
 groups = ["docs"]
-markers = "python_version < \"3.15\""
+markers = "python_version == \"3.10\""
 files = [
     {file = "sphinx-8.1.3-py3-none-any.whl", hash = "sha256:09719015511837b76bf6e03e42eb7595ac8c2e41eeb9c29c5b755c6b677992a2"},
     {file = "sphinx-8.1.3.tar.gz", hash = "sha256:43c1911eecb0d3e161ad78611bc905d1ad0e523e4ddc202a58a821773dc4c927"},
@@ -2440,7 +2335,7 @@ description = "Type hints (PEP 484) support for the Sphinx autodoc extension"
 optional = false
 python-versions = ">=3.10"
 groups = ["docs"]
-markers = "python_version < \"3.15\""
+markers = "python_version == \"3.10\""
 files = [
     {file = "sphinx_autodoc_typehints-3.0.1-py3-none-any.whl", hash = "sha256:4b64b676a14b5b79cefb6628a6dc8070e320d4963e8ff640a2f3e9390ae9045a"},
     {file = "sphinx_autodoc_typehints-3.0.1.tar.gz", hash = "sha256:b9b40dd15dee54f6f810c924f863f9cf1c54f9f3265c495140ea01be7f44fa55"},
@@ -2733,7 +2628,7 @@ files = [
     {file = "sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba"},
     {file = "sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e"},
 ]
-markers = {main = "extra == \"all\" or extra == \"django\""}
+markers = {main = "extra == \"django\" or extra == \"all\""}
 
 [package.extras]
 dev = ["build"]
@@ -2746,7 +2641,7 @@ description = "The little ASGI library that shines."
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"server\""
+markers = "extra == \"server\" or extra == \"all\""
 files = [
     {file = "starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6"},
     {file = "starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0"},
@@ -2766,6 +2661,7 @@ description = "A lil' TOML parser"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev", "docs"]
+markers = "python_version == \"3.10\""
 files = [
     {file = "tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30"},
     {file = "tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a"},
@@ -2815,7 +2711,6 @@ files = [
     {file = "tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe"},
     {file = "tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f"},
 ]
-markers = {dev = "python_full_version <= \"3.11.0a6\"", docs = "python_version == \"3.10\""}
 
 [[package]]
 name = "trove-classifiers"
@@ -2872,7 +2767,7 @@ description = "Runtime typing introspection tools"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"server\""
+markers = "extra == \"server\" or extra == \"all\""
 files = [
     {file = "typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7"},
     {file = "typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464"},
@@ -2892,7 +2787,7 @@ files = [
     {file = "tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7"},
     {file = "tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10"},
 ]
-markers = {main = "sys_platform == \"win32\" and (extra == \"all\" or extra == \"django\" or extra == \"data\" or extra == \"migration\") or extra == \"all\" or extra == \"data\" or extra == \"migration\"", dev = "sys_platform == \"win32\""}
+markers = {main = "(extra == \"django\" or extra == \"all\" or extra == \"migration\" or extra == \"data\") and (sys_platform == \"win32\" or extra == \"migration\" or extra == \"data\" or extra == \"all\")", dev = "sys_platform == \"win32\""}
 
 [[package]]
 name = "urllib3"
@@ -2919,7 +2814,7 @@ description = "The lightning-fast ASGI server."
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"server\""
+markers = "extra == \"server\" or extra == \"all\""
 files = [
     {file = "uvicorn-0.52.1-py3-none-any.whl", hash = "sha256:e4403f9d93188cf9d1088e9f40e3acd12630e2df8675316704379a7fc20fff6a"},
     {file = "uvicorn-0.52.1.tar.gz", hash = "sha256:112ec661814189acbccd3f7b86460147cc065fc92c0821afa78918780e4354dd"},
@@ -2946,7 +2841,7 @@ description = "Fast implementation of asyncio event loop on top of libuv"
 optional = true
 python-versions = ">=3.8.1"
 groups = ["main"]
-markers = "sys_platform != \"win32\" and sys_platform != \"cygwin\" and platform_python_implementation != \"PyPy\" and (extra == \"all\" or extra == \"server\")"
+markers = "sys_platform != \"win32\" and sys_platform != \"cygwin\" and platform_python_implementation != \"PyPy\" and (extra == \"server\" or extra == \"all\")"
 files = [
     {file = "uvloop-0.22.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ef6f0d4cc8a9fa1f6a910230cd53545d9a14479311e87e3cb225495952eb672c"},
     {file = "uvloop-0.22.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7cd375a12b71d33d46af85a3343b35d98e8116134ba404bd657b3b1d15988792"},
@@ -3011,7 +2906,7 @@ description = "Simple, modern and high performance file watching and code reload
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"server\""
+markers = "extra == \"server\" or extra == \"all\""
 files = [
     {file = "watchfiles-1.2.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:bb68bf4df85abebe5efddc53cf2075520f243a59868d9b3973278b23e76962a9"},
     {file = "watchfiles-1.2.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c16cb06dd17d43b9d185094268459eac92c9538356f050e55b54e82cf700e1d4"},
@@ -3132,7 +3027,7 @@ description = "An implementation of the WebSocket Protocol (RFC 6455 & 7692)"
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"server\""
+markers = "extra == \"server\" or extra == \"all\""
 files = [
     {file = "websockets-16.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:04cdd5d2d1dacbad0a7bf36ccbcd3ccd5a30ee188f2560b7a62a30d14107b31a"},
     {file = "websockets-16.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:8ff32bb86522a9e5e31439a58addbb0166f0204d64066fb955265c4e214160f0"},
@@ -3204,7 +3099,7 @@ description = "Backport of pathlib-compatible object wrapper for zip files"
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
-markers = "python_full_version < \"3.10.2\""
+markers = "python_version == \"3.10\" and python_full_version < \"3.10.2\""
 files = [
     {file = "zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f"},
     {file = "zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602"},
@@ -3232,4 +3127,4 @@ sqlserver = ["pyodbc"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "15a30935a738cbbc45a7c24ce2a6075e570389c8cfd9b39df5d5b7f3862e02f1"
+content-hash = "5456399ffedfb95b3f002bb0e62ab18b3a9769ba97020a9182c1818e21920d03"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,11 +91,34 @@ httpx = ">=0.28,<1.0"
 pytest-django = ">=4.13.0"
 django-stubs = ">=6.0.7"
 pandas-stubs = ">=2.2.2,<3.0"
+# django and numpy are not imported by the dev tooling directly; they are
+# pinned here only to keep the resolver from picking a second version.
+# django-stubs requires `django = *` and pandas-stubs `numpy >= 1.23.5`, so
+# without a cap the dev group resolves the newest release while the `django`
+# and `data`/`migration` extras resolve an older one -- Poetry then locks
+# both with overlapping python markers and installs them over each other
+# (issue #321). The caps mirror what those extras already resolve to:
+# `<6.0` matches the `django>=5.2.17` extra floor, and `<2.3` matches the
+# numpy range the extras pin for vtlengine co-installation.
+django = ">=5.2.17,<6.0"
+numpy = ">=2.2.0,<2.3"
 
 [tool.poetry.group.docs.dependencies]
-sphinx = ">=8.1,<9"
+# Sphinx 8.2 and sphinx-autodoc-typehints 3.1 both require Python >= 3.11,
+# so on 3.10 the resolver has to fall back to the previous minor. The split
+# is spelled out per interpreter instead of left to Poetry: given a single
+# open range it locks both minors with overlapping markers (`< "3.15"` for
+# the older one rather than `< "3.11"`) and installs them into the same
+# site-packages, which corrupts the tree at random (issue #321).
+sphinx = [
+    { version = ">=8.1,<8.2", python = "<3.11" },
+    { version = ">=8.2,<9", python = ">=3.11" },
+]
 sphinx-rtd-theme = ">=3.0"
-sphinx-autodoc-typehints = ">=3.0"
+sphinx-autodoc-typehints = [
+    { version = ">=3.0,<3.1", python = "<3.11" },
+    { version = ">=3.1", python = ">=3.11" },
+]
 sphinx-polyversion = ">=2.0"
 
 [build-system]

--- a/src/dpmcore/dpm_xl/ast/constructor.py
+++ b/src/dpmcore/dpm_xl/ast/constructor.py
@@ -35,7 +35,6 @@ from dpmcore.dpm_xl.ast.nodes import (
     ParExpr,
     PersistentAssignment,
     PropertyReference,
-    RankOp,
     RenameNode,
     RenameOp,
     Scalar,
@@ -295,8 +294,19 @@ class ASTVisitor(dpm_xlParserVisitor):
             analytic_clause=analytic_clause,
         )
 
-    def visitRankOp(self, ctx: dpm_xlParser.RankOpContext) -> RankOp:
+    def visitRankOp(self, ctx: dpm_xlParser.RankOpContext) -> AggregationOp:
+        """Build ``rank`` as an ``AggregationOp`` discriminated by ``op``.
+
+        ``rank`` is an alternative of the ``aggregateOperators`` grammar
+        rule, so it is an aggregation like the rest of the family rather
+        than a node class of its own. The grammar offers it no grouping
+        clause and makes the analytic clause mandatory; every later pass
+        -- semantic analysis, ML generation, serialization -- therefore
+        handles it through the ``AggregationOp`` path with no special
+        case.
+        """
         ctx_list = list(ctx.getChildren())
+        op = self._symbol_text(ctx_list[0])
         operand: AST | None = None
         analytic_clause: AnalyticClause | None = None
         for child in ctx_list:
@@ -306,13 +316,18 @@ class ASTVisitor(dpm_xlParserVisitor):
                 operand = self._visit(child)
         if operand is None:
             raise RuntimeError(
-                "RankOp requires an operand; parser produced none"
+                "rank requires an operand; parser produced none"
             )
         if analytic_clause is None:
             raise RuntimeError(
-                "RankOp requires an analytic clause; parser produced none"
+                "rank requires an analytic clause; parser produced none"
             )
-        return RankOp(operand=operand, analytic_clause=analytic_clause)
+        return AggregationOp(
+            op=op,
+            operand=operand,
+            grouping_clause=None,
+            analytic_clause=analytic_clause,
+        )
 
     def visitAnalyticClause(
         self, ctx: dpm_xlParser.AnalyticClauseContext

--- a/src/dpmcore/dpm_xl/ast/ml_generation.py
+++ b/src/dpmcore/dpm_xl/ast/ml_generation.py
@@ -24,7 +24,6 @@ from dpmcore.dpm_xl.ast.nodes import (
     ParExpr,
     PersistentAssignment,
     PreconditionItem,
-    RankOp,
     RenameNode,
     RenameOp,
     Scalar,
@@ -344,9 +343,6 @@ class MLGeneration(ASTTemplate):
             node.grouping_clause.parent = operand_node
             node.grouping_clause.argument = "grouping_clause"
             self.visit(node.grouping_clause)
-
-    def visit_RankOp(self, node: RankOp) -> None:
-        self.visit(node.operand)
 
     def visit_GroupingClause(self, node: GroupingClause) -> None:
         gc_node = self.create_operation_node(node)

--- a/src/dpmcore/dpm_xl/ast/nodes.py
+++ b/src/dpmcore/dpm_xl/ast/nodes.py
@@ -602,6 +602,10 @@ class AnalyticClause(AST):
         }
 
 
+# ``RankOp`` defines no ``toJSON``: it is serialized by
+# ``ASTToJSONVisitor`` as an ``AggregationOp`` with ``op: "rank"``, the
+# shape every other alternative of the ``aggregateOperators`` grammar
+# rule already emits, so the wire shape lives there and nowhere else.
 class RankOp(AST):
     """rank(expression over(...)) operator node."""
 
@@ -620,14 +624,6 @@ class RankOp(AST):
         )
 
     __repr__ = __str__
-
-    def toJSON(self) -> dict[str, Any]:
-        return {
-            "class_name": self.__class__.__name__,
-            "op": self.op,
-            "operand": self.operand,
-            "analytic_clause": self.analytic_clause.toJSON(),
-        }
 
 
 class Dimension(AST):

--- a/src/dpmcore/dpm_xl/ast/nodes.py
+++ b/src/dpmcore/dpm_xl/ast/nodes.py
@@ -425,6 +425,11 @@ class WithExpression(AST):
 class AggregationOp(AST):
     """All aggregate operators are analysed using this AST Object. Check AGGR_OP_MAPPING on Utils/operator_mapping.py
     for the complete list.
+
+    ``rank`` included: it is an alternative of the ``aggregateOperators``
+    grammar rule, so it is discriminated by ``op`` like every sibling
+    rather than carrying a node class of its own. It never has a
+    ``grouping_clause`` and always has an ``analytic_clause``.
     """
 
     def __init__(
@@ -600,30 +605,6 @@ class AnalyticClause(AST):
             "order_by": [item.toJSON() for item in self.order_by],
             "window": self.window.toJSON() if self.window else None,
         }
-
-
-# ``RankOp`` defines no ``toJSON``: it is serialized by
-# ``ASTToJSONVisitor`` as an ``AggregationOp`` with ``op: "rank"``, the
-# shape every other alternative of the ``aggregateOperators`` grammar
-# rule already emits, so the wire shape lives there and nowhere else.
-class RankOp(AST):
-    """rank(expression over(...)) operator node."""
-
-    def __init__(
-        self, operand: AST, analytic_clause: "AnalyticClause"
-    ) -> None:
-        super().__init__()
-        self.op = "rank"
-        self.operand: AST = operand
-        self.analytic_clause: AnalyticClause = analytic_clause
-
-    def __str__(self) -> str:
-        return (
-            f"<RankOp(operand={self.operand}, "
-            f"analytic_clause={self.analytic_clause})>"
-        )
-
-    __repr__ = __str__
 
 
 class Dimension(AST):

--- a/src/dpmcore/dpm_xl/ast/template.py
+++ b/src/dpmcore/dpm_xl/ast/template.py
@@ -20,7 +20,6 @@ from dpmcore.dpm_xl.ast.nodes import (
     PersistentAssignment,
     PreconditionItem,
     PropertyReference,
-    RankOp,
     RenameOp,
     Scalar,
     Set,
@@ -85,9 +84,6 @@ class ASTTemplate(NodeVisitor):
         self.visit(node.operand)
         if node.grouping_clause:
             self.visit(node.grouping_clause)
-
-    def visit_RankOp(self, node: RankOp) -> None:
-        self.visit(node.operand)
 
     def visit_GroupingClause(self, node: GroupingClause) -> None:
         pass

--- a/src/dpmcore/dpm_xl/operators/aggregate.py
+++ b/src/dpmcore/dpm_xl/operators/aggregate.py
@@ -9,6 +9,7 @@ from dpmcore.dpm_xl.symbols import RecordSet, Scalar, Structure
 from dpmcore.dpm_xl.types.promotion import unary_implicit_type_promotion
 from dpmcore.dpm_xl.types.scalar import (
     Integer,
+    Mixed,
     Number,
     ScalarFactory,
     ScalarType,
@@ -195,6 +196,12 @@ class AggregateOperator(Unary):
         Returns a RecordSet with the same structure as the operand — analytic
         invocation never reduces Records.
         """
+        # A Mixed fact has no single type to promote, so reject it before
+        # ``unary_implicit_type_promotion`` reports it as a type clash.
+        # Overrides that do no promotion (``Rank``) are exempt by not
+        # inheriting this method.
+        if isinstance(operand.get_fact_component().type, Mixed):
+            raise errors.SemanticError("4-4-0-3", origin=f"{cls.op}(...)")
         cls.check_operator_well_defined()
         return_type = (
             None

--- a/src/dpmcore/dpm_xl/semantic_analyzer.py
+++ b/src/dpmcore/dpm_xl/semantic_analyzer.py
@@ -25,7 +25,6 @@ from dpmcore.dpm_xl.ast.nodes import (
     PersistentAssignment,
     PreconditionItem,
     PropertyReference,
-    RankOp,
     RenameOp,
     Set,
     SetdiffOp,
@@ -82,7 +81,6 @@ from dpmcore.dpm_xl.utils.operator_mapping import (
     CLAUSE_OP_MAPPING,
     COMPLEX_OP_MAPPING,
     CONDITIONAL_OP_MAPPING,
-    RANK_OP_MAPPING,
     STRING_OPERATORS,
     TIME_OPERATORS,
     UNARY_OP_MAPPING,
@@ -644,8 +642,11 @@ class InputAnalyzer(ASTTemplate, ABC):
         op = cast(str, node.op)
 
         if node.analytic_clause is not None:
-            if isinstance(operand.get_fact_component().type, Mixed):
-                raise errors.SemanticError("4-4-0-3", origin=f"{op}(...)")
+            # The Mixed guard for this path lives in
+            # ``AggregateOperator.validate_analytic``, next to the type
+            # promotion it protects: ``rank`` overrides that method and
+            # does no promotion, so it stays exempt without a special
+            # case here.
             result = AGGR_OP_MAPPING[op].validate_analytic(
                 operand, node.analytic_clause
             )
@@ -665,22 +666,6 @@ class InputAnalyzer(ASTTemplate, ABC):
             operand, grouping_clause
         )
         return cast(Operand, reducing_result)
-
-    def visit_RankOp(  # type: ignore[override]
-        self, node: RankOp
-    ) -> Operand:
-        operand = self.visit(node.operand)
-        if not isinstance(operand, RecordSet):
-            raise errors.SemanticError("4-4-0-1", op="rank")
-        if operand.has_only_global_components:
-            add_semantic_warning(
-                f"Performing an aggregation on recordset: {operand.name} which has only global key components"
-            )
-        op = cast(str, node.op)
-        result = RANK_OP_MAPPING[op].validate_analytic(
-            operand, node.analytic_clause
-        )
-        return cast(Operand, result)
 
     def visit_Dimension(  # type: ignore[override]
         self, node: Dimension

--- a/src/dpmcore/dpm_xl/utils/operator_mapping.py
+++ b/src/dpmcore/dpm_xl/utils/operator_mapping.py
@@ -102,9 +102,9 @@ AGGR_OP_MAPPING = {
     COUNT: Count,
     AVG: Avg,
     MEDIAN: Median,
-}
-
-RANK_OP_MAPPING = {
+    # ``rank`` is an alternative of the ``aggregateOperators`` grammar
+    # rule and is built as an ``AggregationOp``, so it resolves here and
+    # not through a mapping of its own.
     RANK: Rank,
 }
 

--- a/src/dpmcore/dpm_xl/utils/serialization.py
+++ b/src/dpmcore/dpm_xl/utils/serialization.py
@@ -515,15 +515,24 @@ class ASTToJSONVisitor(NodeVisitor):
         return result
 
     def visit_RankOp(self, node: Any) -> NodeDict:
-        """Visit RankOp nodes."""
-        return {
-            "class_name": "RankOp",
-            "op": "rank",
-            "operand": self.visit(node.operand),
-            "analytic_clause": self._serialize_analytic_clause(
-                node.analytic_clause
-            ),
-        }
+        """Visit RankOp nodes as an ``AggregationOp`` with ``op: "rank"``.
+
+        ``rank`` is an alternative of the ``aggregateOperators`` grammar
+        rule, so it is an aggregation discriminated by ``op`` like the
+        rest of the family rather than a class of its own. Its analytic
+        clause is mandatory and the grammar offers it no grouping
+        clause, so the ``AggregationOp`` handler emits
+        ``grouping_clause: null`` for it without a special case, keeping
+        one key set for the class -- which the consumer's
+        ``additionalProperties: false`` nodes require.
+
+        Args:
+            node: The ``RankOp`` AST node.
+
+        Returns:
+            dict: The serialized ``AggregationOp`` node.
+        """
+        return self.visit_AggregationOp(node)
 
     def _serialize_analytic_clause(self, clause: Any) -> NodeDict:
         result: NodeDict = {

--- a/src/dpmcore/dpm_xl/utils/serialization.py
+++ b/src/dpmcore/dpm_xl/utils/serialization.py
@@ -514,26 +514,6 @@ class ASTToJSONVisitor(NodeVisitor):
         result["analytic_clause"] = analytic_clause
         return result
 
-    def visit_RankOp(self, node: Any) -> NodeDict:
-        """Visit RankOp nodes as an ``AggregationOp`` with ``op: "rank"``.
-
-        ``rank`` is an alternative of the ``aggregateOperators`` grammar
-        rule, so it is an aggregation discriminated by ``op`` like the
-        rest of the family rather than a class of its own. Its analytic
-        clause is mandatory and the grammar offers it no grouping
-        clause, so the ``AggregationOp`` handler emits
-        ``grouping_clause: null`` for it without a special case, keeping
-        one key set for the class -- which the consumer's
-        ``additionalProperties: false`` nodes require.
-
-        Args:
-            node: The ``RankOp`` AST node.
-
-        Returns:
-            dict: The serialized ``AggregationOp`` node.
-        """
-        return self.visit_AggregationOp(node)
-
     def _serialize_analytic_clause(self, clause: Any) -> NodeDict:
         result: NodeDict = {
             "class_name": "AnalyticClause",

--- a/tests/unit/ast/conftest.py
+++ b/tests/unit/ast/conftest.py
@@ -1,0 +1,45 @@
+"""Shared helpers for the wire-shape tests in this package.
+
+``ASTToJSONVisitor`` is what script generation emits, so several modules
+here assert on the serialized payload rather than on the AST objects.
+The two helpers they need -- parse-and-serialize, and collect every
+``class_name`` in a payload -- live here so a change to the visitor's
+entry shape is chased in one place.
+"""
+
+import pytest
+
+from dpmcore.dpm_xl.utils.serialization import ASTToJSONVisitor
+from dpmcore.services.syntax import SyntaxService
+
+
+@pytest.fixture
+def serialize_expr():
+    """Return the serialized payload of the first expression in a script."""
+
+    def _serialize_expr(expression: str) -> dict:
+        result = ASTToJSONVisitor().visit(SyntaxService().parse(expression))
+        assert isinstance(result, dict)
+        return result["children"][0]
+
+    return _serialize_expr
+
+
+@pytest.fixture
+def class_names():
+    """Return every ``class_name`` in a serialized payload, at any depth."""
+
+    def _class_names(node) -> set:
+        if isinstance(node, dict):
+            names = {node["class_name"]} if "class_name" in node else set()
+            for value in node.values():
+                names |= _class_names(value)
+            return names
+        if isinstance(node, list):
+            names = set()
+            for item in node:
+                names |= _class_names(item)
+            return names
+        return set()
+
+    return _class_names

--- a/tests/unit/ast/test_analytic_operators.py
+++ b/tests/unit/ast/test_analytic_operators.py
@@ -6,10 +6,20 @@ from dpmcore.dpm_xl.ast.nodes import (
     AggregationOp,
     AnalyticClause,
     GroupingClause,
-    RankOp,
     WindowClause,
 )
-from dpmcore.dpm_xl.utils.serialization import ASTToJSONVisitor, serialize_ast
+from dpmcore.dpm_xl.operators.aggregate import Rank
+from dpmcore.dpm_xl.symbols import (
+    FactComponent,
+    KeyComponent,
+    RecordSet,
+    Structure,
+)
+from dpmcore.dpm_xl.types.scalar import Number
+from dpmcore.dpm_xl.utils.operator_mapping import AGGR_OP_MAPPING
+from dpmcore.dpm_xl.utils.serialization import deserialize_ast, serialize_ast
+from dpmcore.dpm_xl.utils.tokens import STANDARD
+from dpmcore.errors import SemanticError
 from dpmcore.services.syntax import SyntaxService
 
 # ---- Syntax validity --------------------------------------------------
@@ -115,14 +125,18 @@ def test_window_clause_unbounded():
     assert w.end.n is None
 
 
-# ---- AST structure — RankOp -------------------------------------------
+# ---- AST structure — rank ---------------------------------------------
+# ``rank`` is an alternative of the ``aggregateOperators`` grammar rule,
+# so the constructor builds it as an ``AggregationOp`` discriminated by
+# ``op`` — no node class of its own, and so no pass to special-case.
 
 
-def test_rank_builds_rank_op_node():
+def test_rank_builds_aggregation_op_node():
     ast = SyntaxService().parse("rank({vRS} over (order by f desc))")
     node = ast.children[0]
-    assert isinstance(node, RankOp)
+    assert isinstance(node, AggregationOp)
     assert node.op == "rank"
+    assert node.grouping_clause is None
     assert isinstance(node.analytic_clause, AnalyticClause)
     assert node.analytic_clause.order_by[0].key_name == "f"
     assert node.analytic_clause.order_by[0].direction == "desc"
@@ -161,8 +175,7 @@ def test_analytic_clause_tojson_is_serialisable():
 # ---- Wire serialisation ------------------------------------------------
 # ``ASTToJSONVisitor`` is what script generation emits, and ``rank`` goes
 # out as an ``AggregationOp`` discriminated by ``op`` like every other
-# alternative of the ``aggregateOperators`` rule. ``RankOp.toJSON`` is
-# gone, so these cases replace the assertions that read off it.
+# alternative of the ``aggregateOperators`` rule.
 
 # The consumer schema is ``additionalProperties: false``, so the exact
 # key set is part of the contract: ``grouping_clause`` is present and
@@ -175,30 +188,25 @@ AGGREGATION_KEYS = {
     "analytic_clause",
 }
 
-
-def _serialize_expr(expression: str) -> dict:
-    result = ASTToJSONVisitor().visit(SyntaxService().parse(expression))
-    assert isinstance(result, dict)
-    return result["children"][0]
-
-
-def _class_names(node) -> set:
-    """Every ``class_name`` in a serialized payload, at any depth."""
-    if isinstance(node, dict):
-        names = {node["class_name"]} if "class_name" in node else set()
-        for value in node.values():
-            names |= _class_names(value)
-        return names
-    if isinstance(node, list):
-        names = set()
-        for item in node:
-            names |= _class_names(item)
-        return names
-    return set()
+# Every clause pinned below is one ``rank`` actually accepts. A window
+# frame is rejected by ``Rank.validate_analytic`` (4-4-0-6) and script
+# generation drops such expressions before serializing them, so pinning
+# a payload with one would assert a shape the pipeline can never emit —
+# see ``test_rank_rejects_the_window_frame_it_is_never_asked_to_emit``.
+LEGAL_RANK_CLAUSE = "over (partition by c order by f desc)"
 
 
-def test_rank_serializes_as_aggregation_op():
-    node = _serialize_expr("rank({tT1, r001} over (order by f desc))")
+def _recordset(key_names: list[str]) -> RecordSet:
+    """A minimal RecordSet to check a parsed clause against."""
+    components: list = [
+        KeyComponent(k, Number(), STANDARD, "test") for k in key_names
+    ]
+    components.append(FactComponent(Number(), "test"))
+    return RecordSet(Structure(components), "ds", "ds")
+
+
+def test_rank_serializes_as_aggregation_op(serialize_expr):
+    node = serialize_expr("rank({tT1, r001} over (order by f desc))")
     assert set(node) == AGGREGATION_KEYS
     assert node["class_name"] == "AggregationOp"
     assert node["op"] == "rank"
@@ -210,20 +218,21 @@ def test_rank_serializes_as_aggregation_op():
     assert ac["window"] is None
 
 
-def test_rank_serializes_partition_by():
-    node = _serialize_expr(
-        "rank({tT1, r001} over (partition by CNT order by f asc))"
+def test_rank_serializes_partition_by(serialize_expr):
+    node = serialize_expr(
+        "rank({tT1, r001} over (partition by c order by f asc))"
     )
     assert set(node) == AGGREGATION_KEYS
     assert node["op"] == "rank"
     ac = node["analytic_clause"]
-    assert ac["partition_by"] == ["CNT"]
+    assert ac["partition_by"] == ["c"]
     assert ac["order_by"] == [{"key_name": "f", "direction": "asc"}]
 
 
-def test_rank_serializes_window_frame():
-    node = _serialize_expr(
-        "rank({tT1, r001} over (order by r "
+def test_aggregation_serializes_window_frame(serialize_expr):
+    """Window frames are pinned on ``sum``: ``rank`` never carries one."""
+    node = serialize_expr(
+        "sum({tT1, r001} over (order by r "
         "data points between 1 preceding and 2 following))"
     )
     assert set(node) == AGGREGATION_KEYS
@@ -233,25 +242,83 @@ def test_rank_serializes_window_frame():
     assert window["end"] == {"bound_type": "n_following", "n": 2}
 
 
-def test_rank_payload_matches_sum_over_the_same_clause():
+def test_rank_payload_matches_sum_over_the_same_clause(serialize_expr):
     """Only ``op`` may distinguish ``rank`` from the other aggregates."""
-    clause = (
-        "over (partition by CNT order by f desc "
-        "data points between 1 preceding and 1 following)"
-    )
-    rank = _serialize_expr(f"rank({{tT1, r001}} {clause})")
-    aggregation = _serialize_expr(f"sum({{tT1, r001}} {clause})")
+    rank = serialize_expr(f"rank({{tT1, r001}} {LEGAL_RANK_CLAUSE})")
+    aggregation = serialize_expr(f"sum({{tT1, r001}} {LEGAL_RANK_CLAUSE})")
     assert aggregation["op"] == "sum"
     assert rank == {**aggregation, "op": "rank"}
 
 
-def test_no_rank_op_class_name_at_any_depth():
-    node = _serialize_expr(
+def test_the_pinned_rank_clause_is_semantically_accepted():
+    """The parity payload above is one the pipeline can really emit.
+
+    ``ASTGeneratorService`` serializes an expression only after semantic
+    validation passes, so a wire shape is worth pinning only for a
+    clause ``Rank`` accepts.
+    """
+    ast = SyntaxService().parse(f"rank({{tT1, r001}} {LEGAL_RANK_CLAUSE})")
+    result = Rank.validate_analytic(
+        _recordset(["r", "c"]), ast.children[0].analytic_clause
+    )
+    assert isinstance(result, RecordSet)
+
+
+def test_rank_rejects_the_window_frame_it_is_never_asked_to_emit():
+    """Why no wire test pins a ``rank`` with a window frame."""
+    ast = SyntaxService().parse(
+        "rank({tT1, r001} over (order by r "
+        "data points between 1 preceding and 2 following))"
+    )
+    with pytest.raises(SemanticError) as exc_info:
+        Rank.validate_analytic(
+            _recordset(["r", "c"]), ast.children[0].analytic_clause
+        )
+    assert exc_info.value.code == "4-4-0-6"
+
+
+def test_no_rank_op_class_name_at_any_depth(serialize_expr, class_names):
+    node = serialize_expr(
         "{tT1, r002} = rank({tT1, r001} over (order by f desc))"
     )
-    names = _class_names(node)
+    names = class_names(node)
     assert "RankOp" not in names
     assert "AggregationOp" in names
+
+
+def test_rank_tojson_agrees_with_the_visitor():
+    """``toJSON`` is a second serialisation path and must not diverge.
+
+    It is lossier by design (it hands operands to ``serialize_ast``
+    rather than expanding them itself), but the discriminating keys have
+    to be the ones the visitor emits.
+    """
+    node = (
+        SyntaxService()
+        .parse(f"rank({{tT1, r001}} {LEGAL_RANK_CLAUSE})")
+        .children[0]
+    )
+    payload = node.toJSON()
+    assert set(payload) == AGGREGATION_KEYS
+    assert payload["class_name"] == "AggregationOp"
+    assert payload["op"] == "rank"
+    assert payload["grouping_clause"] is None
+
+
+def test_serialized_rank_round_trips_to_a_resolvable_node(serialize_expr):
+    """A deserialized ``rank`` must resolve in ``AGGR_OP_MAPPING``.
+
+    The wire node is read back as a real ``AggregationOp``, and the
+    semantic analyzer looks its ``op`` up in ``AGGR_OP_MAPPING`` — a
+    missing key would surface as a bare ``KeyError`` instead of a
+    ``DpmCoreError``.
+    """
+    node = deserialize_ast(
+        serialize_expr(f"rank({{tT1, r001}} {LEGAL_RANK_CLAUSE})")
+    )
+    assert isinstance(node, AggregationOp)
+    assert node.op == "rank"
+    assert AGGR_OP_MAPPING[node.op] is Rank
 
 
 def test_serialize_ast_emits_aggregation_op_at_the_public_entry_point():
@@ -272,8 +339,8 @@ def test_serialize_ast_emits_aggregation_op_at_the_public_entry_point():
     assert node["grouping_clause"] is None
 
 
-def test_group_by_aggregation_serialization_is_unchanged():
-    node = _serialize_expr("sum({tT1, r001} group by CNT)")
+def test_group_by_aggregation_serialization_is_unchanged(serialize_expr):
+    node = serialize_expr("sum({tT1, r001} group by CNT)")
     assert set(node) == AGGREGATION_KEYS
     assert node["class_name"] == "AggregationOp"
     assert node["op"] == "sum"

--- a/tests/unit/ast/test_analytic_operators.py
+++ b/tests/unit/ast/test_analytic_operators.py
@@ -9,6 +9,7 @@ from dpmcore.dpm_xl.ast.nodes import (
     RankOp,
     WindowClause,
 )
+from dpmcore.dpm_xl.utils.serialization import ASTToJSONVisitor, serialize_ast
 from dpmcore.services.syntax import SyntaxService
 
 # ---- Syntax validity --------------------------------------------------
@@ -157,8 +158,127 @@ def test_analytic_clause_tojson_is_serialisable():
     assert ac["window"]["end"]["bound_type"] == "n_following"
 
 
-def test_rank_tojson_is_serialisable():
-    ast = SyntaxService().parse("rank({vRS} over (order by f desc))")
-    result = ast.children[0].toJSON()
-    assert result["op"] == "rank"
-    assert result["analytic_clause"]["order_by"][0]["direction"] == "desc"
+# ---- Wire serialisation ------------------------------------------------
+# ``ASTToJSONVisitor`` is what script generation emits, and ``rank`` goes
+# out as an ``AggregationOp`` discriminated by ``op`` like every other
+# alternative of the ``aggregateOperators`` rule. ``RankOp.toJSON`` is
+# gone, so these cases replace the assertions that read off it.
+
+# The consumer schema is ``additionalProperties: false``, so the exact
+# key set is part of the contract: ``grouping_clause`` is present and
+# ``null`` rather than omitted, matching the rest of the family.
+AGGREGATION_KEYS = {
+    "class_name",
+    "op",
+    "operand",
+    "grouping_clause",
+    "analytic_clause",
+}
+
+
+def _serialize_expr(expression: str) -> dict:
+    result = ASTToJSONVisitor().visit(SyntaxService().parse(expression))
+    assert isinstance(result, dict)
+    return result["children"][0]
+
+
+def _class_names(node) -> set:
+    """Every ``class_name`` in a serialized payload, at any depth."""
+    if isinstance(node, dict):
+        names = {node["class_name"]} if "class_name" in node else set()
+        for value in node.values():
+            names |= _class_names(value)
+        return names
+    if isinstance(node, list):
+        names = set()
+        for item in node:
+            names |= _class_names(item)
+        return names
+    return set()
+
+
+def test_rank_serializes_as_aggregation_op():
+    node = _serialize_expr("rank({tT1, r001} over (order by f desc))")
+    assert set(node) == AGGREGATION_KEYS
+    assert node["class_name"] == "AggregationOp"
+    assert node["op"] == "rank"
+    assert node["grouping_clause"] is None
+    ac = node["analytic_clause"]
+    assert ac["class_name"] == "AnalyticClause"
+    assert ac["partition_by"] == []
+    assert ac["order_by"] == [{"key_name": "f", "direction": "desc"}]
+    assert ac["window"] is None
+
+
+def test_rank_serializes_partition_by():
+    node = _serialize_expr(
+        "rank({tT1, r001} over (partition by CNT order by f asc))"
+    )
+    assert set(node) == AGGREGATION_KEYS
+    assert node["op"] == "rank"
+    ac = node["analytic_clause"]
+    assert ac["partition_by"] == ["CNT"]
+    assert ac["order_by"] == [{"key_name": "f", "direction": "asc"}]
+
+
+def test_rank_serializes_window_frame():
+    node = _serialize_expr(
+        "rank({tT1, r001} over (order by r "
+        "data points between 1 preceding and 2 following))"
+    )
+    assert set(node) == AGGREGATION_KEYS
+    window = node["analytic_clause"]["window"]
+    assert window["frame_type"] == "data_points"
+    assert window["start"] == {"bound_type": "n_preceding", "n": 1}
+    assert window["end"] == {"bound_type": "n_following", "n": 2}
+
+
+def test_rank_payload_matches_sum_over_the_same_clause():
+    """Only ``op`` may distinguish ``rank`` from the other aggregates."""
+    clause = (
+        "over (partition by CNT order by f desc "
+        "data points between 1 preceding and 1 following)"
+    )
+    rank = _serialize_expr(f"rank({{tT1, r001}} {clause})")
+    aggregation = _serialize_expr(f"sum({{tT1, r001}} {clause})")
+    assert aggregation["op"] == "sum"
+    assert rank == {**aggregation, "op": "rank"}
+
+
+def test_no_rank_op_class_name_at_any_depth():
+    node = _serialize_expr(
+        "{tT1, r002} = rank({tT1, r001} over (order by f desc))"
+    )
+    names = _class_names(node)
+    assert "RankOp" not in names
+    assert "AggregationOp" in names
+
+
+def test_serialize_ast_emits_aggregation_op_at_the_public_entry_point():
+    """``serialize_ast`` expands ``with`` scopes before serializing.
+
+    It is the entry point ``ASTGeneratorService`` builds scripts with, so
+    the shape has to hold there and not only under a bare visit.
+    """
+    payload = serialize_ast(
+        SyntaxService().parse(
+            "with {tT1} : {r002} = rank({r001} over (order by f desc))"
+        )
+    )
+    node = payload["right"]
+    assert set(node) == AGGREGATION_KEYS
+    assert node["class_name"] == "AggregationOp"
+    assert node["op"] == "rank"
+    assert node["grouping_clause"] is None
+
+
+def test_group_by_aggregation_serialization_is_unchanged():
+    node = _serialize_expr("sum({tT1, r001} group by CNT)")
+    assert set(node) == AGGREGATION_KEYS
+    assert node["class_name"] == "AggregationOp"
+    assert node["op"] == "sum"
+    assert node["grouping_clause"] == {
+        "class_name": "GroupingClause",
+        "components": ["CNT"],
+    }
+    assert node["analytic_clause"] is None

--- a/tests/unit/ast/test_ml_generation.py
+++ b/tests/unit/ast/test_ml_generation.py
@@ -9,10 +9,13 @@ import pytest
 
 from dpmcore.dpm_xl.ast.ml_generation import MLGeneration
 from dpmcore.dpm_xl.ast.nodes import (
+    AggregationOp,
+    AnalyticClause,
     Constant,
     CountSetOp,
     Dimension,
     IntersectSetOp,
+    OrderItem,
     Set,
     SetdiffOp,
     SetOfOp,
@@ -110,6 +113,30 @@ def test_visit_set_of_op_no_longer_raises_and_walks_operand(ml_generation):
     assert ml_generation.create_operation_node.call_count == 1
     assert len(visited) == 1
     assert visited[0].argument == "operand"
+
+
+def test_visit_rank_creates_an_operation_node_and_links_its_operand(
+    ml_generation,
+):
+    """``rank`` is walked as an ``AggregationOp``, so it lands in the tree.
+
+    Its own visitor created no ``OperationNode`` and never set the
+    operand's ``parent``/``argument``, which stored the operand as a
+    root-level orphan and left nothing representing the operator itself.
+    """
+    node = AggregationOp(
+        op="rank",
+        operand=_int_constant(1),
+        grouping_clause=None,
+        analytic_clause=AnalyticClause(
+            partition_by=[], order_by=[OrderItem("r")], window=None
+        ),
+    )
+    visited = _visit_and_capture(ml_generation, "visit_AggregationOp", node)
+    assert ml_generation.create_operation_node.call_count == 1
+    assert len(visited) == 1
+    assert visited[0].argument == "operand"
+    assert visited[0].parent is node
 
 
 def test_visit_union_set_op_walks_every_operand(ml_generation):

--- a/tests/unit/ast/test_set_operators.py
+++ b/tests/unit/ast/test_set_operators.py
@@ -220,18 +220,9 @@ def test_existing_literal_set_still_works():
 # and these nodes were silently dropped from the enriched AST payload.
 # ---------------------------------------------------------------------------
 
-from dpmcore.dpm_xl.utils.serialization import ASTToJSONVisitor  # noqa: E402
 
-
-def _serialize_expr(expression: str) -> dict:
-    ast = SyntaxService().parse(expression)
-    result = ASTToJSONVisitor().visit(ast)
-    assert isinstance(result, dict)
-    return result["children"][0]
-
-
-def test_ast_to_json_serializes_empty_set_literal():
-    node = _serialize_expr("{tT1, r001} in {}")
+def test_ast_to_json_serializes_empty_set_literal(serialize_expr):
+    node = serialize_expr("{tT1, r001} in {}")
     assert node["class_name"] == "BinOp"
     assert node["op"] == "in"
     right = node["right"]
@@ -239,8 +230,8 @@ def test_ast_to_json_serializes_empty_set_literal():
     assert right["children"] == []
 
 
-def test_ast_to_json_serializes_non_empty_set_literal():
-    node = _serialize_expr("{tT1, r001} in {1, 2, 3}")
+def test_ast_to_json_serializes_non_empty_set_literal(serialize_expr):
+    node = serialize_expr("{tT1, r001} in {1, 2, 3}")
     right = node["right"]
     assert right["class_name"] == "Set"
     assert len(right["children"]) == 3
@@ -249,16 +240,16 @@ def test_ast_to_json_serializes_non_empty_set_literal():
         assert child["value"] == expected
 
 
-def test_ast_to_json_serializes_set_of_op():
-    node = _serialize_expr("{tT1, r001} in set_of({tT2, r001-010})")
+def test_ast_to_json_serializes_set_of_op(serialize_expr):
+    node = serialize_expr("{tT1, r001} in set_of({tT2, r001-010})")
     right = node["right"]
     assert right["class_name"] == "SetOfOp"
     assert right["op"] == "set_of"
     assert isinstance(right["operand"], dict)
 
 
-def test_ast_to_json_serializes_union_variadic():
-    node = _serialize_expr("{tT1, r001} in union({1, 2}, {3, 4}, {5, 6})")
+def test_ast_to_json_serializes_union_variadic(serialize_expr):
+    node = serialize_expr("{tT1, r001} in union({1, 2}, {3, 4}, {5, 6})")
     right = node["right"]
     assert right["class_name"] == "UnionSetOp"
     assert right["op"] == "union"
@@ -267,16 +258,16 @@ def test_ast_to_json_serializes_union_variadic():
         assert operand["class_name"] == "Set"
 
 
-def test_ast_to_json_serializes_intersect():
-    node = _serialize_expr("{tT1, r001} in intersect({1, 2, 3}, {2, 3, 4})")
+def test_ast_to_json_serializes_intersect(serialize_expr):
+    node = serialize_expr("{tT1, r001} in intersect({1, 2, 3}, {2, 3, 4})")
     right = node["right"]
     assert right["class_name"] == "IntersectSetOp"
     assert right["op"] == "intersect"
     assert len(right["operands"]) == 2
 
 
-def test_ast_to_json_serializes_setdiff():
-    node = _serialize_expr("{tT1, r001} in setdiff({1, 2, 3}, {3})")
+def test_ast_to_json_serializes_setdiff(serialize_expr):
+    node = serialize_expr("{tT1, r001} in setdiff({1, 2, 3}, {3})")
     right = node["right"]
     assert right["class_name"] == "SetdiffOp"
     assert right["op"] == "setdiff"
@@ -284,8 +275,8 @@ def test_ast_to_json_serializes_setdiff():
     assert right["right"]["class_name"] == "Set"
 
 
-def test_ast_to_json_serializes_symdiff():
-    node = _serialize_expr("{tT1, r001} in symdiff({1, 2}, {2, 3})")
+def test_ast_to_json_serializes_symdiff(serialize_expr):
+    node = serialize_expr("{tT1, r001} in symdiff({1, 2}, {2, 3})")
     right = node["right"]
     assert right["class_name"] == "SymdiffOp"
     assert right["op"] == "symdiff"
@@ -293,13 +284,11 @@ def test_ast_to_json_serializes_symdiff():
     assert right["right"]["class_name"] == "Set"
 
 
-def test_ast_to_json_preserves_nested_set_operators():
+def test_ast_to_json_preserves_nested_set_operators(serialize_expr):
     """A nested ``setdiff(union(...), ...)`` expression must round-trip with
     every intermediate ``class_name`` intact — not just the outermost node.
     """
-    node = _serialize_expr(
-        "{tT1, r001} in setdiff(union({1, 2}, {3, 4}), {5})"
-    )
+    node = serialize_expr("{tT1, r001} in setdiff(union({1, 2}, {3, 4}), {5})")
     outer = node["right"]
     assert outer["class_name"] == "SetdiffOp"
     inner = outer["left"]

--- a/tests/unit/dpm_xl/test_analytic_semantic.py
+++ b/tests/unit/dpm_xl/test_analytic_semantic.py
@@ -16,7 +16,7 @@ from dpmcore.dpm_xl.symbols import (
     RecordSet,
     Structure,
 )
-from dpmcore.dpm_xl.types.scalar import Integer, Number, String
+from dpmcore.dpm_xl.types.scalar import Integer, Mixed, Number, String
 from dpmcore.dpm_xl.utils.tokens import STANDARD
 from dpmcore.errors import SemanticError
 
@@ -131,6 +131,34 @@ class TestWindowClause:
         b = WindowBoundary("n_following", 5)
         assert b.bound_type == "n_following"
         assert b.n == 5
+
+
+class TestMixedFactGuard:
+    """The Mixed guard lives with the type promotion it protects.
+
+    It used to sit in ``SemanticAnalyzer.visit_AggregationOp``, which
+    ``rank`` reached through a visitor of its own and so never hit.
+    ``Rank`` overrides ``validate_analytic`` and does no promotion, so it
+    stays exempt by not inheriting the check rather than by a
+    node-class special case.
+    """
+
+    def test_promoting_aggregate_rejects_a_mixed_fact(self) -> None:
+        with pytest.raises(SemanticError) as exc_info:
+            Sum.validate_analytic(
+                _make_rs(fact_type=Mixed(), key_names=["r"]),
+                _analytic(order_by=["r"]),
+            )
+        assert exc_info.value.code == "4-4-0-3"
+        assert "sum(...)" in str(exc_info.value)
+
+    def test_rank_still_accepts_a_mixed_fact(self) -> None:
+        result = Rank.validate_analytic(
+            _make_rs(fact_type=Mixed(), key_names=["r"]),
+            _analytic(order_by=["r"]),
+        )
+        assert isinstance(result, RecordSet)
+        assert isinstance(result.get_fact_component().type, Integer)
 
 
 class TestRankValidate:


### PR DESCRIPTION
## Summary

`rank` was the only alternative of the `aggregateOperators` grammar rule with a node class of its own. Every sibling — `max`, `min`, `sum`, `count`, `avg`, `median` — is an `AggregationOp` discriminated by `op`, and serializes as one; `RankOp` serialized under its own `class_name`, which the engine's closed `class_name` enum rejects.

The fix is at the constructor rather than at the serializer: `visitRankOp` now builds an `AggregationOp` with `op = "rank"`, so there is no `RankOp` node for any later pass to special-case.

```json
{"class_name": "RankOp",        "op": "rank", "operand": {…}, "analytic_clause": {…}}
{"class_name": "AggregationOp", "op": "rank", "operand": {…}, "grouping_clause": null, "analytic_clause": {…}}
```

`grouping_clause` is emitted as `null` rather than omitted. The grammar makes the analytic clause mandatory on `rank` and offers it no grouping clause, so it can never carry one, and keeping the key gives the class a single key set: the consumer's node objects are `additionalProperties: false` and its `AggregationOp` always carries both clause keys, so dropping the key for one `op` would be a schema question rather than a simplification. The payload is byte-identical to what `sum(… over (…))` emits for the same clause, with a different `op` — asserted as a dict comparison rather than field by field.

Collapsing the node removes the special case everywhere at once rather than at the wire alone:

- `RankOp` and the `visit_RankOp` handlers in the serializer, the semantic analyzer, the AST template and ML generation are gone; `RANK_OP_MAPPING` folds into `AGGR_OP_MAPPING`.
- `toJSON()` now agrees with the visitor. Dropping the override on its own would not have removed the name: `AST.toJSON()` returns `{"class_name": "RankOp"}` with the operand and the analytic clause dropped, so the one name the consumer rejects would have survived on that path with the payload gone.
- A serialized `rank` deserializes back into a real `AggregationOp`, and `AGGR_OP_MAPPING` now resolves `"rank"`, so semantic analysis of a round-tripped node reaches `Rank` instead of raising a bare `KeyError`.
- ML generation emits an operation node for `rank` and links its operand. `visit_RankOp` created neither, so the operand was persisted as a root-level orphan with nothing representing the operator; the `AggregationOp` path it now takes does both.

The one behavioural point worth review: `SemanticAnalyzer.visit_AggregationOp` pre-checked for a `Mixed` fact component before delegating to `validate_analytic`. `rank` reached that method through its own visitor and so was never subject to the check. That guard now sits at the top of `AggregateOperator.validate_analytic`, next to the type promotion it protects, and `Rank` — which overrides the method and does no promotion — stays exempt by not inheriting it rather than by a node-class special case. Behaviour is unchanged on both sides and pinned by tests.

Fixes #317.

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [ ] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`) — tests pass, coverage gate not run: see Notes
- [ ] Documentation updated (if applicable)

## Impact / Risk

- Breaking change to the serialized script payload for `rank`, and a cutover: once merged, dpmcore stops emitting `RankOp` entirely. Nothing has to be added to the engine's `class_name` enum, since `AggregationOp` is already accepted there; what needs confirming on the engine side is that its `AggregationOp` handling accepts `op: "rank"` in whatever operator list it validates, and tolerates `grouping_clause: null` next to a populated `analytic_clause`.
- Smaller blast radius than #314: none of the delivered script sets to hand contains a `rank` node, so there is likely nothing to regenerate. Worth confirming against the script the discrepancy was found in.
- `RankOp` is removed from `dpmcore.dpm_xl.ast.nodes`. Anything importing it or dispatching on it breaks; nothing in the library or the suite does after this change. The public entry points are untouched — `serialize_ast`, the visitor and the services keep their signatures — as are the CLI, the REST endpoints and the Django models.
- Operation nodes stored for a `rank` expression change shape: the operator now has a node of its own and its operand is no longer a root-level orphan. Any operation tree already persisted from a `rank` expression is wrong in the old shape and would need regenerating.
- No database schema or migration changes.
- Release note: `rank` now serializes as `class_name` `AggregationOp` with `op: "rank"`, carrying `grouping_clause: null` beside its analytic clause. The other aggregates, `group by` aggregation and `count(setExpression)` are unchanged.

## Notes

- There was no serialization-level coverage of `rank` at all before this: the analytic-operator tests asserted the AST structure and the node's own `toJSON`, never the visitor's `class_name`. Added cases for a bare `order by` and a `partition by`, both asserting the exact key set; a parity case against `sum(… over (…))`; a nested expression walked recursively to assert `RankOp` survives at no depth; a `with`-scoped case through `serialize_ast`, which is the entry point script generation uses and does more than a bare visit; a `toJSON` case asserting the second path agrees; and a round-trip through `deserialize_ast` asserting the node resolves in `AGGR_OP_MAPPING`.
- Every clause pinned in those tests is one `rank` accepts. A window frame is rejected by `Rank.validate_analytic` (4-4-0-6) and `ASTGeneratorService` drops an expression that fails semantic validation before serializing it, so pinning a payload with a window frame would assert a shape the pipeline can never emit; window-frame serialization is pinned on `sum` instead, and the rejection is pinned as the reason.
- Also pinned the serialized shape of `sum(x group by K)`, which had no wire-level coverage either, so the `grouping_clause` path is asserted on both sides of the change, and the ML-generation operand linking for `rank`.
- `_serialize_expr` and `_class_names` were duplicated across the wire-shape tests; they are now fixtures in `tests/unit/ast/conftest.py`, where the next `class_name` collapse can reuse them.
- Unit tests pass (4270 passed, 70 skipped). `tests/integration` minus the 28-minute `test_semantic_all.py` sweep: 5 failed, 464 passed — the same 5 failures master shows against this fixture DB, none of them related. The 100% coverage gate was not run: it needs the full suite, and CI does not enforce it either (`--cov-fail-under=0`).
- This and #314 are the same move made twice, found one discrepancy at a time. The names dpmcore can emit are a closed, enumerable set, including the ones produced by the serializer's generic fallback, which emits the internal Python class name verbatim — `CondExpr` and `PersistentAssignment` both already reach delivered scripts that way. Diffing that set against the engine's enum in one pass would be worth its own issue.