### PR TITLE
fix: declare the shifted home instance for a home-module time_shift

### DIFF
--- a/src/dpmcore/services/ast_generator.py
+++ b/src/dpmcore/services/ast_generator.py
@@ -1345,15 +1345,25 @@ extract_precondition_codes`, shared with
     ) -> None:
         """Merge *new* cross-instance deps into *existing*.
 
-        Deduplicates by the set of module URIs.  When a duplicate is
-        found, its ``affected_operations`` are merged instead.
+        Deduplicates by the set of ``(module URI, reference period)``
+        pairs. When a duplicate is found, its ``affected_operations``
+        are merged instead.
+
+        The reference period is part of the key because two operations
+        can need the *same* module at *different* instances — one at
+        ``T``, another at ``T-1Q`` (#325 makes a non-default period
+        reachable for the home module). Keying on the URI alone merged
+        them into a single entry whose period was whichever operation
+        came first, silently sending the other to the wrong instance.
         """
 
-        def _uri_key(dep: Dict[str, Any]) -> Tuple[str, ...]:
+        def _uri_key(dep: Dict[str, Any]) -> Tuple[Tuple[str, str], ...]:
             modules = dep.get("modules", [])
             return tuple(
                 sorted(
-                    m.get("URI", "") if isinstance(m, dict) else str(m)
+                    (m.get("URI", ""), m.get("ref_period", ""))
+                    if isinstance(m, dict)
+                    else (str(m), "")
                     for m in modules
                 )
             )
@@ -1404,16 +1414,22 @@ extract_precondition_codes`, shared with
 
     @staticmethod
     def _to_ref_period(internal: str) -> str:
-        if internal.startswith("t+"):
+        """Render a ``t(+|-)<indicator><n>`` marker as a reference period.
+
+        The declared period is the *opposite* of the shift the expression
+        asks for. ``time_shift`` moves the operand's reference period by
+        ``shift_number``, so the instance whose shifted operand lines up
+        with the one being reported is the one at ``T - shift_number``:
+        ``time_shift(x, A, 1, refPeriod)`` needs ``T-1A`` and
+        ``time_shift(x, Q, -1, refPeriod)`` needs ``T+1Q``. The marker is
+        built with that inversion already applied (see
+        :meth:`_extract_time_shifts`), so this only reorders it.
+        """
+        if internal.startswith(("t+", "t-")):
+            sign = internal[1]
             ind = internal[2]
             num = internal[3:]
-            if num.startswith("-"):
-                return f"T{num}{ind}"
-            return f"T+{num}{ind}"
-        if internal.startswith("t-"):
-            ind = internal[2]
-            num = internal[3:]
-            return f"T-{num}{ind}"
+            return f"T{sign}{num}{ind}"
         return "T"
 
     @staticmethod
@@ -1438,16 +1454,17 @@ extract_precondition_codes`, shared with
                 prev = current_period[0]
                 pi = node.period_indicator
                 sn = node.shift_number
+                # The declared period inverts the shift number: a shift
+                # of ``+n`` needs the instance ``n`` periods back, a
+                # shift of ``-n`` the one ``n`` periods ahead. A shift
+                # number that is not a literal keeps its direction but
+                # not its size (``n``), which no instance resolves to.
                 if isinstance(sn, Constant):
                     current_period[0] = f"t-{pi}{sn.value}"
                 elif isinstance(sn, UnaryOp) and sn.op == "-":
                     inner = sn.operand
-                    sn_str = (
-                        f"-{inner.value}"
-                        if isinstance(inner, Constant)
-                        else "n"
-                    )
-                    current_period[0] = f"t+{pi}{sn_str}"
+                    num = inner.value if isinstance(inner, Constant) else "n"
+                    current_period[0] = f"t+{pi}{num}"
                 else:
                     current_period[0] = f"t-{pi}n"
                 self.visit(node.operand)

--- a/src/dpmcore/services/ast_generator.py
+++ b/src/dpmcore/services/ast_generator.py
@@ -1433,6 +1433,42 @@ extract_precondition_codes`, shared with
         return "T"
 
     @staticmethod
+    def _literal_shift(node: Any) -> Tuple[int, Optional[int]]:
+        """Resolve a ``shift_number`` expression to ``(sign, magnitude)``.
+
+        ``sign`` is the direction the expression asks for (``1`` or
+        ``-1``) and ``magnitude`` its size, or ``None`` when the shift
+        number is not an integer literal — a reference or a computed
+        expression, whose size no reference period can name.
+
+        The same written literal reaches this in several shapes, and
+        reading only the two obvious ones mis-declared the rest: ``+1``
+        is a ``UnaryOp``, so it lost its size and rendered ``T-nQ``;
+        ``( -1 )`` is a ``ParExpr`` around one, so it lost its direction
+        too; and ``(-1)`` without the spaces is lexed as a *negative*
+        ``Constant``, which rendered the sign twice (``T--1Q``).
+        """
+        from dpmcore.dpm_xl.ast.nodes import Constant, ParExpr, UnaryOp
+
+        sign = 1
+        while True:
+            if isinstance(node, ParExpr):
+                node = node.expression
+            elif isinstance(node, UnaryOp) and node.op in ("+", "-"):
+                if node.op == "-":
+                    sign = -sign
+                node = node.operand
+            else:
+                break
+        if not isinstance(node, Constant):
+            return sign, None
+        try:
+            shift = sign * int(node.value)
+        except (TypeError, ValueError):
+            return sign, None
+        return (-1 if shift < 0 else 1), abs(shift)
+
+    @staticmethod
     def _extract_time_shifts(ast: Any) -> Dict[str, str]:
         """Extract per-table time shifts from an AST.
 
@@ -1449,24 +1485,24 @@ extract_precondition_codes`, shared with
                 self.visit(node.operand)
 
             def visit_TimeShiftOp(self, node: Any) -> None:
-                from dpmcore.dpm_xl.ast.nodes import Constant, UnaryOp
-
                 prev = current_period[0]
                 pi = node.period_indicator
-                sn = node.shift_number
                 # The declared period inverts the shift number: a shift
                 # of ``+n`` needs the instance ``n`` periods back, a
                 # shift of ``-n`` the one ``n`` periods ahead. A shift
                 # number that is not a literal keeps its direction but
-                # not its size (``n``), which no instance resolves to.
-                if isinstance(sn, Constant):
-                    current_period[0] = f"t-{pi}{sn.value}"
-                elif isinstance(sn, UnaryOp) and sn.op == "-":
-                    inner = sn.operand
-                    num = inner.value if isinstance(inner, Constant) else "n"
-                    current_period[0] = f"t+{pi}{num}"
+                # not its size (``n``), which no instance resolves to,
+                # and a shift of ``0`` is no shift at all.
+                sign, magnitude = ASTGeneratorService._literal_shift(
+                    node.shift_number
+                )
+                marker = "-" if sign > 0 else "+"
+                if magnitude is None:
+                    current_period[0] = f"t{marker}{pi}n"
+                elif magnitude == 0:
+                    current_period[0] = "t"
                 else:
-                    current_period[0] = f"t-{pi}n"
+                    current_period[0] = f"t{marker}{pi}{magnitude}"
                 self.visit(node.operand)
                 current_period[0] = prev
 

--- a/src/dpmcore/services/scope_calculator.py
+++ b/src/dpmcore/services/scope_calculator.py
@@ -533,6 +533,24 @@ class ScopeCalculatorService:
         is_cross = scope_result.is_cross_module
         ts = time_shifts or {}
 
+        # #325: a ``time_shift`` over a table of the reporting module
+        # needs another *instance of that same module*, so the operation
+        # is not intra-instance and the shifted instance has to be
+        # declared like any other cross-instance dependency — under the
+        # home module's own URI and the shift's reference period.
+        # Without this the shift is silently dropped: the engine resolves
+        # both operands against the current instance and the script fails.
+        home_periods = (
+            self._home_shift_ref_periods(
+                ts=ts,
+                primary_module_vid=primary_module_vid,
+                release_id=release_id,
+                home_module_tables=home_module_tables,
+            )
+            if not scope_result.has_error
+            else []
+        )
+
         # Issue #120: when the primary module can evaluate the operation
         # on its own (it appears as a single-module scope), prefer the
         # intra-instance reading even if cross-instance scopes also exist
@@ -560,19 +578,38 @@ class ScopeCalculatorService:
                     release_id=release_id,
                     valid_module_uris=set(),
                 )
+            # A shifted home table turns the intra claim into a
+            # cross-instance dependency on the home module itself (#325).
+            # The primary still has to own a single-module scope: a module
+            # hosting none of the referenced tables is neither the
+            # intra-instance owner nor the shifted instance's reporter.
+            self_deps = (
+                self._build_home_instance_deps(
+                    periods=home_periods,
+                    primary_module_vid=primary_module_vid,
+                    operation_code=operation_code,
+                )
+                if primary_has_intra
+                else []
+            )
             # The intra claim needs the primary to actually own a
             # single-module scope. Keying it off ``not is_cross`` instead
             # declared intra for a module that participates in no scope at
             # all — it hosts none of the referenced tables (#141). That was
             # masked while a redundant superset scope kept ``is_cross``
             # true; dropping those scopes (#304) exposes it.
+            # ``not self_deps`` rather than ``not home_periods``: when the
+            # shifted instance cannot be declared (no resolvable URI) the
+            # operation keeps its intra classification instead of being
+            # dropped from the script's dependency block entirely.
             return {
                 **empty_result,
                 "intra_instance_validations": (
                     [operation_code]
-                    if operation_code and primary_has_intra
+                    if operation_code and primary_has_intra and not self_deps
                     else []
                 ),
+                "cross_instance_dependencies": self_deps,
                 "alternative_dependencies": alternative_deps,
             }
 
@@ -636,6 +673,18 @@ class ScopeCalculatorService:
             cross_deps.append(cross_dep)
             dep_modules[uri] = dep_module
 
+        # A cross-module operation can shift a home table too, and that
+        # shifted home instance is a dependency of its own (#325). It is
+        # appended after the external ones so their order — and the entry
+        # every existing caller reads first — stays unchanged.
+        cross_deps.extend(
+            self._build_home_instance_deps(
+                periods=home_periods,
+                primary_module_vid=primary_module_vid,
+                operation_code=operation_code,
+            )
+        )
+
         alternative_deps = (
             self.detect_alternative_dependencies(
                 scope_results=[scope_result],
@@ -652,6 +701,106 @@ class ScopeCalculatorService:
             "cross_instance_dependencies": cross_deps,
             "alternative_dependencies": alternative_deps,
             "dependency_modules": dep_modules,
+        }
+
+    def _home_shift_ref_periods(
+        self,
+        ts: Dict[str, str],
+        primary_module_vid: int,
+        release_id: Optional[int],
+        home_module_tables: Optional[Set[str]] = None,
+    ) -> List[str]:
+        """Return the reference periods shifted *within* the home module.
+
+        ``ts`` maps table codes to reference periods. A table owned by
+        the primary (home) module and shifted away from ``"T"`` means the
+        operation reads another instance of the reporting module itself
+        (#325), which is a cross-instance dependency the script has to
+        declare — the reference period never reached the output before,
+        because it was only ever read off a *dependency* module's tables.
+
+        One entry per distinct period, sorted for determinism: a single
+        operation shifting two home tables by different amounts needs
+        both instances, and the schema carries a period per declared
+        module rather than per table.
+        """
+        shifted = {tcode: rp for tcode, rp in ts.items() if rp and rp != "T"}
+        if not shifted:
+            return []
+        # Only pay for the table lookup once a shift is actually present.
+        tables = home_module_tables
+        if tables is None:
+            tables = set(
+                self._get_module_tables(
+                    primary_module_vid, release_id=release_id
+                ).keys()
+            )
+        return sorted({rp for tcode, rp in shifted.items() if tcode in tables})
+
+    def _build_home_instance_deps(
+        self,
+        periods: List[str],
+        primary_module_vid: int,
+        operation_code: Optional[str],
+    ) -> List[Dict[str, Any]]:
+        """Build the cross-instance entries for shifted home instances.
+
+        Each period yields one entry naming the home module's own URI —
+        the same URI the script is published under — so the engine knows
+        which instance to load for the shifted operand (#325). No
+        ``dependency_modules`` entry accompanies it: the home module's
+        tables and variables are already declared at the top level of
+        the script, and the shifted instance is the same module version.
+        """
+        if not periods:
+            return []
+        mv = (
+            self.session.query(ModuleVersion)
+            .filter(ModuleVersion.module_vid == primary_module_vid)
+            .first()
+        )
+        uri = self._get_module_uri(module_vid=primary_module_vid, mv=mv)
+        if not uri:
+            return []
+        return [
+            self._cross_dep_entry(
+                uri=uri,
+                ref_period=period,
+                mv=mv,
+                operation_code=operation_code,
+            )
+            for period in periods
+        ]
+
+    @staticmethod
+    def _cross_dep_entry(
+        uri: str,
+        ref_period: str,
+        mv: Any,
+        operation_code: Optional[str],
+    ) -> Dict[str, Any]:
+        """Build one ``cross_instance_dependencies`` entry for *uri*.
+
+        The reference dates are the declared module version's own
+        window, and ``module_version`` is omitted when the row carries
+        no version number.
+        """
+        module_entry: Dict[str, Any] = {
+            "URI": uri,
+            "ref_period": ref_period,
+        }
+        version_number = getattr(mv, "version_number", None)
+        if version_number:
+            module_entry["module_version"] = version_number
+        from_date = getattr(mv, "from_reference_date", None)
+        to_date = getattr(mv, "to_reference_date", None)
+        return {
+            "modules": [module_entry],
+            "affected_operations": (
+                [operation_code] if operation_code else []
+            ),
+            "from_reference_date": (str(from_date) if from_date else ""),
+            "to_reference_date": (str(to_date) if to_date else ""),
         }
 
     def _build_dependency_entry(
@@ -733,23 +882,12 @@ class ScopeCalculatorService:
                 if tcode not in home_module_tables
             }
 
-        module_entry: Dict[str, Any] = {
-            "URI": uri,
-            "ref_period": ref_period,
-        }
-        if mv.version_number:
-            module_entry["module_version"] = mv.version_number
-
-        from_date = mv.from_reference_date
-        to_date = mv.to_reference_date
-        cross_dep = {
-            "modules": [module_entry],
-            "affected_operations": (
-                [operation_code] if operation_code else []
-            ),
-            "from_reference_date": (str(from_date) if from_date else ""),
-            "to_reference_date": (str(to_date) if to_date else ""),
-        }
+        cross_dep = self._cross_dep_entry(
+            uri=uri,
+            ref_period=ref_period,
+            mv=mv,
+            operation_code=operation_code,
+        )
         variables: Dict[str, str] = {
             k: v
             for tbl in tables_dict.values()

--- a/src/dpmcore/services/scope_calculator.py
+++ b/src/dpmcore/services/scope_calculator.py
@@ -80,6 +80,13 @@ class ScopeCalculatorService:
         """Build the service bound to ``session``."""
         self.session = session
         self._syntax = SyntaxService()
+        # ``(ModuleVersion, URI)`` per module VID, for the home module of
+        # a script. ``detect_cross_module_dependencies`` runs once per
+        # operation with a fixed ``primary_module_vid``, so resolving it
+        # inside repeats the same row fetch and URI resolution for every
+        # operation that shifts a home table. Both are keyed by VID
+        # alone and neither varies with the release being generated.
+        self._home_module_refs: Dict[int, Tuple[Any, Optional[str]]] = {}
 
     def _check_release_exists(self, release_id: Optional[int]) -> None:
         """Raise SemanticError if *release_id* does not exist."""
@@ -751,15 +758,26 @@ class ScopeCalculatorService:
         ``dependency_modules`` entry accompanies it: the home module's
         tables and variables are already declared at the top level of
         the script, and the shifted instance is the same module version.
+
+        The module version and its URI are memoised in
+        ``_home_module_refs``: the caller iterates this once per
+        operation with the same ``primary_module_vid``.
         """
         if not periods:
             return []
-        mv = (
-            self.session.query(ModuleVersion)
-            .filter(ModuleVersion.module_vid == primary_module_vid)
-            .first()
-        )
-        uri = self._get_module_uri(module_vid=primary_module_vid, mv=mv)
+        cached = self._home_module_refs.get(primary_module_vid)
+        if cached is None:
+            mv = (
+                self.session.query(ModuleVersion)
+                .filter(ModuleVersion.module_vid == primary_module_vid)
+                .first()
+            )
+            cached = (
+                mv,
+                self._get_module_uri(module_vid=primary_module_vid, mv=mv),
+            )
+            self._home_module_refs[primary_module_vid] = cached
+        mv, uri = cached
         if not uri:
             return []
         return [

--- a/tests/integration/services/test_home_instance_shift.py
+++ b/tests/integration/services/test_home_instance_shift.py
@@ -1,0 +1,92 @@
+"""Integration regression: ``time_shift`` over a home-module table (#325).
+
+A validation that shifts a table of the module the script is generated for
+needs another instance of *that* module. It is therefore not
+intra-instance, and the shifted instance must be declared under the
+module's own URI with the shift's reference period — before #325 the
+validation was declared intra with no dependency at all, and the computed
+reference period never reached the output because it was only ever read
+off a dependency module's tables.
+
+Both real forms are covered: the shifted table named inline, and the
+shifted table inherited from a ``with`` clause.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import text
+
+from dpmcore.services.ast_generator import ASTGeneratorService
+
+_MODULE_CODE = "FINREP9"
+_MODULE_VERSION = "3.3.0"
+
+# Both validations shift a FINREP9 table by one year:
+# v1313_m names it inline — ``{tF_46.00, ...} = time_shift({tF_01.03,
+# ...}, A, 1, refPeriod)`` — and v1226_m inherits ``tF_46.00`` from its
+# ``with`` clause, so the shifted operand only resolves to a table after
+# semantic enrichment.
+_INLINE_CODE = "v1313_m"
+_WITH_CLAUSE_CODE = "v1226_m"
+_EXPECTED_REF_PERIOD = "T-1A"
+
+
+def _latest_expression(session, code: str) -> str:
+    operation_id = session.execute(
+        text("SELECT OperationID FROM Operation WHERE Code = :c"),
+        {"c": code},
+    ).scalar()
+    assert operation_id is not None, f"{code} not in fixture DB"
+    expression = session.execute(
+        text(
+            "SELECT Expression FROM OperationVersion "
+            "WHERE OperationID = :o ORDER BY OperationVID DESC LIMIT 1"
+        ),
+        {"o": operation_id},
+    ).scalar()
+    assert expression is not None, f"{code} has no expression in fixture DB"
+    return expression
+
+
+def _script(session, code: str) -> tuple[str, dict]:
+    expression = _latest_expression(session, code)
+    assert "time_shift" in expression, f"{code} must shift an operand"
+    result = ASTGeneratorService(session).script(
+        expressions=[(expression, code)],
+        module_code=_MODULE_CODE,
+        module_version=_MODULE_VERSION,
+    )
+    assert result["success"], result["error"]
+    assert not result["failed_operations"], result["failed_operations"]
+    namespace = next(iter(result["enriched_ast"]))
+    return namespace, result["enriched_ast"][namespace]
+
+
+@pytest.mark.parametrize("code", [_INLINE_CODE, _WITH_CLAUSE_CODE])
+def test_home_shift_is_declared_as_a_cross_instance_dependency(
+    fixture_session, code
+):
+    namespace, module = _script(fixture_session, code)
+    info = module["dependency_information"]
+
+    assert info["intra_instance_validations"] == []
+    assert len(info["cross_instance_dependencies"]) == 1
+    dependency = info["cross_instance_dependencies"][0]
+    assert dependency["affected_operations"] == [code]
+    assert dependency["modules"] == [
+        {
+            "URI": namespace,
+            "ref_period": _EXPECTED_REF_PERIOD,
+            "module_version": _MODULE_VERSION,
+        }
+    ]
+
+
+@pytest.mark.parametrize("code", [_INLINE_CODE, _WITH_CLAUSE_CODE])
+def test_home_module_is_not_declared_as_a_dependency_module(
+    fixture_session, code
+):
+    """The home module's tables and variables are already at the top level."""
+    namespace, module = _script(fixture_session, code)
+    assert namespace not in module["dependency_modules"]

--- a/tests/unit/services/test_ast_generator.py
+++ b/tests/unit/services/test_ast_generator.py
@@ -922,13 +922,30 @@ class TestExtractTimeShifts:
         node = _FakeTimeShiftOp("Q", sn, _FakeVarID(table="T_01"))
         assert Cls._extract_time_shifts(node) == {"T_01": "T-1Q"}
 
-    def test_negative_unary_shift_produces_T_minus(self):
+    def test_negative_unary_shift_produces_T_plus(self):
+        """The declared period inverts the shift: ``-2`` needs ``T+2Y``."""
         _, Cls, _ = _bare_svc()
         from dpmcore.dpm_xl.ast.nodes import Constant, UnaryOp
 
         sn = UnaryOp(op="-", operand=Constant(type_="Integer", value=2))
         node = _FakeTimeShiftOp("Y", sn, _FakeVarID(table="T_02"))
-        assert Cls._extract_time_shifts(node) == {"T_02": "T-2Y"}
+        assert Cls._extract_time_shifts(node) == {"T_02": "T+2Y"}
+
+    def test_negative_unary_shift_of_an_expression_keeps_direction(self):
+        """A non-literal shift keeps its direction, not its size."""
+        _, Cls, _ = _bare_svc()
+        from dpmcore.dpm_xl.ast.nodes import BinOp, Constant, UnaryOp
+
+        sn = UnaryOp(
+            op="-",
+            operand=BinOp(
+                op="*",
+                left=Constant(type_="Integer", value=2),
+                right=Constant(type_="Integer", value=2),
+            ),
+        )
+        node = _FakeTimeShiftOp("Q", sn, _FakeVarID(table="T_04"))
+        assert Cls._extract_time_shifts(node) == {"T_04": "T+nQ"}
 
     def test_var_without_table_ignored(self):
         _, Cls, _ = _bare_svc()

--- a/tests/unit/services/test_ast_generator.py
+++ b/tests/unit/services/test_ast_generator.py
@@ -955,6 +955,69 @@ class TestExtractTimeShifts:
         node = _FakeTimeShiftOp("Q", sn, _FakeVarID(table=None))
         assert Cls._extract_time_shifts(node) == {}
 
+    def test_unary_plus_shift_keeps_its_size(self):
+        """``+1`` is a UnaryOp, not a bare Constant: it still means 1."""
+        _, Cls, _ = _bare_svc()
+        from dpmcore.dpm_xl.ast.nodes import Constant, UnaryOp
+
+        sn = UnaryOp(op="+", operand=Constant(type_="Integer", value=1))
+        node = _FakeTimeShiftOp("Q", sn, _FakeVarID(table="T_05"))
+        assert Cls._extract_time_shifts(node) == {"T_05": "T-1Q"}
+
+    def test_parenthesised_shift_is_unwrapped(self):
+        """``( -1 )`` parses as a ParExpr around the unary minus."""
+        _, Cls, _ = _bare_svc()
+        from dpmcore.dpm_xl.ast.nodes import Constant, ParExpr, UnaryOp
+
+        sn = ParExpr(
+            expression=UnaryOp(
+                op="-", operand=Constant(type_="Integer", value=1)
+            )
+        )
+        node = _FakeTimeShiftOp("Q", sn, _FakeVarID(table="T_06"))
+        assert Cls._extract_time_shifts(node) == {"T_06": "T+1Q"}
+
+    def test_negative_constant_renders_a_single_sign(self):
+        """``(-1)`` is lexed as a negative Constant, not a unary minus."""
+        _, Cls, _ = _bare_svc()
+        from dpmcore.dpm_xl.ast.nodes import Constant
+
+        sn = Constant(type_="Integer", value=-1)
+        node = _FakeTimeShiftOp("Q", sn, _FakeVarID(table="T_07"))
+        assert Cls._extract_time_shifts(node) == {"T_07": "T+1Q"}
+
+    def test_double_negation_shift_is_positive(self):
+        _, Cls, _ = _bare_svc()
+        from dpmcore.dpm_xl.ast.nodes import Constant, UnaryOp
+
+        sn = UnaryOp(
+            op="-",
+            operand=UnaryOp(
+                op="-", operand=Constant(type_="Integer", value=1)
+            ),
+        )
+        node = _FakeTimeShiftOp("Q", sn, _FakeVarID(table="T_08"))
+        assert Cls._extract_time_shifts(node) == {"T_08": "T-1Q"}
+
+    def test_zero_shift_declares_no_period(self):
+        """A shift of 0 reads the current instance: nothing to declare."""
+        _, Cls, _ = _bare_svc()
+        from dpmcore.dpm_xl.ast.nodes import Constant
+
+        sn = Constant(type_="Integer", value=0)
+        node = _FakeTimeShiftOp("Q", sn, _FakeVarID(table="T_09"))
+        assert Cls._extract_time_shifts(node) == {}
+
+    def test_non_numeric_constant_shift_keeps_direction(self):
+        _, Cls, _ = _bare_svc()
+        from dpmcore.dpm_xl.ast.nodes import Constant, UnaryOp
+
+        sn = UnaryOp(
+            op="-", operand=Constant(type_="String", value="not-a-number")
+        )
+        node = _FakeTimeShiftOp("Q", sn, _FakeVarID(table="T_10"))
+        assert Cls._extract_time_shifts(node) == {"T_10": "T+nQ"}
+
     def test_complex_expression_ast_node_shift(self):
         _, Cls, _ = _bare_svc()
         from dpmcore.dpm_xl.ast.nodes import BinOp, Constant

--- a/tests/unit/services/test_home_instance_shift.py
+++ b/tests/unit/services/test_home_instance_shift.py
@@ -1,0 +1,274 @@
+"""A ``time_shift`` over a table of the reporting module (#325).
+
+The shifted operand needs another instance of the home module itself, so
+the operation is not intra-instance: the shifted instance has to be
+declared in ``cross_instance_dependencies`` under the home module's own
+URI, carrying the shift's reference period. Before #325 the operation was
+declared intra with no dependency at all, and the computed reference
+period — correct internally — was only ever read off a *dependency*
+module's tables, so it never reached the output.
+
+Imports the service normally (as ``test_prefer_intra`` does) instead of
+the legacy ORM-stubbing shim used elsewhere in the suite.
+"""
+
+from datetime import date
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from dpmcore.services import scope_calculator as sc_mod
+from dpmcore.services.scope_calculator import (
+    ScopeCalculatorService,
+    ScopeResult,
+)
+
+pytestmark = pytest.mark.unit
+
+HOME = 10
+EXTERNAL = 20
+
+
+def _scope(module_vids):
+    """A scope whose compositions cover *module_vids*."""
+    return SimpleNamespace(
+        operation_scope_compositions=[
+            SimpleNamespace(module_vid=v) for v in module_vids
+        ]
+    )
+
+
+def _mv(module_vid, version_number="3.1.0"):
+    return SimpleNamespace(
+        module_vid=module_vid,
+        version_number=version_number,
+        from_reference_date=date(2022, 12, 31),
+        to_reference_date=date(2025, 3, 30),
+    )
+
+
+@pytest.fixture
+def svc(monkeypatch):
+    """Service whose home module (10) owns C_48.02 and an external (20) T_20."""
+    monkeypatch.setattr(
+        sc_mod,
+        "resolve_release_id",
+        lambda session, release_id=None, release_code=None: release_id,
+    )
+    service = ScopeCalculatorService(MagicMock())
+    service._get_module_uri = lambda module_vid, mv=None: f"uri/{module_vid}"
+    tables = {
+        HOME: {"C_48.02": {"variables": {"v1": "m"}, "open_keys": {}}},
+        EXTERNAL: {"T_20": {"variables": {"v2": "m"}, "open_keys": {}}},
+    }
+    service._get_module_tables = lambda module_vid, release_id=None: tables[
+        module_vid
+    ]
+    query = service.session.query.return_value
+    # ``_build_home_instance_deps`` resolves the home module version;
+    # ``detect_cross_module_dependencies`` resolves the dependency ones.
+    query.filter.return_value.first.return_value = _mv(HOME)
+    query.filter.return_value.all.return_value = [_mv(EXTERNAL, "1.0.0")]
+    return service
+
+
+class TestHomeShiftIsCrossInstance:
+    """The reported case: a single-module scope with a shifted home table."""
+
+    def test_shifted_home_table_is_not_intra(self, svc):
+        info = svc.detect_cross_module_dependencies(
+            scope_result=ScopeResult(scopes=[_scope([HOME])]),
+            primary_module_vid=HOME,
+            operation_code="EGDQ_0896",
+            time_shifts={"C_48.02": "T-1Q"},
+        )
+        assert info["intra_instance_validations"] == []
+
+    def test_shifted_home_instance_is_declared(self, svc):
+        info = svc.detect_cross_module_dependencies(
+            scope_result=ScopeResult(scopes=[_scope([HOME])]),
+            primary_module_vid=HOME,
+            operation_code="EGDQ_0896",
+            time_shifts={"C_48.02": "T-1Q"},
+        )
+        assert info["cross_instance_dependencies"] == [
+            {
+                "modules": [
+                    {
+                        "URI": "uri/10",
+                        "ref_period": "T-1Q",
+                        "module_version": "3.1.0",
+                    }
+                ],
+                "affected_operations": ["EGDQ_0896"],
+                "from_reference_date": "2022-12-31",
+                "to_reference_date": "2025-03-30",
+            }
+        ]
+
+    def test_home_module_is_not_a_dependency_module(self, svc):
+        """Its tables and variables are declared at the script's top level."""
+        info = svc.detect_cross_module_dependencies(
+            scope_result=ScopeResult(scopes=[_scope([HOME])]),
+            primary_module_vid=HOME,
+            operation_code="EGDQ_0896",
+            time_shifts={"C_48.02": "T-1Q"},
+        )
+        assert info["dependency_modules"] == {}
+
+    def test_unshifted_operation_stays_intra(self, svc):
+        info = svc.detect_cross_module_dependencies(
+            scope_result=ScopeResult(scopes=[_scope([HOME])]),
+            primary_module_vid=HOME,
+            operation_code="EGDQ_0896",
+        )
+        assert info["intra_instance_validations"] == ["EGDQ_0896"]
+        assert info["cross_instance_dependencies"] == []
+
+    def test_ref_period_t_is_not_a_shift(self, svc):
+        """``T`` is the default reference period, not a shifted instance."""
+        info = svc.detect_cross_module_dependencies(
+            scope_result=ScopeResult(scopes=[_scope([HOME])]),
+            primary_module_vid=HOME,
+            operation_code="EGDQ_0896",
+            time_shifts={"C_48.02": "T"},
+        )
+        assert info["intra_instance_validations"] == ["EGDQ_0896"]
+        assert info["cross_instance_dependencies"] == []
+
+    def test_shift_on_a_table_the_home_does_not_own_is_ignored(self, svc):
+        """An external module's shift belongs to that module's entry."""
+        info = svc.detect_cross_module_dependencies(
+            scope_result=ScopeResult(scopes=[_scope([HOME])]),
+            primary_module_vid=HOME,
+            operation_code="EGDQ_0896",
+            time_shifts={"T_20": "T-1Q"},
+        )
+        assert info["intra_instance_validations"] == ["EGDQ_0896"]
+        assert info["cross_instance_dependencies"] == []
+
+    def test_caller_supplied_home_tables_are_used(self, svc):
+        """The pre-computed set spares the per-table lookup (script path)."""
+        svc._get_module_tables = MagicMock(
+            side_effect=AssertionError("should not be queried")
+        )
+        info = svc.detect_cross_module_dependencies(
+            scope_result=ScopeResult(scopes=[_scope([HOME])]),
+            primary_module_vid=HOME,
+            operation_code="EGDQ_0896",
+            time_shifts={"C_48.02": "T-1Q"},
+            home_module_tables={"C_48.02"},
+        )
+        assert (
+            info["cross_instance_dependencies"][0]["modules"][0]["ref_period"]
+            == "T-1Q"
+        )
+
+    def test_two_distinct_home_shifts_are_both_declared(self, svc):
+        """One entry per distinct period — the schema has no per-table one."""
+        svc._get_module_tables = lambda module_vid, release_id=None: {
+            "C_48.02": {"variables": {"v1": "m"}, "open_keys": {}},
+            "C_47.00": {"variables": {"v2": "m"}, "open_keys": {}},
+        }
+        info = svc.detect_cross_module_dependencies(
+            scope_result=ScopeResult(scopes=[_scope([HOME])]),
+            primary_module_vid=HOME,
+            operation_code="OP_BOTH",
+            time_shifts={"C_48.02": "T-1Q", "C_47.00": "T-4Q"},
+        )
+        periods = [
+            m["ref_period"]
+            for dep in info["cross_instance_dependencies"]
+            for m in dep["modules"]
+        ]
+        assert periods == ["T-1Q", "T-4Q"]
+
+    def test_module_version_omitted_when_the_row_has_none(self, svc):
+        """A version-less module version declares only URI and period."""
+        svc.session.query.return_value.filter.return_value.first.return_value = _mv(  # noqa: E501
+            HOME, version_number=None
+        )
+        info = svc.detect_cross_module_dependencies(
+            scope_result=ScopeResult(scopes=[_scope([HOME])]),
+            primary_module_vid=HOME,
+            operation_code="EGDQ_0896",
+            time_shifts={"C_48.02": "T-1Q"},
+        )
+        assert info["cross_instance_dependencies"][0]["modules"] == [
+            {"URI": "uri/10", "ref_period": "T-1Q"}
+        ]
+
+    def test_unresolvable_uri_keeps_the_intra_classification(self, svc):
+        """Better a wrong-but-present classification than no entry at all."""
+        svc._get_module_uri = lambda module_vid, mv=None: None
+        info = svc.detect_cross_module_dependencies(
+            scope_result=ScopeResult(scopes=[_scope([HOME])]),
+            primary_module_vid=HOME,
+            operation_code="EGDQ_0896",
+            time_shifts={"C_48.02": "T-1Q"},
+        )
+        assert info["intra_instance_validations"] == ["EGDQ_0896"]
+        assert info["cross_instance_dependencies"] == []
+
+    def test_scope_error_declares_nothing(self, svc):
+        info = svc.detect_cross_module_dependencies(
+            scope_result=ScopeResult(has_error=True, error_message="boom"),
+            primary_module_vid=HOME,
+            operation_code="EGDQ_0896",
+            time_shifts={"C_48.02": "T-1Q"},
+        )
+        assert info["intra_instance_validations"] == []
+        assert info["cross_instance_dependencies"] == []
+
+    def test_module_hosting_no_referenced_table_declares_nothing(self, svc):
+        """No scope of its own: neither intra owner nor shifted reporter."""
+        info = svc.detect_cross_module_dependencies(
+            scope_result=ScopeResult(scopes=[_scope([EXTERNAL])]),
+            primary_module_vid=HOME,
+            operation_code="EGDQ_0896",
+            time_shifts={"C_48.02": "T-1Q"},
+        )
+        assert info["intra_instance_validations"] == []
+        assert info["cross_instance_dependencies"] == []
+
+
+class TestHomeShiftAlongsideExternalDependency:
+    """A genuinely cross-module operation that also shifts a home table."""
+
+    def test_external_and_home_instances_are_both_declared(self, svc):
+        info = svc.detect_cross_module_dependencies(
+            scope_result=ScopeResult(
+                scopes=[_scope([HOME, EXTERNAL])],
+                is_cross_module=True,
+            ),
+            primary_module_vid=HOME,
+            operation_code="X_BOTH",
+            time_shifts={"C_48.02": "T-1Q"},
+        )
+        assert info["intra_instance_validations"] == []
+        declared = [
+            (m["URI"], m["ref_period"])
+            for dep in info["cross_instance_dependencies"]
+            for m in dep["modules"]
+        ]
+        # The external entry keeps its position: callers reading the
+        # first entry see the same module they saw before #325.
+        assert declared == [("uri/20", "T"), ("uri/10", "T-1Q")]
+        assert set(info["dependency_modules"]) == {"uri/20"}
+
+    def test_external_dependency_alone_is_unchanged(self, svc):
+        info = svc.detect_cross_module_dependencies(
+            scope_result=ScopeResult(
+                scopes=[_scope([HOME, EXTERNAL])],
+                is_cross_module=True,
+            ),
+            primary_module_vid=HOME,
+            operation_code="X_CROSS",
+        )
+        declared = [
+            (m["URI"], m["ref_period"])
+            for dep in info["cross_instance_dependencies"]
+            for m in dep["modules"]
+        ]
+        assert declared == [("uri/20", "T")]

--- a/tests/unit/services/test_home_instance_shift.py
+++ b/tests/unit/services/test_home_instance_shift.py
@@ -272,3 +272,63 @@ class TestHomeShiftAlongsideExternalDependency:
             for m in dep["modules"]
         ]
         assert declared == [("uri/20", "T")]
+
+
+class TestHomeModuleResolutionIsMemoised:
+    """The home module is resolved once, not once per operation.
+
+    ``detect_cross_module_dependencies`` runs per operation with a fixed
+    ``primary_module_vid``, so the row fetch and URI resolution behind
+    the shifted home instance repeated for every shifting operation in
+    a script.
+    """
+
+    def test_repeated_operations_resolve_the_home_module_once(self, svc):
+        resolver = MagicMock(
+            side_effect=lambda module_vid, mv=None: f"uri/{module_vid}"
+        )
+        svc._get_module_uri = resolver
+        declared = []
+        for code in ("OP_1", "OP_2", "OP_3"):
+            info = svc.detect_cross_module_dependencies(
+                scope_result=ScopeResult(scopes=[_scope([HOME])]),
+                primary_module_vid=HOME,
+                operation_code=code,
+                time_shifts={"C_48.02": "T-1Q"},
+            )
+            declared.append(info["cross_instance_dependencies"])
+        assert resolver.call_count == 1
+        # Memoising must not change what is declared: same entry every
+        # time, only the operation it affects differs.
+        assert [d[0]["modules"] for d in declared] == [
+            [
+                {
+                    "URI": "uri/10",
+                    "ref_period": "T-1Q",
+                    "module_version": "3.1.0",
+                }
+            ]
+        ] * 3
+        assert [d[0]["affected_operations"] for d in declared] == [
+            ["OP_1"],
+            ["OP_2"],
+            ["OP_3"],
+        ]
+
+    def test_a_different_home_module_is_resolved_on_its_own(self, svc):
+        resolver = MagicMock(
+            side_effect=lambda module_vid, mv=None: f"uri/{module_vid}"
+        )
+        svc._get_module_uri = resolver
+        for vid, table in ((HOME, "C_48.02"), (EXTERNAL, "T_20")):
+            info = svc.detect_cross_module_dependencies(
+                scope_result=ScopeResult(scopes=[_scope([vid])]),
+                primary_module_vid=vid,
+                operation_code="OP",
+                time_shifts={table: "T-1Q"},
+            )
+            assert (
+                info["cross_instance_dependencies"][0]["modules"][0]["URI"]
+                == f"uri/{vid}"
+            )
+        assert resolver.call_count == 2


### PR DESCRIPTION
## Summary

Fixes #325.

A validation that applies `time_shift` to a table of the module the script is generated for needs a different instance of that same module. The script said otherwise: the validation was declared intra-instance with no dependency for the shifted operand, so the engine had nothing to resolve it against. The reference period was computed but only ever attached to a module other than the reporting one, which is why `ref_period` was `"T"` in all 74 module entries of the generated scripts.

- A shift on a table the home module owns no longer counts as intra-instance. The shifted instance is declared in `cross_instance_dependencies` under the home module's own URI, with the shift's reference period, module version and reference-date window. A cross-module operation that also shifts a home table gets both entries, the external ones first. No `dependency_modules` entry accompanies the home instance: its tables and variables are the script's top-level blocks already.
- The declared period inverts the shift number: `time_shift(x, A, 1, refPeriod)` needs `T-1A` and `time_shift(x, Q, -1, refPeriod)` needs `T+1Q`. The sign used to be dropped, so a forward shift was inexpressible.
- Cross-instance entries dedupe by `(URI, ref_period)` instead of by URI alone, so two operations needing one module at different instances keep both entries instead of collapsing onto whichever came first.

For COREP_LR 3.1.0 / EGDQ_0896 the block is now the one the issue asks for, with `T+1Q` where the issue wrote `T-1Q`.


## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [ ] Documentation updated (if applicable)

## Impact / Risk

- Breaking changes? (public API / CLI / REST endpoints / Django models)
- Database schema or migration concerns?
- Notes for release/changelog?

## Notes

<!-- Follow-ups, TODOs, or anything reviewers should know. -->
