### PR TITLE
fix: declare every reference period a dependency module is read at

### DIFF
--- a/src/dpmcore/errors.py
+++ b/src/dpmcore/errors.py
@@ -293,6 +293,10 @@ centralised_messages: Dict[str, str] = {
         "For time_shift operator,"
         " shift_number must evaluate to an integer scalar"
     ),
+    "4-7-5": (
+        "For time_shift operator, shift_number must be an integer"
+        " literal to declare the shifted operand's reference period"
+    ),
     # - String Operators
     "4-8-1": (
         "Invalid {op} parameter: {parameter_name} must be {constraint}."

--- a/src/dpmcore/services/ast_generator.py
+++ b/src/dpmcore/services/ast_generator.py
@@ -1345,15 +1345,25 @@ extract_precondition_codes`, shared with
     ) -> None:
         """Merge *new* cross-instance deps into *existing*.
 
-        Deduplicates by the set of module URIs.  When a duplicate is
-        found, its ``affected_operations`` are merged instead.
+        Deduplicates by the set of ``(module URI, reference period)``
+        pairs. When a duplicate is found, its ``affected_operations``
+        are merged instead.
+
+        The reference period is part of the key because two operations
+        can need the *same* module at *different* instances — one at
+        ``T``, another at ``T-1Q`` (#325 makes a non-default period
+        reachable for the home module). Keying on the URI alone merged
+        them into a single entry whose period was whichever operation
+        came first, silently sending the other to the wrong instance.
         """
 
-        def _uri_key(dep: Dict[str, Any]) -> Tuple[str, ...]:
+        def _uri_key(dep: Dict[str, Any]) -> Tuple[Tuple[str, str], ...]:
             modules = dep.get("modules", [])
             return tuple(
                 sorted(
-                    m.get("URI", "") if isinstance(m, dict) else str(m)
+                    (m.get("URI", ""), m.get("ref_period", ""))
+                    if isinstance(m, dict)
+                    else (str(m), "")
                     for m in modules
                 )
             )
@@ -1404,16 +1414,22 @@ extract_precondition_codes`, shared with
 
     @staticmethod
     def _to_ref_period(internal: str) -> str:
-        if internal.startswith("t+"):
+        """Render a ``t(+|-)<indicator><n>`` marker as a reference period.
+
+        The declared period is the *opposite* of the shift the expression
+        asks for. ``time_shift`` moves the operand's reference period by
+        ``shift_number``, so the instance whose shifted operand lines up
+        with the one being reported is the one at ``T - shift_number``:
+        ``time_shift(x, A, 1, refPeriod)`` needs ``T-1A`` and
+        ``time_shift(x, Q, -1, refPeriod)`` needs ``T+1Q``. The marker is
+        built with that inversion already applied (see
+        :meth:`_extract_time_shifts`), so this only reorders it.
+        """
+        if internal.startswith(("t+", "t-")):
+            sign = internal[1]
             ind = internal[2]
             num = internal[3:]
-            if num.startswith("-"):
-                return f"T{num}{ind}"
-            return f"T+{num}{ind}"
-        if internal.startswith("t-"):
-            ind = internal[2]
-            num = internal[3:]
-            return f"T-{num}{ind}"
+            return f"T{sign}{num}{ind}"
         return "T"
 
     @staticmethod
@@ -1438,16 +1454,17 @@ extract_precondition_codes`, shared with
                 prev = current_period[0]
                 pi = node.period_indicator
                 sn = node.shift_number
+                # The declared period inverts the shift number: a shift
+                # of ``+n`` needs the instance ``n`` periods back, a
+                # shift of ``-n`` the one ``n`` periods ahead. A shift
+                # number that is not a literal keeps its direction but
+                # not its size (``n``), which no instance resolves to.
                 if isinstance(sn, Constant):
                     current_period[0] = f"t-{pi}{sn.value}"
                 elif isinstance(sn, UnaryOp) and sn.op == "-":
                     inner = sn.operand
-                    sn_str = (
-                        f"-{inner.value}"
-                        if isinstance(inner, Constant)
-                        else "n"
-                    )
-                    current_period[0] = f"t+{pi}{sn_str}"
+                    num = inner.value if isinstance(inner, Constant) else "n"
+                    current_period[0] = f"t+{pi}{num}"
                 else:
                     current_period[0] = f"t-{pi}n"
                 self.visit(node.operand)

--- a/src/dpmcore/services/ast_generator.py
+++ b/src/dpmcore/services/ast_generator.py
@@ -1433,6 +1433,42 @@ extract_precondition_codes`, shared with
         return "T"
 
     @staticmethod
+    def _literal_shift(node: Any) -> Tuple[int, Optional[int]]:
+        """Resolve a ``shift_number`` expression to ``(sign, magnitude)``.
+
+        ``sign`` is the direction the expression asks for (``1`` or
+        ``-1``) and ``magnitude`` its size, or ``None`` when the shift
+        number is not an integer literal — a reference or a computed
+        expression, whose size no reference period can name.
+
+        The same written literal reaches this in several shapes, and
+        reading only the two obvious ones mis-declared the rest: ``+1``
+        is a ``UnaryOp``, so it lost its size and rendered ``T-nQ``;
+        ``( -1 )`` is a ``ParExpr`` around one, so it lost its direction
+        too; and ``(-1)`` without the spaces is lexed as a *negative*
+        ``Constant``, which rendered the sign twice (``T--1Q``).
+        """
+        from dpmcore.dpm_xl.ast.nodes import Constant, ParExpr, UnaryOp
+
+        sign = 1
+        while True:
+            if isinstance(node, ParExpr):
+                node = node.expression
+            elif isinstance(node, UnaryOp) and node.op in ("+", "-"):
+                if node.op == "-":
+                    sign = -sign
+                node = node.operand
+            else:
+                break
+        if not isinstance(node, Constant):
+            return sign, None
+        try:
+            shift = sign * int(node.value)
+        except (TypeError, ValueError):
+            return sign, None
+        return (-1 if shift < 0 else 1), abs(shift)
+
+    @staticmethod
     def _extract_time_shifts(ast: Any) -> Dict[str, str]:
         """Extract per-table time shifts from an AST.
 
@@ -1449,24 +1485,24 @@ extract_precondition_codes`, shared with
                 self.visit(node.operand)
 
             def visit_TimeShiftOp(self, node: Any) -> None:
-                from dpmcore.dpm_xl.ast.nodes import Constant, UnaryOp
-
                 prev = current_period[0]
                 pi = node.period_indicator
-                sn = node.shift_number
                 # The declared period inverts the shift number: a shift
                 # of ``+n`` needs the instance ``n`` periods back, a
                 # shift of ``-n`` the one ``n`` periods ahead. A shift
                 # number that is not a literal keeps its direction but
-                # not its size (``n``), which no instance resolves to.
-                if isinstance(sn, Constant):
-                    current_period[0] = f"t-{pi}{sn.value}"
-                elif isinstance(sn, UnaryOp) and sn.op == "-":
-                    inner = sn.operand
-                    num = inner.value if isinstance(inner, Constant) else "n"
-                    current_period[0] = f"t+{pi}{num}"
+                # not its size (``n``), which no instance resolves to,
+                # and a shift of ``0`` is no shift at all.
+                sign, magnitude = ASTGeneratorService._literal_shift(
+                    node.shift_number
+                )
+                marker = "-" if sign > 0 else "+"
+                if magnitude is None:
+                    current_period[0] = f"t{marker}{pi}n"
+                elif magnitude == 0:
+                    current_period[0] = "t"
                 else:
-                    current_period[0] = f"t-{pi}n"
+                    current_period[0] = f"t{marker}{pi}{magnitude}"
                 self.visit(node.operand)
                 current_period[0] = prev
 

--- a/src/dpmcore/services/ast_generator.py
+++ b/src/dpmcore/services/ast_generator.py
@@ -23,6 +23,7 @@ from dpmcore.dpm_xl.utils.tokens import (
     SEVERITY_WARNING,
     VALID_SEVERITIES,
 )
+from dpmcore.errors import SemanticError
 from dpmcore.services._parameters import merge_parameters
 from dpmcore.services._precondition_codes import (
     extract_precondition_codes as _extract_precondition_codes,
@@ -60,6 +61,25 @@ class _OperandRefs:
 
     tables: set[str] = field(default_factory=set)
     variables: Dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class _PreparedExpression:
+    """One expression readied for the script, or the reason it is not.
+
+    ``error`` is set when the expression cannot become a declarable
+    operation — it failed semantic validation, or it carries a shift
+    whose reference period cannot be declared (#326). Both are reported
+    the same way, through ``failed_operations``, and both must be caught
+    before the caller accumulates anything for the operation: a skip
+    afterwards would leave its tables, parameters and operation entry in
+    the script.
+    """
+
+    result: Any = None
+    ast: Any = None
+    ts: Dict[str, List[str]] = field(default_factory=dict)
+    error: Optional[str] = None
 
 
 def _normalize_variable_code(code: str) -> str:
@@ -200,7 +220,7 @@ class ASTGeneratorService:
                 Tuple[
                     Tuple[str, str],
                     "ScopeResult",
-                    Dict[str, str],
+                    Dict[str, List[str]],
                     _OperandRefs,
                 ]
             ] = []
@@ -209,17 +229,18 @@ class ASTGeneratorService:
 
             for item in expressions:
                 expr, code = item[0], item[1]
-                # validate() runs the per-expression scope check: a parameter
-                # referenced here must not clash with the declared type of a
-                # co-scoped operation already persisted in the DB (raises 3-8).
-                # _accumulate_parameters below is complementary — it catches
-                # conflicts between two expressions in this same script.
-                result = self._semantic.validate(expr, release_id=release_id)
-                if not result.is_valid:
-                    failed_operations[code] = result.error_message or ""
+                # Semantic validation plus the reference periods the
+                # expression needs; either can reject it. The
+                # _accumulate_parameters call below is complementary to
+                # the scope check inside — it catches conflicts between
+                # two expressions in this same script.
+                prepared = self._prepare_expression(
+                    self._semantic, expr, release_id
+                )
+                if prepared.error is not None:
+                    failed_operations[code] = prepared.error
                     continue
-
-                ast = self._semantic.ast
+                result, ast, ts = prepared.result, prepared.ast, prepared.ts
                 ast_dict = serialize_ast(ast)
                 # Operand refs come off the *raw* serialisation: cleaning
                 # strips the ``data_type`` each datapoint is typed by.
@@ -264,7 +285,6 @@ class ASTGeneratorService:
                         ),
                         "failed_operations": failed_operations,
                     }
-                ts = self._extract_time_shifts(ast)
                 scope_pairs.append((item, sr, ts, op_refs))
 
             primary_tables_full = self._scope_calc._get_module_tables(
@@ -1256,7 +1276,7 @@ extract_precondition_codes`, shared with
             Tuple[
                 Tuple[str, str],
                 "ScopeResult",
-                Dict[str, str],
+                Dict[str, List[str]],
                 _OperandRefs,
             ]
         ],
@@ -1468,16 +1488,86 @@ extract_precondition_codes`, shared with
             return sign, None
         return (-1 if shift < 0 else 1), abs(shift)
 
-    @staticmethod
-    def _extract_time_shifts(ast: Any) -> Dict[str, str]:
-        """Extract per-table time shifts from an AST.
+    def _prepare_expression(
+        self,
+        semantic: SemanticService,
+        expr: str,
+        release_id: int,
+    ) -> _PreparedExpression:
+        """Validate *expr* and read the reference periods it needs.
 
-        Returns a mapping of table codes to ref-period strings
-        (e.g. ``{"C_01.00": "T-1Q"}``).
+        ``validate()`` runs the per-expression scope check: a parameter
+        referenced here must not clash with the declared type of a
+        co-scoped operation already persisted in the DB (raises 3-8).
+        ``_accumulate_parameters`` in the caller is complementary — it
+        catches conflicts between two expressions in the same script.
+        """
+        result = semantic.validate(expr, release_id=release_id)
+        if not result.is_valid:
+            return _PreparedExpression(
+                error=result.error_message or "",
+            )
+        ast = semantic.ast
+        try:
+            return _PreparedExpression(
+                result=result,
+                ast=ast,
+                ts=self._extract_time_shifts(ast),
+            )
+        except SemanticError as exc:
+            return _PreparedExpression(error=str(exc))
+
+    @staticmethod
+    def _shift_marker(node: Any) -> str:
+        """Return the ``t(+|-)<indicator><n>`` marker for a time shift.
+
+        The marker encodes the *declared* period, which inverts the
+        shift the expression asks for: ``time_shift(x, A, 1, refPeriod)``
+        reads the instance at ``T-1A`` and
+        ``time_shift(x, Q, -1, refPeriod)`` the one at ``T+1Q``. A shift
+        of ``0`` is no shift at all, so it keeps the plain marker.
+
+        Raises:
+            SemanticError: 4-7-5, when the shift number is not an
+                integer literal. Such a shift used
+                to render as ``T-nQ``, which names no resolvable
+                instance and so silently sent the operation to an
+                instance the engine cannot load (#326).
+        """
+        sign, magnitude = ASTGeneratorService._literal_shift(node.shift_number)
+        if magnitude is None:
+            raise SemanticError("4-7-5")
+        if magnitude == 0:
+            return "t"
+        # ``magnitude`` is unsigned, so the sign is carried by the marker
+        # alone — a ``Constant`` holding a negative value would otherwise
+        # render two signs (``t-Q-1``).
+        marker = "-" if sign > 0 else "+"
+        return f"t{marker}{node.period_indicator}{magnitude}"
+
+    @staticmethod
+    def _extract_time_shifts(ast: Any) -> Dict[str, List[str]]:
+        """Extract the reference periods each table is referenced at.
+
+        Returns a mapping of table codes to the sorted, de-duplicated
+        reference periods that table is read at, e.g.
+        ``{"C_01.00": ["T", "T-1Q"]}``.
+
+        One period per table is not enough (#326): a table read both
+        plain and shifted, or shifted twice by different amounts, needs
+        one instance per period, and keeping a single period collapsed
+        the rest into whichever the visitor reached last. Unshifted
+        references are recorded as ``"T"`` too, so a module read at both
+        the current and a shifted instance is visible to the caller
+        instead of being declared at the shifted one alone.
+
+        Raises:
+            SemanticError: 4-7-5, propagated from
+                :meth:`_shift_marker` for a non-literal shift number.
         """
         from dpmcore.dpm_xl.ast.template import ASTTemplate
 
-        time_shifts: Dict[str, str] = {}
+        time_shifts: Dict[str, Set[str]] = {}
         current_period = ["t"]
 
         class _Extractor(ASTTemplate):
@@ -1486,41 +1576,34 @@ extract_precondition_codes`, shared with
 
             def visit_TimeShiftOp(self, node: Any) -> None:
                 prev = current_period[0]
-                pi = node.period_indicator
-                # The declared period inverts the shift number: a shift
-                # of ``+n`` needs the instance ``n`` periods back, a
-                # shift of ``-n`` the one ``n`` periods ahead. A shift
-                # number that is not a literal keeps its direction but
-                # not its size (``n``), which no instance resolves to,
-                # and a shift of ``0`` is no shift at all.
-                sign, magnitude = ASTGeneratorService._literal_shift(
-                    node.shift_number
-                )
-                marker = "-" if sign > 0 else "+"
-                if magnitude is None:
-                    current_period[0] = f"t{marker}{pi}n"
-                elif magnitude == 0:
-                    current_period[0] = "t"
-                else:
-                    current_period[0] = f"t{marker}{pi}{magnitude}"
+                current_period[0] = ASTGeneratorService._shift_marker(node)
                 self.visit(node.operand)
                 current_period[0] = prev
 
             def visit_VarID(self, node: Any) -> None:
-                if node.table and current_period[0] != "t":
-                    time_shifts[node.table] = current_period[0]
+                if node.table:
+                    time_shifts.setdefault(node.table, set()).add(
+                        current_period[0]
+                    )
 
         try:
             _Extractor().visit(ast)
-            return {
-                t: ASTGeneratorService._to_ref_period(p)
-                for t, p in time_shifts.items()
-            }
+        except SemanticError:
+            # A shift whose period cannot be declared is the caller's
+            # decision to act on, not something to swallow into an
+            # empty mapping.
+            raise
         except Exception:
             logger.exception(
                 "Failed to extract time shifts; returning an empty mapping.",
             )
             return {}
+        return {
+            table: sorted(
+                {ASTGeneratorService._to_ref_period(p) for p in periods}
+            )
+            for table, periods in time_shifts.items()
+        }
 
 
 __all__ = ["ASTGeneratorService"]

--- a/src/dpmcore/services/scope_calculator.py
+++ b/src/dpmcore/services/scope_calculator.py
@@ -9,9 +9,11 @@ from typing import (
     Any,
     Dict,
     List,
+    Mapping,
     Optional,
     Set,
     Tuple,
+    Union,
 )
 
 from dpmcore.dpm_xl.ast.operands import OperandsChecking
@@ -479,7 +481,7 @@ class ScopeCalculatorService:
         primary_module_vid: int,
         operation_code: Optional[str] = None,
         release_id: Optional[int] = None,
-        time_shifts: Optional[Dict[str, str]] = None,
+        time_shifts: Optional[Mapping[str, Union[str, List[str]]]] = None,
         compute_alternative_deps: bool = True,
         release_code: Optional[str] = None,
         referenced_variables: Optional[Dict[str, str]] = None,
@@ -493,9 +495,13 @@ class ScopeCalculatorService:
             primary_module_vid: VID of the primary module.
             operation_code: Current operation code (if any).
             release_id: Optional release filter.
-            time_shifts: Optional mapping of table codes to
-                ref-period strings (e.g. ``{"C_01.00": "T-1Q"}``).
-                Tables not present default to ``"T"``.
+            time_shifts: Optional mapping of table codes to the
+                ref-period strings that table is read at (e.g.
+                ``{"C_01.00": ["T", "T-1Q"]}``). A table read at more
+                than one period needs one declared instance per period
+                (#326). A bare string is accepted as a single period, so
+                the pre-#326 ``{"C_01.00": "T-1Q"}`` shape still works.
+                Tables not present default to ``["T"]``.
             compute_alternative_deps: When True (default) the returned
                 ``alternative_dependencies`` is populated from this
                 single ``scope_result``. Aggregating callers that
@@ -538,7 +544,13 @@ class ScopeCalculatorService:
             "dependency_modules": {},
         }
         is_cross = scope_result.is_cross_module
-        ts = time_shifts or {}
+        # Normalised up front: a bare string left as-is would be
+        # iterated character by character downstream and manufacture
+        # periods like ``"-"`` and ``"1"`` out of ``"T-1Q"``.
+        ts = {
+            table: [periods] if isinstance(periods, str) else list(periods)
+            for table, periods in (time_shifts or {}).items()
+        }
 
         # #325: a ``time_shift`` over a table of the reporting module
         # needs another *instance of that same module*, so the operation
@@ -676,8 +688,8 @@ class ScopeCalculatorService:
             )
             if entry is None:
                 continue
-            cross_dep, uri, dep_module = entry
-            cross_deps.append(cross_dep)
+            entry_deps, uri, dep_module = entry
+            cross_deps.extend(entry_deps)
             dep_modules[uri] = dep_module
 
         # A cross-module operation can shift a home table too, and that
@@ -712,26 +724,31 @@ class ScopeCalculatorService:
 
     def _home_shift_ref_periods(
         self,
-        ts: Dict[str, str],
+        ts: Dict[str, List[str]],
         primary_module_vid: int,
         release_id: Optional[int],
         home_module_tables: Optional[Set[str]] = None,
     ) -> List[str]:
         """Return the reference periods shifted *within* the home module.
 
-        ``ts`` maps table codes to reference periods. A table owned by
-        the primary (home) module and shifted away from ``"T"`` means the
-        operation reads another instance of the reporting module itself
-        (#325), which is a cross-instance dependency the script has to
-        declare — the reference period never reached the output before,
-        because it was only ever read off a *dependency* module's tables.
+        ``ts`` maps table codes to the reference periods they are read
+        at. A table owned by the primary (home) module and read at a
+        period other than ``"T"`` means the operation reads another
+        instance of the reporting module itself (#325), which is a
+        cross-instance dependency the script has to declare — the
+        reference period never reached the output before, because it was
+        only ever read off a *dependency* module's tables.
 
         One entry per distinct period, sorted for determinism: a single
         operation shifting two home tables by different amounts needs
         both instances, and the schema carries a period per declared
         module rather than per table.
         """
-        shifted = {tcode: rp for tcode, rp in ts.items() if rp and rp != "T"}
+        shifted = {
+            tcode: [rp for rp in periods if rp and rp != "T"]
+            for tcode, periods in ts.items()
+        }
+        shifted = {tcode: rps for tcode, rps in shifted.items() if rps}
         if not shifted:
             return []
         # Only pay for the table lookup once a shift is actually present.
@@ -742,7 +759,14 @@ class ScopeCalculatorService:
                     primary_module_vid, release_id=release_id
                 ).keys()
             )
-        return sorted({rp for tcode, rp in shifted.items() if tcode in tables})
+        return sorted(
+            {
+                rp
+                for tcode, rps in shifted.items()
+                if tcode in tables
+                for rp in rps
+            }
+        )
 
     def _build_home_instance_deps(
         self,
@@ -826,13 +850,20 @@ class ScopeCalculatorService:
         vid: int,
         mv: Any,
         release_id: Optional[int],
-        ts: Dict[str, str],
+        ts: Dict[str, List[str]],
         operation_code: Optional[str],
         referenced_variables: Optional[Dict[str, str]] = None,
         referenced_tables: Optional[Set[str]] = None,
         home_module_tables: Optional[Set[str]] = None,
-    ) -> Optional[Tuple[Dict[str, Any], str, Dict[str, Any]]]:
-        """Build a single (cross_dep, uri, dependency_module) triple.
+    ) -> Optional[Tuple[List[Dict[str, Any]], str, Dict[str, Any]]]:
+        """Build the (cross_deps, uri, dependency_module) triple for *vid*.
+
+        One ``cross_instance_dependencies`` entry per distinct reference
+        period the module is read at — the schema carries a period per
+        declared module, so a module needed at two instances has to be
+        declared twice (#326). ``dependency_modules`` stays keyed by URI
+        and carries the union of the tables, exactly as before: the
+        table and datapoint definitions do not vary by instance.
 
         Returns ``None`` when the module has no resolvable URI or
         when every one of its tables is variable-less (and therefore
@@ -865,11 +896,20 @@ class ScopeCalculatorService:
         # table not referenced by the cross-rules, and a dropped table takes
         # its timeshift with it — a module whose only timeshifted table is
         # not referenced would otherwise fall back to ref_period T.
-        ref_period = "T"
-        for tbl_code in tables_dict:
-            rp = ts.get(tbl_code)
-            if rp and rp != "T":
-                ref_period = rp
+        # Every period any of the module's tables is read at is kept:
+        # taking one dropped the others, so an operation reading two
+        # tables of the same module at different instances — or one
+        # table both plain and shifted — was declared against a single
+        # instance and evaluated against the wrong one (#326). Sorted so
+        # the output does not depend on visit order; ``"T"`` sorts first.
+        periods = sorted(
+            {
+                rp
+                for tbl_code in tables_dict
+                for rp in ts.get(tbl_code, ())
+                if rp
+            }
+        ) or ["T"]
 
         # #250: declare only the tables and datapoints the cross-rules
         # actually reference — a whole dependency module is 100+ tables and
@@ -900,12 +940,15 @@ class ScopeCalculatorService:
                 if tcode not in home_module_tables
             }
 
-        cross_dep = self._cross_dep_entry(
-            uri=uri,
-            ref_period=ref_period,
-            mv=mv,
-            operation_code=operation_code,
-        )
+        cross_deps = [
+            self._cross_dep_entry(
+                uri=uri,
+                ref_period=period,
+                mv=mv,
+                operation_code=operation_code,
+            )
+            for period in periods
+        ]
         variables: Dict[str, str] = {
             k: v
             for tbl in tables_dict.values()
@@ -924,7 +967,7 @@ class ScopeCalculatorService:
             "tables": tables_dict,
             "variables": variables,
         }
-        return cross_dep, uri, dep_module
+        return cross_deps, uri, dep_module
 
     @staticmethod
     def _narrow_dependency_tables(

--- a/src/dpmcore/services/scope_calculator.py
+++ b/src/dpmcore/services/scope_calculator.py
@@ -533,6 +533,24 @@ class ScopeCalculatorService:
         is_cross = scope_result.is_cross_module
         ts = time_shifts or {}
 
+        # #325: a ``time_shift`` over a table of the reporting module
+        # needs another *instance of that same module*, so the operation
+        # is not intra-instance and the shifted instance has to be
+        # declared like any other cross-instance dependency — under the
+        # home module's own URI and the shift's reference period.
+        # Without this the shift is silently dropped: the engine resolves
+        # both operands against the current instance and the script fails.
+        home_periods = (
+            self._home_shift_ref_periods(
+                ts=ts,
+                primary_module_vid=primary_module_vid,
+                release_id=release_id,
+                home_module_tables=home_module_tables,
+            )
+            if not scope_result.has_error
+            else []
+        )
+
         # Issue #120: when the primary module can evaluate the operation
         # on its own (it appears as a single-module scope), prefer the
         # intra-instance reading even if cross-instance scopes also exist
@@ -560,19 +578,38 @@ class ScopeCalculatorService:
                     release_id=release_id,
                     valid_module_uris=set(),
                 )
+            # A shifted home table turns the intra claim into a
+            # cross-instance dependency on the home module itself (#325).
+            # The primary still has to own a single-module scope: a module
+            # hosting none of the referenced tables is neither the
+            # intra-instance owner nor the shifted instance's reporter.
+            self_deps = (
+                self._build_home_instance_deps(
+                    periods=home_periods,
+                    primary_module_vid=primary_module_vid,
+                    operation_code=operation_code,
+                )
+                if primary_has_intra
+                else []
+            )
             # The intra claim needs the primary to actually own a
             # single-module scope. Keying it off ``not is_cross`` instead
             # declared intra for a module that participates in no scope at
             # all — it hosts none of the referenced tables (#141). That was
             # masked while a redundant superset scope kept ``is_cross``
             # true; dropping those scopes (#304) exposes it.
+            # ``not self_deps`` rather than ``not home_periods``: when the
+            # shifted instance cannot be declared (no resolvable URI) the
+            # operation keeps its intra classification instead of being
+            # dropped from the script's dependency block entirely.
             return {
                 **empty_result,
                 "intra_instance_validations": (
                     [operation_code]
-                    if operation_code and primary_has_intra
+                    if operation_code and primary_has_intra and not self_deps
                     else []
                 ),
+                "cross_instance_dependencies": self_deps,
                 "alternative_dependencies": alternative_deps,
             }
 
@@ -636,6 +673,18 @@ class ScopeCalculatorService:
             cross_deps.append(cross_dep)
             dep_modules[uri] = dep_module
 
+        # A cross-module operation can shift a home table too, and that
+        # shifted home instance is a dependency of its own (#325). It is
+        # appended after the external ones so their order — and the entry
+        # every existing caller reads first — stays unchanged.
+        cross_deps.extend(
+            self._build_home_instance_deps(
+                periods=home_periods,
+                primary_module_vid=primary_module_vid,
+                operation_code=operation_code,
+            )
+        )
+
         alternative_deps = (
             self.detect_alternative_dependencies(
                 scope_results=[scope_result],
@@ -652,6 +701,106 @@ class ScopeCalculatorService:
             "cross_instance_dependencies": cross_deps,
             "alternative_dependencies": alternative_deps,
             "dependency_modules": dep_modules,
+        }
+
+    def _home_shift_ref_periods(
+        self,
+        ts: Dict[str, str],
+        primary_module_vid: int,
+        release_id: Optional[int],
+        home_module_tables: Optional[Set[str]] = None,
+    ) -> List[str]:
+        """Return the reference periods shifted *within* the home module.
+
+        ``ts`` maps table codes to reference periods. A table owned by
+        the primary (home) module and shifted away from ``"T"`` means the
+        operation reads another instance of the reporting module itself
+        (#325), which is a cross-instance dependency the script has to
+        declare — the reference period never reached the output before,
+        because it was only ever read off a *dependency* module's tables.
+
+        One entry per distinct period, sorted for determinism: a single
+        operation shifting two home tables by different amounts needs
+        both instances, and the schema carries a period per declared
+        module rather than per table.
+        """
+        shifted = {tcode: rp for tcode, rp in ts.items() if rp and rp != "T"}
+        if not shifted:
+            return []
+        # Only pay for the table lookup once a shift is actually present.
+        tables = home_module_tables
+        if tables is None:
+            tables = set(
+                self._get_module_tables(
+                    primary_module_vid, release_id=release_id
+                ).keys()
+            )
+        return sorted({rp for tcode, rp in shifted.items() if tcode in tables})
+
+    def _build_home_instance_deps(
+        self,
+        periods: List[str],
+        primary_module_vid: int,
+        operation_code: Optional[str],
+    ) -> List[Dict[str, Any]]:
+        """Build the cross-instance entries for shifted home instances.
+
+        Each period yields one entry naming the home module's own URI —
+        the same URI the script is published under — so the engine knows
+        which instance to load for the shifted operand (#325). No
+        ``dependency_modules`` entry accompanies it: the home module's
+        tables and variables are already declared at the top level of
+        the script, and the shifted instance is the same module version.
+        """
+        if not periods:
+            return []
+        mv = (
+            self.session.query(ModuleVersion)
+            .filter(ModuleVersion.module_vid == primary_module_vid)
+            .first()
+        )
+        uri = self._get_module_uri(module_vid=primary_module_vid, mv=mv)
+        if not uri:
+            return []
+        return [
+            self._cross_dep_entry(
+                uri=uri,
+                ref_period=period,
+                mv=mv,
+                operation_code=operation_code,
+            )
+            for period in periods
+        ]
+
+    @staticmethod
+    def _cross_dep_entry(
+        uri: str,
+        ref_period: str,
+        mv: Any,
+        operation_code: Optional[str],
+    ) -> Dict[str, Any]:
+        """Build one ``cross_instance_dependencies`` entry for *uri*.
+
+        The reference dates are the declared module version's own
+        window, and ``module_version`` is omitted when the row carries
+        no version number.
+        """
+        module_entry: Dict[str, Any] = {
+            "URI": uri,
+            "ref_period": ref_period,
+        }
+        version_number = getattr(mv, "version_number", None)
+        if version_number:
+            module_entry["module_version"] = version_number
+        from_date = getattr(mv, "from_reference_date", None)
+        to_date = getattr(mv, "to_reference_date", None)
+        return {
+            "modules": [module_entry],
+            "affected_operations": (
+                [operation_code] if operation_code else []
+            ),
+            "from_reference_date": (str(from_date) if from_date else ""),
+            "to_reference_date": (str(to_date) if to_date else ""),
         }
 
     def _build_dependency_entry(
@@ -733,23 +882,12 @@ class ScopeCalculatorService:
                 if tcode not in home_module_tables
             }
 
-        module_entry: Dict[str, Any] = {
-            "URI": uri,
-            "ref_period": ref_period,
-        }
-        if mv.version_number:
-            module_entry["module_version"] = mv.version_number
-
-        from_date = mv.from_reference_date
-        to_date = mv.to_reference_date
-        cross_dep = {
-            "modules": [module_entry],
-            "affected_operations": (
-                [operation_code] if operation_code else []
-            ),
-            "from_reference_date": (str(from_date) if from_date else ""),
-            "to_reference_date": (str(to_date) if to_date else ""),
-        }
+        cross_dep = self._cross_dep_entry(
+            uri=uri,
+            ref_period=ref_period,
+            mv=mv,
+            operation_code=operation_code,
+        )
         variables: Dict[str, str] = {
             k: v
             for tbl in tables_dict.values()

--- a/src/dpmcore/services/scope_calculator.py
+++ b/src/dpmcore/services/scope_calculator.py
@@ -80,6 +80,13 @@ class ScopeCalculatorService:
         """Build the service bound to ``session``."""
         self.session = session
         self._syntax = SyntaxService()
+        # ``(ModuleVersion, URI)`` per module VID, for the home module of
+        # a script. ``detect_cross_module_dependencies`` runs once per
+        # operation with a fixed ``primary_module_vid``, so resolving it
+        # inside repeats the same row fetch and URI resolution for every
+        # operation that shifts a home table. Both are keyed by VID
+        # alone and neither varies with the release being generated.
+        self._home_module_refs: Dict[int, Tuple[Any, Optional[str]]] = {}
 
     def _check_release_exists(self, release_id: Optional[int]) -> None:
         """Raise SemanticError if *release_id* does not exist."""
@@ -751,15 +758,26 @@ class ScopeCalculatorService:
         ``dependency_modules`` entry accompanies it: the home module's
         tables and variables are already declared at the top level of
         the script, and the shifted instance is the same module version.
+
+        The module version and its URI are memoised in
+        ``_home_module_refs``: the caller iterates this once per
+        operation with the same ``primary_module_vid``.
         """
         if not periods:
             return []
-        mv = (
-            self.session.query(ModuleVersion)
-            .filter(ModuleVersion.module_vid == primary_module_vid)
-            .first()
-        )
-        uri = self._get_module_uri(module_vid=primary_module_vid, mv=mv)
+        cached = self._home_module_refs.get(primary_module_vid)
+        if cached is None:
+            mv = (
+                self.session.query(ModuleVersion)
+                .filter(ModuleVersion.module_vid == primary_module_vid)
+                .first()
+            )
+            cached = (
+                mv,
+                self._get_module_uri(module_vid=primary_module_vid, mv=mv),
+            )
+            self._home_module_refs[primary_module_vid] = cached
+        mv, uri = cached
         if not uri:
             return []
         return [

--- a/tests/integration/services/test_home_instance_shift.py
+++ b/tests/integration/services/test_home_instance_shift.py
@@ -1,0 +1,92 @@
+"""Integration regression: ``time_shift`` over a home-module table (#325).
+
+A validation that shifts a table of the module the script is generated for
+needs another instance of *that* module. It is therefore not
+intra-instance, and the shifted instance must be declared under the
+module's own URI with the shift's reference period — before #325 the
+validation was declared intra with no dependency at all, and the computed
+reference period never reached the output because it was only ever read
+off a dependency module's tables.
+
+Both real forms are covered: the shifted table named inline, and the
+shifted table inherited from a ``with`` clause.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import text
+
+from dpmcore.services.ast_generator import ASTGeneratorService
+
+_MODULE_CODE = "FINREP9"
+_MODULE_VERSION = "3.3.0"
+
+# Both validations shift a FINREP9 table by one year:
+# v1313_m names it inline — ``{tF_46.00, ...} = time_shift({tF_01.03,
+# ...}, A, 1, refPeriod)`` — and v1226_m inherits ``tF_46.00`` from its
+# ``with`` clause, so the shifted operand only resolves to a table after
+# semantic enrichment.
+_INLINE_CODE = "v1313_m"
+_WITH_CLAUSE_CODE = "v1226_m"
+_EXPECTED_REF_PERIOD = "T-1A"
+
+
+def _latest_expression(session, code: str) -> str:
+    operation_id = session.execute(
+        text("SELECT OperationID FROM Operation WHERE Code = :c"),
+        {"c": code},
+    ).scalar()
+    assert operation_id is not None, f"{code} not in fixture DB"
+    expression = session.execute(
+        text(
+            "SELECT Expression FROM OperationVersion "
+            "WHERE OperationID = :o ORDER BY OperationVID DESC LIMIT 1"
+        ),
+        {"o": operation_id},
+    ).scalar()
+    assert expression is not None, f"{code} has no expression in fixture DB"
+    return expression
+
+
+def _script(session, code: str) -> tuple[str, dict]:
+    expression = _latest_expression(session, code)
+    assert "time_shift" in expression, f"{code} must shift an operand"
+    result = ASTGeneratorService(session).script(
+        expressions=[(expression, code)],
+        module_code=_MODULE_CODE,
+        module_version=_MODULE_VERSION,
+    )
+    assert result["success"], result["error"]
+    assert not result["failed_operations"], result["failed_operations"]
+    namespace = next(iter(result["enriched_ast"]))
+    return namespace, result["enriched_ast"][namespace]
+
+
+@pytest.mark.parametrize("code", [_INLINE_CODE, _WITH_CLAUSE_CODE])
+def test_home_shift_is_declared_as_a_cross_instance_dependency(
+    fixture_session, code
+):
+    namespace, module = _script(fixture_session, code)
+    info = module["dependency_information"]
+
+    assert info["intra_instance_validations"] == []
+    assert len(info["cross_instance_dependencies"]) == 1
+    dependency = info["cross_instance_dependencies"][0]
+    assert dependency["affected_operations"] == [code]
+    assert dependency["modules"] == [
+        {
+            "URI": namespace,
+            "ref_period": _EXPECTED_REF_PERIOD,
+            "module_version": _MODULE_VERSION,
+        }
+    ]
+
+
+@pytest.mark.parametrize("code", [_INLINE_CODE, _WITH_CLAUSE_CODE])
+def test_home_module_is_not_declared_as_a_dependency_module(
+    fixture_session, code
+):
+    """The home module's tables and variables are already at the top level."""
+    namespace, module = _script(fixture_session, code)
+    assert namespace not in module["dependency_modules"]

--- a/tests/integration/services/test_multi_period_dependencies.py
+++ b/tests/integration/services/test_multi_period_dependencies.py
@@ -1,0 +1,151 @@
+"""Integration regression: one module needed at several instances (#326).
+
+The reference period is a property of a declared module and only one was
+kept per module, so an operation reading two tables of the same
+dependency module at different instances — or one table both plain and
+shifted — was declared against a single instance and evaluated against
+the wrong one. Every distinct period is now its own
+``cross_instance_dependencies`` entry.
+
+A shift number that is not an integer literal used to render as
+``T-nQ``, which names no resolvable instance; the operation is now
+skipped with a reason instead.
+
+``C_47.00`` is a COREP_LR table (the home module here) and ``C_01.00`` /
+``C_05.01`` are COREP_OF tables, so each expression crosses into a real
+dependency module of the fixture dictionary.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dpmcore.services.ast_generator import ASTGeneratorService
+
+_MODULE_CODE = "COREP_LR"
+_MODULE_VERSION = "3.1.0"
+_DEPENDENCY = "corep_of"
+
+_SHIFT_Q1 = (
+    "{tC_47.00, r0310, c0010} > "
+    "time_shift({tC_01.00, r0020, c0010}, Q, -1, refPeriod)[get refPeriod]"
+)
+_SHIFT_Q4 = (
+    "{tC_47.00, r0370, c0010} > "
+    "time_shift({tC_01.00, r0030, c0010}, Q, -4, refPeriod)[get refPeriod]"
+)
+# One expression shifting two tables of the same dependency module by
+# different amounts: reachable without any merging of operations.
+_TWO_TABLES = (
+    "{tC_47.00, r0310, c0010} > "
+    "time_shift({tC_01.00, r0020, c0010}, Q, -1, refPeriod)[get refPeriod] and "
+    "{tC_47.00, r0370, c0010} > "
+    "time_shift({tC_05.01, r0010, c0010}, Q, -4, refPeriod)[get refPeriod]"
+)
+# One expression reading the same dependency table shifted and plain.
+_SHIFTED_AND_PLAIN = (
+    "{tC_47.00, r0310, c0010} > "
+    "time_shift({tC_01.00, r0020, c0010}, Q, -1, refPeriod)[get refPeriod] and "
+    "{tC_47.00, r0370, c0010} = {tC_01.00, r0020, c0010}"
+)
+_NON_LITERAL_SHIFT = (
+    "{tC_47.00, r0310, c0010} > "
+    "time_shift({tC_01.00, r0020, c0010}, Q, 2 * 2, refPeriod)[get refPeriod]"
+)
+
+
+def _script(session, expressions):
+    result = ASTGeneratorService(session).script(
+        expressions=expressions,
+        module_code=_MODULE_CODE,
+        module_version=_MODULE_VERSION,
+    )
+    assert result["success"], result["error"]
+    module = next(iter(result["enriched_ast"].values()))
+    return result, module
+
+
+def _declared(module):
+    """The ``(module code, ref_period, affected operations)`` triples."""
+    return [
+        (
+            entry["URI"].rsplit("/", 1)[-1],
+            entry["ref_period"],
+            tuple(dependency["affected_operations"]),
+        )
+        for dependency in module["dependency_information"][
+            "cross_instance_dependencies"
+        ]
+        for entry in dependency["modules"]
+    ]
+
+
+def test_two_shifted_tables_of_one_module_declare_both_instances(
+    fixture_session,
+):
+    _, module = _script(fixture_session, [(_TWO_TABLES, "OP_BOTH")])
+    assert _declared(module) == [
+        (_DEPENDENCY, "T+1Q", ("OP_BOTH",)),
+        (_DEPENDENCY, "T+4Q", ("OP_BOTH",)),
+    ]
+
+
+def test_a_table_read_shifted_and_plain_declares_both_instances(
+    fixture_session,
+):
+    """The plain operand used to be sent to the shifted instance."""
+    _, module = _script(fixture_session, [(_SHIFTED_AND_PLAIN, "OP_MIX")])
+    assert _declared(module) == [
+        (_DEPENDENCY, "T", ("OP_MIX",)),
+        (_DEPENDENCY, "T+1Q", ("OP_MIX",)),
+    ]
+
+
+def test_the_declared_instances_do_not_depend_on_input_order(fixture_session):
+    """Whichever operation came first used to fix the period for both."""
+    _, forward = _script(
+        fixture_session, [(_SHIFT_Q1, "OP_Q1"), (_SHIFT_Q4, "OP_Q4")]
+    )
+    _, reverse = _script(
+        fixture_session, [(_SHIFT_Q4, "OP_Q4"), (_SHIFT_Q1, "OP_Q1")]
+    )
+    assert sorted(_declared(forward)) == sorted(_declared(reverse))
+    assert sorted(_declared(forward)) == [
+        (_DEPENDENCY, "T+1Q", ("OP_Q1",)),
+        (_DEPENDENCY, "T+4Q", ("OP_Q4",)),
+    ]
+
+
+def test_the_dependency_module_is_declared_once(fixture_session):
+    """Two instances, one set of table and datapoint definitions."""
+    _, module = _script(fixture_session, [(_TWO_TABLES, "OP_BOTH")])
+    assert len(module["dependency_modules"]) == 1
+
+
+def test_a_non_literal_shift_skips_only_its_own_operation(fixture_session):
+    result, module = _script(
+        fixture_session,
+        [(_NON_LITERAL_SHIFT, "OP_BAD"), (_SHIFT_Q1, "OP_GOOD")],
+    )
+    assert list(result["failed_operations"]) == ["OP_BAD"]
+    assert "integer literal" in result["failed_operations"]["OP_BAD"]
+    assert "OP_BAD" not in module["operations"]
+    assert "OP_GOOD" in module["operations"]
+    assert _declared(module) == [(_DEPENDENCY, "T+1Q", ("OP_GOOD",))]
+
+
+@pytest.mark.parametrize(
+    ("shift", "expected"),
+    [("1", "T-1Q"), ("-1", "T+1Q"), ("4", "T-4Q"), ("-4", "T+4Q")],
+)
+def test_the_declared_period_inverts_the_shift_sign(
+    fixture_session, shift, expected
+):
+    """A forward and a backward shift used to report the same period."""
+    expression = (
+        "{tC_47.00, r0310, c0010} > "
+        f"time_shift({{tC_01.00, r0020, c0010}}, Q, {shift}, refPeriod)"
+        "[get refPeriod]"
+    )
+    _, module = _script(fixture_session, [(expression, "OP")])
+    assert _declared(module) == [(_DEPENDENCY, expected, ("OP",))]

--- a/tests/unit/services/test_ast_generator.py
+++ b/tests/unit/services/test_ast_generator.py
@@ -11,6 +11,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from dpmcore import errors
+
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
@@ -25,7 +27,6 @@ def _patch_orm(monkeypatch):
         "dpmcore.orm.rendering": MagicMock(),
         "dpmcore.orm.variables": MagicMock(),
         "dpmcore.orm.glossary": MagicMock(),
-        "dpmcore.errors": MagicMock(),
         "dpmcore.loaders": MagicMock(),
         "dpmcore.loaders.migration": MagicMock(),
         "dpmcore.dpm_xl.model_queries": MagicMock(),
@@ -909,6 +910,18 @@ class _FakeVarID:
 _FakeVarID.__name__ = "VarID"
 
 
+class _FakeBinOp:
+    """Two-operand node the AST template walks into generically."""
+
+    def __init__(self, left, right):
+        self.op = "and"
+        self.left = left
+        self.right = right
+
+
+_FakeBinOp.__name__ = "BinOp"
+
+
 class TestExtractTimeShifts:
     def test_empty_returns_empty(self):
         _, Cls, _ = _bare_svc()
@@ -920,7 +933,7 @@ class TestExtractTimeShifts:
 
         sn = Constant(type_="Integer", value=1)
         node = _FakeTimeShiftOp("Q", sn, _FakeVarID(table="T_01"))
-        assert Cls._extract_time_shifts(node) == {"T_01": "T-1Q"}
+        assert Cls._extract_time_shifts(node) == {"T_01": ["T-1Q"]}
 
     def test_negative_unary_shift_produces_T_plus(self):
         """The declared period inverts the shift: ``-2`` needs ``T+2Y``."""
@@ -929,10 +942,10 @@ class TestExtractTimeShifts:
 
         sn = UnaryOp(op="-", operand=Constant(type_="Integer", value=2))
         node = _FakeTimeShiftOp("Y", sn, _FakeVarID(table="T_02"))
-        assert Cls._extract_time_shifts(node) == {"T_02": "T+2Y"}
+        assert Cls._extract_time_shifts(node) == {"T_02": ["T+2Y"]}
 
-    def test_negative_unary_shift_of_an_expression_keeps_direction(self):
-        """A non-literal shift keeps its direction, not its size."""
+    def test_negated_non_literal_shift_is_rejected(self):
+        """A negated non-literal shift names no resolvable period."""
         _, Cls, _ = _bare_svc()
         from dpmcore.dpm_xl.ast.nodes import BinOp, Constant, UnaryOp
 
@@ -945,7 +958,9 @@ class TestExtractTimeShifts:
             ),
         )
         node = _FakeTimeShiftOp("Q", sn, _FakeVarID(table="T_04"))
-        assert Cls._extract_time_shifts(node) == {"T_04": "T+nQ"}
+        with pytest.raises(errors.SemanticError) as exc:
+            Cls._extract_time_shifts(node)
+        assert exc.value.code == "4-7-5"
 
     def test_var_without_table_ignored(self):
         _, Cls, _ = _bare_svc()
@@ -955,14 +970,88 @@ class TestExtractTimeShifts:
         node = _FakeTimeShiftOp("Q", sn, _FakeVarID(table=None))
         assert Cls._extract_time_shifts(node) == {}
 
+    def test_non_literal_shift_is_rejected(self):
+        """``2 * 2`` used to render as ``T-nQ``, which resolves to no
+        instance; the operation is now skipped instead (#326).
+        """
+        _, Cls, _ = _bare_svc()
+        from dpmcore.dpm_xl.ast.nodes import BinOp, Constant
+
+        sn = BinOp(
+            op="*",
+            left=Constant(type_="Integer", value=5),
+            right=Constant(type_="Integer", value=12),
+        )
+        node = _FakeTimeShiftOp("Q", sn, _FakeVarID(table="T_03"))
+        with pytest.raises(errors.SemanticError) as exc:
+            Cls._extract_time_shifts(node)
+        assert exc.value.code == "4-7-5"
+
+    def test_plain_reference_is_recorded_as_t(self):
+        """An unshifted table is recorded at ``T`` so a module read at
+        both the current and a shifted instance stays visible.
+        """
+        _, Cls, _ = _bare_svc()
+
+        assert Cls._extract_time_shifts(_FakeVarID(table="T_05")) == {
+            "T_05": ["T"]
+        }
+
+    def test_a_table_read_plain_and_shifted_keeps_both_periods(self):
+        _, Cls, _ = _bare_svc()
+        from dpmcore.dpm_xl.ast.nodes import Constant
+
+        sn = Constant(type_="Integer", value=1)
+        shifted = _FakeTimeShiftOp("Q", sn, _FakeVarID(table="T_06"))
+        node = _FakeBinOp(_FakeVarID(table="T_06"), shifted)
+        assert Cls._extract_time_shifts(node) == {"T_06": ["T", "T-1Q"]}
+
+    def test_a_table_shifted_twice_keeps_both_periods(self):
+        _, Cls, _ = _bare_svc()
+        from dpmcore.dpm_xl.ast.nodes import Constant
+
+        node = _FakeBinOp(
+            _FakeTimeShiftOp(
+                "Q", Constant(type_="Integer", value=1), _FakeVarID("T_07")
+            ),
+            _FakeTimeShiftOp(
+                "Q", Constant(type_="Integer", value=4), _FakeVarID("T_07")
+            ),
+        )
+        assert Cls._extract_time_shifts(node) == {"T_07": ["T-1Q", "T-4Q"]}
+
+    def test_the_shift_does_not_leak_past_the_operand(self):
+        """A plain table read after a shifted one stays at ``T``."""
+        _, Cls, _ = _bare_svc()
+        from dpmcore.dpm_xl.ast.nodes import Constant
+
+        node = _FakeBinOp(
+            _FakeTimeShiftOp(
+                "Q", Constant(type_="Integer", value=1), _FakeVarID("T_08")
+            ),
+            _FakeVarID(table="T_09"),
+        )
+        assert Cls._extract_time_shifts(node) == {
+            "T_08": ["T-1Q"],
+            "T_09": ["T"],
+        }
+
+    def test_a_zero_shift_is_no_shift(self):
+        _, Cls, _ = _bare_svc()
+        from dpmcore.dpm_xl.ast.nodes import Constant
+
+        sn = Constant(type_="Integer", value=0)
+        node = _FakeTimeShiftOp("Q", sn, _FakeVarID(table="T_10"))
+        assert Cls._extract_time_shifts(node) == {"T_10": ["T"]}
+
     def test_unary_plus_shift_keeps_its_size(self):
         """``+1`` is a UnaryOp, not a bare Constant: it still means 1."""
         _, Cls, _ = _bare_svc()
         from dpmcore.dpm_xl.ast.nodes import Constant, UnaryOp
 
         sn = UnaryOp(op="+", operand=Constant(type_="Integer", value=1))
-        node = _FakeTimeShiftOp("Q", sn, _FakeVarID(table="T_05"))
-        assert Cls._extract_time_shifts(node) == {"T_05": "T-1Q"}
+        node = _FakeTimeShiftOp("Q", sn, _FakeVarID(table="T_11"))
+        assert Cls._extract_time_shifts(node) == {"T_11": ["T-1Q"]}
 
     def test_parenthesised_shift_is_unwrapped(self):
         """``( -1 )`` parses as a ParExpr around the unary minus."""
@@ -974,8 +1063,8 @@ class TestExtractTimeShifts:
                 op="-", operand=Constant(type_="Integer", value=1)
             )
         )
-        node = _FakeTimeShiftOp("Q", sn, _FakeVarID(table="T_06"))
-        assert Cls._extract_time_shifts(node) == {"T_06": "T+1Q"}
+        node = _FakeTimeShiftOp("Q", sn, _FakeVarID(table="T_12"))
+        assert Cls._extract_time_shifts(node) == {"T_12": ["T+1Q"]}
 
     def test_negative_constant_renders_a_single_sign(self):
         """``(-1)`` is lexed as a negative Constant, not a unary minus."""
@@ -983,8 +1072,8 @@ class TestExtractTimeShifts:
         from dpmcore.dpm_xl.ast.nodes import Constant
 
         sn = Constant(type_="Integer", value=-1)
-        node = _FakeTimeShiftOp("Q", sn, _FakeVarID(table="T_07"))
-        assert Cls._extract_time_shifts(node) == {"T_07": "T+1Q"}
+        node = _FakeTimeShiftOp("Q", sn, _FakeVarID(table="T_13"))
+        assert Cls._extract_time_shifts(node) == {"T_13": ["T+1Q"]}
 
     def test_double_negation_shift_is_positive(self):
         _, Cls, _ = _bare_svc()
@@ -996,40 +1085,8 @@ class TestExtractTimeShifts:
                 op="-", operand=Constant(type_="Integer", value=1)
             ),
         )
-        node = _FakeTimeShiftOp("Q", sn, _FakeVarID(table="T_08"))
-        assert Cls._extract_time_shifts(node) == {"T_08": "T-1Q"}
-
-    def test_zero_shift_declares_no_period(self):
-        """A shift of 0 reads the current instance: nothing to declare."""
-        _, Cls, _ = _bare_svc()
-        from dpmcore.dpm_xl.ast.nodes import Constant
-
-        sn = Constant(type_="Integer", value=0)
-        node = _FakeTimeShiftOp("Q", sn, _FakeVarID(table="T_09"))
-        assert Cls._extract_time_shifts(node) == {}
-
-    def test_non_numeric_constant_shift_keeps_direction(self):
-        _, Cls, _ = _bare_svc()
-        from dpmcore.dpm_xl.ast.nodes import Constant, UnaryOp
-
-        sn = UnaryOp(
-            op="-", operand=Constant(type_="String", value="not-a-number")
-        )
-        node = _FakeTimeShiftOp("Q", sn, _FakeVarID(table="T_10"))
-        assert Cls._extract_time_shifts(node) == {"T_10": "T+nQ"}
-
-    def test_complex_expression_ast_node_shift(self):
-        _, Cls, _ = _bare_svc()
-        from dpmcore.dpm_xl.ast.nodes import BinOp, Constant
-
-        sn = BinOp(
-            op="*",
-            left=Constant(type_="Integer", value=5),
-            right=Constant(type_="Integer", value=12),
-        )
-        node = _FakeTimeShiftOp("Q", sn, _FakeVarID(table="T_03"))
-        result = Cls._extract_time_shifts(node)
-        assert result == {"T_03": "T-nQ"}
+        node = _FakeTimeShiftOp("Q", sn, _FakeVarID(table="T_14"))
+        assert Cls._extract_time_shifts(node) == {"T_14": ["T-1Q"]}
 
     def test_exception_returns_empty(self):
         _, Cls, _ = _bare_svc()
@@ -1228,6 +1285,44 @@ class TestScript:
         assert out["failed_operations"] == {
             "v1": "Grey cells {F_32.03.a, r0040, c0010} were found."
         }
+
+    def test_non_literal_shift_skips_op_preserves_others(self, monkeypatch):
+        """#326: a shift whose period cannot be declared skips that op.
+
+        Emitting the old ``T-nQ`` sent the operation to an instance no
+        engine can resolve, and failing the whole module would drop the
+        operations that are fine.
+        """
+        self._stub_serialize_ast(
+            monkeypatch,
+            {"class_name": "VarID", "table": "C_01.00", "data": []},
+        )
+        svc, *_ = self._build_svc()
+        svc._semantic.ast = "AST"
+
+        calls = iter(["bad", "ok", "ok"])
+
+        def _extract(ast):
+            if next(calls) == "bad":
+                raise errors.SemanticError("4-7-5")
+            return {"C_01.00": ["T"]}
+
+        monkeypatch.setattr(
+            type(svc), "_extract_time_shifts", staticmethod(_extract)
+        )
+
+        out = svc.script(
+            expressions=[("e_bad", "v1"), ("e2", "v2"), ("e3", "v3")],
+            module_code="MOD",
+            module_version="1.0",
+        )
+        assert out["success"] is True
+        ns = next(iter(out["enriched_ast"].values()))
+        # Skipped before any accumulation: no operation entry either.
+        assert "v1" not in ns["operations"]
+        assert {"v2", "v3"} <= set(ns["operations"])
+        assert list(out["failed_operations"]) == ["v1"]
+        assert "integer literal" in out["failed_operations"]["v1"]
 
     def test_scope_error_fails_generation(self, monkeypatch):
         """Regression for #122: a scope-calculation error must fail the

--- a/tests/unit/services/test_ast_generator.py
+++ b/tests/unit/services/test_ast_generator.py
@@ -922,13 +922,30 @@ class TestExtractTimeShifts:
         node = _FakeTimeShiftOp("Q", sn, _FakeVarID(table="T_01"))
         assert Cls._extract_time_shifts(node) == {"T_01": "T-1Q"}
 
-    def test_negative_unary_shift_produces_T_minus(self):
+    def test_negative_unary_shift_produces_T_plus(self):
+        """The declared period inverts the shift: ``-2`` needs ``T+2Y``."""
         _, Cls, _ = _bare_svc()
         from dpmcore.dpm_xl.ast.nodes import Constant, UnaryOp
 
         sn = UnaryOp(op="-", operand=Constant(type_="Integer", value=2))
         node = _FakeTimeShiftOp("Y", sn, _FakeVarID(table="T_02"))
-        assert Cls._extract_time_shifts(node) == {"T_02": "T-2Y"}
+        assert Cls._extract_time_shifts(node) == {"T_02": "T+2Y"}
+
+    def test_negative_unary_shift_of_an_expression_keeps_direction(self):
+        """A non-literal shift keeps its direction, not its size."""
+        _, Cls, _ = _bare_svc()
+        from dpmcore.dpm_xl.ast.nodes import BinOp, Constant, UnaryOp
+
+        sn = UnaryOp(
+            op="-",
+            operand=BinOp(
+                op="*",
+                left=Constant(type_="Integer", value=2),
+                right=Constant(type_="Integer", value=2),
+            ),
+        )
+        node = _FakeTimeShiftOp("Q", sn, _FakeVarID(table="T_04"))
+        assert Cls._extract_time_shifts(node) == {"T_04": "T+nQ"}
 
     def test_var_without_table_ignored(self):
         _, Cls, _ = _bare_svc()

--- a/tests/unit/services/test_ast_generator.py
+++ b/tests/unit/services/test_ast_generator.py
@@ -955,6 +955,69 @@ class TestExtractTimeShifts:
         node = _FakeTimeShiftOp("Q", sn, _FakeVarID(table=None))
         assert Cls._extract_time_shifts(node) == {}
 
+    def test_unary_plus_shift_keeps_its_size(self):
+        """``+1`` is a UnaryOp, not a bare Constant: it still means 1."""
+        _, Cls, _ = _bare_svc()
+        from dpmcore.dpm_xl.ast.nodes import Constant, UnaryOp
+
+        sn = UnaryOp(op="+", operand=Constant(type_="Integer", value=1))
+        node = _FakeTimeShiftOp("Q", sn, _FakeVarID(table="T_05"))
+        assert Cls._extract_time_shifts(node) == {"T_05": "T-1Q"}
+
+    def test_parenthesised_shift_is_unwrapped(self):
+        """``( -1 )`` parses as a ParExpr around the unary minus."""
+        _, Cls, _ = _bare_svc()
+        from dpmcore.dpm_xl.ast.nodes import Constant, ParExpr, UnaryOp
+
+        sn = ParExpr(
+            expression=UnaryOp(
+                op="-", operand=Constant(type_="Integer", value=1)
+            )
+        )
+        node = _FakeTimeShiftOp("Q", sn, _FakeVarID(table="T_06"))
+        assert Cls._extract_time_shifts(node) == {"T_06": "T+1Q"}
+
+    def test_negative_constant_renders_a_single_sign(self):
+        """``(-1)`` is lexed as a negative Constant, not a unary minus."""
+        _, Cls, _ = _bare_svc()
+        from dpmcore.dpm_xl.ast.nodes import Constant
+
+        sn = Constant(type_="Integer", value=-1)
+        node = _FakeTimeShiftOp("Q", sn, _FakeVarID(table="T_07"))
+        assert Cls._extract_time_shifts(node) == {"T_07": "T+1Q"}
+
+    def test_double_negation_shift_is_positive(self):
+        _, Cls, _ = _bare_svc()
+        from dpmcore.dpm_xl.ast.nodes import Constant, UnaryOp
+
+        sn = UnaryOp(
+            op="-",
+            operand=UnaryOp(
+                op="-", operand=Constant(type_="Integer", value=1)
+            ),
+        )
+        node = _FakeTimeShiftOp("Q", sn, _FakeVarID(table="T_08"))
+        assert Cls._extract_time_shifts(node) == {"T_08": "T-1Q"}
+
+    def test_zero_shift_declares_no_period(self):
+        """A shift of 0 reads the current instance: nothing to declare."""
+        _, Cls, _ = _bare_svc()
+        from dpmcore.dpm_xl.ast.nodes import Constant
+
+        sn = Constant(type_="Integer", value=0)
+        node = _FakeTimeShiftOp("Q", sn, _FakeVarID(table="T_09"))
+        assert Cls._extract_time_shifts(node) == {}
+
+    def test_non_numeric_constant_shift_keeps_direction(self):
+        _, Cls, _ = _bare_svc()
+        from dpmcore.dpm_xl.ast.nodes import Constant, UnaryOp
+
+        sn = UnaryOp(
+            op="-", operand=Constant(type_="String", value="not-a-number")
+        )
+        node = _FakeTimeShiftOp("Q", sn, _FakeVarID(table="T_10"))
+        assert Cls._extract_time_shifts(node) == {"T_10": "T+nQ"}
+
     def test_complex_expression_ast_node_shift(self):
         _, Cls, _ = _bare_svc()
         from dpmcore.dpm_xl.ast.nodes import BinOp, Constant

--- a/tests/unit/services/test_home_instance_shift.py
+++ b/tests/unit/services/test_home_instance_shift.py
@@ -81,7 +81,7 @@ class TestHomeShiftIsCrossInstance:
             scope_result=ScopeResult(scopes=[_scope([HOME])]),
             primary_module_vid=HOME,
             operation_code="EGDQ_0896",
-            time_shifts={"C_48.02": "T-1Q"},
+            time_shifts={"C_48.02": ["T-1Q"]},
         )
         assert info["intra_instance_validations"] == []
 
@@ -90,7 +90,7 @@ class TestHomeShiftIsCrossInstance:
             scope_result=ScopeResult(scopes=[_scope([HOME])]),
             primary_module_vid=HOME,
             operation_code="EGDQ_0896",
-            time_shifts={"C_48.02": "T-1Q"},
+            time_shifts={"C_48.02": ["T-1Q"]},
         )
         assert info["cross_instance_dependencies"] == [
             {
@@ -113,7 +113,7 @@ class TestHomeShiftIsCrossInstance:
             scope_result=ScopeResult(scopes=[_scope([HOME])]),
             primary_module_vid=HOME,
             operation_code="EGDQ_0896",
-            time_shifts={"C_48.02": "T-1Q"},
+            time_shifts={"C_48.02": ["T-1Q"]},
         )
         assert info["dependency_modules"] == {}
 
@@ -132,7 +132,7 @@ class TestHomeShiftIsCrossInstance:
             scope_result=ScopeResult(scopes=[_scope([HOME])]),
             primary_module_vid=HOME,
             operation_code="EGDQ_0896",
-            time_shifts={"C_48.02": "T"},
+            time_shifts={"C_48.02": ["T"]},
         )
         assert info["intra_instance_validations"] == ["EGDQ_0896"]
         assert info["cross_instance_dependencies"] == []
@@ -143,7 +143,7 @@ class TestHomeShiftIsCrossInstance:
             scope_result=ScopeResult(scopes=[_scope([HOME])]),
             primary_module_vid=HOME,
             operation_code="EGDQ_0896",
-            time_shifts={"T_20": "T-1Q"},
+            time_shifts={"T_20": ["T-1Q"]},
         )
         assert info["intra_instance_validations"] == ["EGDQ_0896"]
         assert info["cross_instance_dependencies"] == []
@@ -157,7 +157,7 @@ class TestHomeShiftIsCrossInstance:
             scope_result=ScopeResult(scopes=[_scope([HOME])]),
             primary_module_vid=HOME,
             operation_code="EGDQ_0896",
-            time_shifts={"C_48.02": "T-1Q"},
+            time_shifts={"C_48.02": ["T-1Q"]},
             home_module_tables={"C_48.02"},
         )
         assert (
@@ -175,7 +175,7 @@ class TestHomeShiftIsCrossInstance:
             scope_result=ScopeResult(scopes=[_scope([HOME])]),
             primary_module_vid=HOME,
             operation_code="OP_BOTH",
-            time_shifts={"C_48.02": "T-1Q", "C_47.00": "T-4Q"},
+            time_shifts={"C_48.02": ["T-1Q"], "C_47.00": ["T-4Q"]},
         )
         periods = [
             m["ref_period"]
@@ -193,7 +193,7 @@ class TestHomeShiftIsCrossInstance:
             scope_result=ScopeResult(scopes=[_scope([HOME])]),
             primary_module_vid=HOME,
             operation_code="EGDQ_0896",
-            time_shifts={"C_48.02": "T-1Q"},
+            time_shifts={"C_48.02": ["T-1Q"]},
         )
         assert info["cross_instance_dependencies"][0]["modules"] == [
             {"URI": "uri/10", "ref_period": "T-1Q"}
@@ -206,7 +206,7 @@ class TestHomeShiftIsCrossInstance:
             scope_result=ScopeResult(scopes=[_scope([HOME])]),
             primary_module_vid=HOME,
             operation_code="EGDQ_0896",
-            time_shifts={"C_48.02": "T-1Q"},
+            time_shifts={"C_48.02": ["T-1Q"]},
         )
         assert info["intra_instance_validations"] == ["EGDQ_0896"]
         assert info["cross_instance_dependencies"] == []
@@ -216,7 +216,7 @@ class TestHomeShiftIsCrossInstance:
             scope_result=ScopeResult(has_error=True, error_message="boom"),
             primary_module_vid=HOME,
             operation_code="EGDQ_0896",
-            time_shifts={"C_48.02": "T-1Q"},
+            time_shifts={"C_48.02": ["T-1Q"]},
         )
         assert info["intra_instance_validations"] == []
         assert info["cross_instance_dependencies"] == []
@@ -227,7 +227,7 @@ class TestHomeShiftIsCrossInstance:
             scope_result=ScopeResult(scopes=[_scope([EXTERNAL])]),
             primary_module_vid=HOME,
             operation_code="EGDQ_0896",
-            time_shifts={"C_48.02": "T-1Q"},
+            time_shifts={"C_48.02": ["T-1Q"]},
         )
         assert info["intra_instance_validations"] == []
         assert info["cross_instance_dependencies"] == []
@@ -244,7 +244,7 @@ class TestHomeShiftAlongsideExternalDependency:
             ),
             primary_module_vid=HOME,
             operation_code="X_BOTH",
-            time_shifts={"C_48.02": "T-1Q"},
+            time_shifts={"C_48.02": ["T-1Q"]},
         )
         assert info["intra_instance_validations"] == []
         declared = [

--- a/tests/unit/services/test_home_instance_shift.py
+++ b/tests/unit/services/test_home_instance_shift.py
@@ -1,0 +1,274 @@
+"""A ``time_shift`` over a table of the reporting module (#325).
+
+The shifted operand needs another instance of the home module itself, so
+the operation is not intra-instance: the shifted instance has to be
+declared in ``cross_instance_dependencies`` under the home module's own
+URI, carrying the shift's reference period. Before #325 the operation was
+declared intra with no dependency at all, and the computed reference
+period — correct internally — was only ever read off a *dependency*
+module's tables, so it never reached the output.
+
+Imports the service normally (as ``test_prefer_intra`` does) instead of
+the legacy ORM-stubbing shim used elsewhere in the suite.
+"""
+
+from datetime import date
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from dpmcore.services import scope_calculator as sc_mod
+from dpmcore.services.scope_calculator import (
+    ScopeCalculatorService,
+    ScopeResult,
+)
+
+pytestmark = pytest.mark.unit
+
+HOME = 10
+EXTERNAL = 20
+
+
+def _scope(module_vids):
+    """A scope whose compositions cover *module_vids*."""
+    return SimpleNamespace(
+        operation_scope_compositions=[
+            SimpleNamespace(module_vid=v) for v in module_vids
+        ]
+    )
+
+
+def _mv(module_vid, version_number="3.1.0"):
+    return SimpleNamespace(
+        module_vid=module_vid,
+        version_number=version_number,
+        from_reference_date=date(2022, 12, 31),
+        to_reference_date=date(2025, 3, 30),
+    )
+
+
+@pytest.fixture
+def svc(monkeypatch):
+    """Service whose home module (10) owns C_48.02 and an external (20) T_20."""
+    monkeypatch.setattr(
+        sc_mod,
+        "resolve_release_id",
+        lambda session, release_id=None, release_code=None: release_id,
+    )
+    service = ScopeCalculatorService(MagicMock())
+    service._get_module_uri = lambda module_vid, mv=None: f"uri/{module_vid}"
+    tables = {
+        HOME: {"C_48.02": {"variables": {"v1": "m"}, "open_keys": {}}},
+        EXTERNAL: {"T_20": {"variables": {"v2": "m"}, "open_keys": {}}},
+    }
+    service._get_module_tables = lambda module_vid, release_id=None: tables[
+        module_vid
+    ]
+    query = service.session.query.return_value
+    # ``_build_home_instance_deps`` resolves the home module version;
+    # ``detect_cross_module_dependencies`` resolves the dependency ones.
+    query.filter.return_value.first.return_value = _mv(HOME)
+    query.filter.return_value.all.return_value = [_mv(EXTERNAL, "1.0.0")]
+    return service
+
+
+class TestHomeShiftIsCrossInstance:
+    """The reported case: a single-module scope with a shifted home table."""
+
+    def test_shifted_home_table_is_not_intra(self, svc):
+        info = svc.detect_cross_module_dependencies(
+            scope_result=ScopeResult(scopes=[_scope([HOME])]),
+            primary_module_vid=HOME,
+            operation_code="EGDQ_0896",
+            time_shifts={"C_48.02": "T-1Q"},
+        )
+        assert info["intra_instance_validations"] == []
+
+    def test_shifted_home_instance_is_declared(self, svc):
+        info = svc.detect_cross_module_dependencies(
+            scope_result=ScopeResult(scopes=[_scope([HOME])]),
+            primary_module_vid=HOME,
+            operation_code="EGDQ_0896",
+            time_shifts={"C_48.02": "T-1Q"},
+        )
+        assert info["cross_instance_dependencies"] == [
+            {
+                "modules": [
+                    {
+                        "URI": "uri/10",
+                        "ref_period": "T-1Q",
+                        "module_version": "3.1.0",
+                    }
+                ],
+                "affected_operations": ["EGDQ_0896"],
+                "from_reference_date": "2022-12-31",
+                "to_reference_date": "2025-03-30",
+            }
+        ]
+
+    def test_home_module_is_not_a_dependency_module(self, svc):
+        """Its tables and variables are declared at the script's top level."""
+        info = svc.detect_cross_module_dependencies(
+            scope_result=ScopeResult(scopes=[_scope([HOME])]),
+            primary_module_vid=HOME,
+            operation_code="EGDQ_0896",
+            time_shifts={"C_48.02": "T-1Q"},
+        )
+        assert info["dependency_modules"] == {}
+
+    def test_unshifted_operation_stays_intra(self, svc):
+        info = svc.detect_cross_module_dependencies(
+            scope_result=ScopeResult(scopes=[_scope([HOME])]),
+            primary_module_vid=HOME,
+            operation_code="EGDQ_0896",
+        )
+        assert info["intra_instance_validations"] == ["EGDQ_0896"]
+        assert info["cross_instance_dependencies"] == []
+
+    def test_ref_period_t_is_not_a_shift(self, svc):
+        """``T`` is the default reference period, not a shifted instance."""
+        info = svc.detect_cross_module_dependencies(
+            scope_result=ScopeResult(scopes=[_scope([HOME])]),
+            primary_module_vid=HOME,
+            operation_code="EGDQ_0896",
+            time_shifts={"C_48.02": "T"},
+        )
+        assert info["intra_instance_validations"] == ["EGDQ_0896"]
+        assert info["cross_instance_dependencies"] == []
+
+    def test_shift_on_a_table_the_home_does_not_own_is_ignored(self, svc):
+        """An external module's shift belongs to that module's entry."""
+        info = svc.detect_cross_module_dependencies(
+            scope_result=ScopeResult(scopes=[_scope([HOME])]),
+            primary_module_vid=HOME,
+            operation_code="EGDQ_0896",
+            time_shifts={"T_20": "T-1Q"},
+        )
+        assert info["intra_instance_validations"] == ["EGDQ_0896"]
+        assert info["cross_instance_dependencies"] == []
+
+    def test_caller_supplied_home_tables_are_used(self, svc):
+        """The pre-computed set spares the per-table lookup (script path)."""
+        svc._get_module_tables = MagicMock(
+            side_effect=AssertionError("should not be queried")
+        )
+        info = svc.detect_cross_module_dependencies(
+            scope_result=ScopeResult(scopes=[_scope([HOME])]),
+            primary_module_vid=HOME,
+            operation_code="EGDQ_0896",
+            time_shifts={"C_48.02": "T-1Q"},
+            home_module_tables={"C_48.02"},
+        )
+        assert (
+            info["cross_instance_dependencies"][0]["modules"][0]["ref_period"]
+            == "T-1Q"
+        )
+
+    def test_two_distinct_home_shifts_are_both_declared(self, svc):
+        """One entry per distinct period — the schema has no per-table one."""
+        svc._get_module_tables = lambda module_vid, release_id=None: {
+            "C_48.02": {"variables": {"v1": "m"}, "open_keys": {}},
+            "C_47.00": {"variables": {"v2": "m"}, "open_keys": {}},
+        }
+        info = svc.detect_cross_module_dependencies(
+            scope_result=ScopeResult(scopes=[_scope([HOME])]),
+            primary_module_vid=HOME,
+            operation_code="OP_BOTH",
+            time_shifts={"C_48.02": "T-1Q", "C_47.00": "T-4Q"},
+        )
+        periods = [
+            m["ref_period"]
+            for dep in info["cross_instance_dependencies"]
+            for m in dep["modules"]
+        ]
+        assert periods == ["T-1Q", "T-4Q"]
+
+    def test_module_version_omitted_when_the_row_has_none(self, svc):
+        """A version-less module version declares only URI and period."""
+        svc.session.query.return_value.filter.return_value.first.return_value = _mv(  # noqa: E501
+            HOME, version_number=None
+        )
+        info = svc.detect_cross_module_dependencies(
+            scope_result=ScopeResult(scopes=[_scope([HOME])]),
+            primary_module_vid=HOME,
+            operation_code="EGDQ_0896",
+            time_shifts={"C_48.02": "T-1Q"},
+        )
+        assert info["cross_instance_dependencies"][0]["modules"] == [
+            {"URI": "uri/10", "ref_period": "T-1Q"}
+        ]
+
+    def test_unresolvable_uri_keeps_the_intra_classification(self, svc):
+        """Better a wrong-but-present classification than no entry at all."""
+        svc._get_module_uri = lambda module_vid, mv=None: None
+        info = svc.detect_cross_module_dependencies(
+            scope_result=ScopeResult(scopes=[_scope([HOME])]),
+            primary_module_vid=HOME,
+            operation_code="EGDQ_0896",
+            time_shifts={"C_48.02": "T-1Q"},
+        )
+        assert info["intra_instance_validations"] == ["EGDQ_0896"]
+        assert info["cross_instance_dependencies"] == []
+
+    def test_scope_error_declares_nothing(self, svc):
+        info = svc.detect_cross_module_dependencies(
+            scope_result=ScopeResult(has_error=True, error_message="boom"),
+            primary_module_vid=HOME,
+            operation_code="EGDQ_0896",
+            time_shifts={"C_48.02": "T-1Q"},
+        )
+        assert info["intra_instance_validations"] == []
+        assert info["cross_instance_dependencies"] == []
+
+    def test_module_hosting_no_referenced_table_declares_nothing(self, svc):
+        """No scope of its own: neither intra owner nor shifted reporter."""
+        info = svc.detect_cross_module_dependencies(
+            scope_result=ScopeResult(scopes=[_scope([EXTERNAL])]),
+            primary_module_vid=HOME,
+            operation_code="EGDQ_0896",
+            time_shifts={"C_48.02": "T-1Q"},
+        )
+        assert info["intra_instance_validations"] == []
+        assert info["cross_instance_dependencies"] == []
+
+
+class TestHomeShiftAlongsideExternalDependency:
+    """A genuinely cross-module operation that also shifts a home table."""
+
+    def test_external_and_home_instances_are_both_declared(self, svc):
+        info = svc.detect_cross_module_dependencies(
+            scope_result=ScopeResult(
+                scopes=[_scope([HOME, EXTERNAL])],
+                is_cross_module=True,
+            ),
+            primary_module_vid=HOME,
+            operation_code="X_BOTH",
+            time_shifts={"C_48.02": "T-1Q"},
+        )
+        assert info["intra_instance_validations"] == []
+        declared = [
+            (m["URI"], m["ref_period"])
+            for dep in info["cross_instance_dependencies"]
+            for m in dep["modules"]
+        ]
+        # The external entry keeps its position: callers reading the
+        # first entry see the same module they saw before #325.
+        assert declared == [("uri/20", "T"), ("uri/10", "T-1Q")]
+        assert set(info["dependency_modules"]) == {"uri/20"}
+
+    def test_external_dependency_alone_is_unchanged(self, svc):
+        info = svc.detect_cross_module_dependencies(
+            scope_result=ScopeResult(
+                scopes=[_scope([HOME, EXTERNAL])],
+                is_cross_module=True,
+            ),
+            primary_module_vid=HOME,
+            operation_code="X_CROSS",
+        )
+        declared = [
+            (m["URI"], m["ref_period"])
+            for dep in info["cross_instance_dependencies"]
+            for m in dep["modules"]
+        ]
+        assert declared == [("uri/20", "T")]

--- a/tests/unit/services/test_home_instance_shift.py
+++ b/tests/unit/services/test_home_instance_shift.py
@@ -272,3 +272,63 @@ class TestHomeShiftAlongsideExternalDependency:
             for m in dep["modules"]
         ]
         assert declared == [("uri/20", "T")]
+
+
+class TestHomeModuleResolutionIsMemoised:
+    """The home module is resolved once, not once per operation.
+
+    ``detect_cross_module_dependencies`` runs per operation with a fixed
+    ``primary_module_vid``, so the row fetch and URI resolution behind
+    the shifted home instance repeated for every shifting operation in
+    a script.
+    """
+
+    def test_repeated_operations_resolve_the_home_module_once(self, svc):
+        resolver = MagicMock(
+            side_effect=lambda module_vid, mv=None: f"uri/{module_vid}"
+        )
+        svc._get_module_uri = resolver
+        declared = []
+        for code in ("OP_1", "OP_2", "OP_3"):
+            info = svc.detect_cross_module_dependencies(
+                scope_result=ScopeResult(scopes=[_scope([HOME])]),
+                primary_module_vid=HOME,
+                operation_code=code,
+                time_shifts={"C_48.02": "T-1Q"},
+            )
+            declared.append(info["cross_instance_dependencies"])
+        assert resolver.call_count == 1
+        # Memoising must not change what is declared: same entry every
+        # time, only the operation it affects differs.
+        assert [d[0]["modules"] for d in declared] == [
+            [
+                {
+                    "URI": "uri/10",
+                    "ref_period": "T-1Q",
+                    "module_version": "3.1.0",
+                }
+            ]
+        ] * 3
+        assert [d[0]["affected_operations"] for d in declared] == [
+            ["OP_1"],
+            ["OP_2"],
+            ["OP_3"],
+        ]
+
+    def test_a_different_home_module_is_resolved_on_its_own(self, svc):
+        resolver = MagicMock(
+            side_effect=lambda module_vid, mv=None: f"uri/{module_vid}"
+        )
+        svc._get_module_uri = resolver
+        for vid, table in ((HOME, "C_48.02"), (EXTERNAL, "T_20")):
+            info = svc.detect_cross_module_dependencies(
+                scope_result=ScopeResult(scopes=[_scope([vid])]),
+                primary_module_vid=vid,
+                operation_code="OP",
+                time_shifts={table: "T-1Q"},
+            )
+            assert (
+                info["cross_instance_dependencies"][0]["modules"][0]["URI"]
+                == f"uri/{vid}"
+            )
+        assert resolver.call_count == 2

--- a/tests/unit/services/test_multi_period_dependencies.py
+++ b/tests/unit/services/test_multi_period_dependencies.py
@@ -1,0 +1,173 @@
+"""One dependency module needed at more than one instance (#326).
+
+The reference period is a property of a declared *module*, and only one
+was kept per module: the last shifted table of the dependency won, so an
+operation reading two tables of the same module at different instances —
+or one table both plain and shifted — was declared against a single
+instance and evaluated against the wrong one. Nothing downstream could
+detect the loss, because the script stayed structurally valid.
+
+Every distinct period is now declared as its own
+``cross_instance_dependencies`` entry, which is the shape the schema
+allows: it carries a period per declared module, not per table.
+
+Follows ``test_home_instance_shift`` in importing the service normally
+rather than through the legacy ORM-stubbing shim.
+"""
+
+from datetime import date
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from dpmcore.services import scope_calculator as sc_mod
+from dpmcore.services.scope_calculator import (
+    ScopeCalculatorService,
+    ScopeResult,
+)
+
+pytestmark = pytest.mark.unit
+
+HOME = 10
+EXTERNAL = 20
+
+
+def _scope(module_vids):
+    return SimpleNamespace(
+        operation_scope_compositions=[
+            SimpleNamespace(module_vid=v) for v in module_vids
+        ]
+    )
+
+
+def _mv(module_vid, version_number="3.1.0"):
+    return SimpleNamespace(
+        module_vid=module_vid,
+        version_number=version_number,
+        from_reference_date=date(2022, 12, 31),
+        to_reference_date=date(2025, 3, 30),
+    )
+
+
+@pytest.fixture
+def svc(monkeypatch):
+    """Home (10) owns C_47.00; the external module (20) owns two tables."""
+    monkeypatch.setattr(
+        sc_mod,
+        "resolve_release_id",
+        lambda session, release_id=None, release_code=None: release_id,
+    )
+    service = ScopeCalculatorService(MagicMock())
+    service._get_module_uri = lambda module_vid, mv=None: f"uri/{module_vid}"
+    tables = {
+        HOME: {"C_47.00": {"variables": {"v1": "m"}, "open_keys": {}}},
+        EXTERNAL: {
+            "C_01.00": {"variables": {"v2": "m"}, "open_keys": {}},
+            "C_05.01": {"variables": {"v3": "m"}, "open_keys": {}},
+        },
+    }
+    service._get_module_tables = lambda module_vid, release_id=None: tables[
+        module_vid
+    ]
+    query = service.session.query.return_value
+    query.filter.return_value.first.return_value = _mv(HOME)
+    query.filter.return_value.all.return_value = [_mv(EXTERNAL, "1.0.0")]
+    return service
+
+
+def _periods(info):
+    """The (URI, ref_period) pairs declared, in declared order."""
+    return [
+        (m["URI"], m["ref_period"])
+        for dep in info["cross_instance_dependencies"]
+        for m in dep["modules"]
+    ]
+
+
+def _cross(svc, time_shifts, operation_code="OP"):
+    return svc.detect_cross_module_dependencies(
+        scope_result=ScopeResult(
+            scopes=[_scope([HOME, EXTERNAL])], is_cross_module=True
+        ),
+        primary_module_vid=HOME,
+        operation_code=operation_code,
+        time_shifts=time_shifts,
+    )
+
+
+class TestOneModuleAtSeveralPeriods:
+    def test_two_tables_shifted_differently_declare_both(self, svc):
+        """The issue's single-expression case: no merging is involved."""
+        info = _cross(svc, {"C_01.00": ["T-1Q"], "C_05.01": ["T-4Q"]})
+        assert _periods(info) == [
+            (f"uri/{EXTERNAL}", "T-1Q"),
+            (f"uri/{EXTERNAL}", "T-4Q"),
+        ]
+
+    def test_a_table_read_plain_and_shifted_declares_both(self, svc):
+        info = _cross(svc, {"C_01.00": ["T", "T-1Q"]})
+        assert _periods(info) == [
+            (f"uri/{EXTERNAL}", "T"),
+            (f"uri/{EXTERNAL}", "T-1Q"),
+        ]
+
+    def test_a_table_shifted_twice_declares_both(self, svc):
+        info = _cross(svc, {"C_01.00": ["T-1Q", "T-4Q"]})
+        assert _periods(info) == [
+            (f"uri/{EXTERNAL}", "T-1Q"),
+            (f"uri/{EXTERNAL}", "T-4Q"),
+        ]
+
+    def test_a_shifted_and_a_plain_table_declare_both(self, svc):
+        info = _cross(svc, {"C_01.00": ["T-1Q"], "C_05.01": ["T"]})
+        assert _periods(info) == [
+            (f"uri/{EXTERNAL}", "T"),
+            (f"uri/{EXTERNAL}", "T-1Q"),
+        ]
+
+    def test_declaration_order_does_not_follow_visit_order(self, svc):
+        """The same shifts in the opposite mapping order declare the same."""
+        forward = _periods(
+            _cross(svc, {"C_01.00": ["T-1Q"], "C_05.01": ["T-4Q"]})
+        )
+        reverse = _periods(
+            _cross(svc, {"C_05.01": ["T-4Q"], "C_01.00": ["T-1Q"]})
+        )
+        assert forward == reverse
+
+    def test_every_entry_lists_the_operation(self, svc):
+        info = _cross(svc, {"C_01.00": ["T-1Q"], "C_05.01": ["T-4Q"]})
+        assert [
+            dep["affected_operations"]
+            for dep in info["cross_instance_dependencies"]
+        ] == [["OP"], ["OP"]]
+
+    def test_the_module_is_declared_once_in_dependency_modules(self, svc):
+        """Table and datapoint definitions do not vary by instance."""
+        info = _cross(svc, {"C_01.00": ["T-1Q"], "C_05.01": ["T-4Q"]})
+        assert list(info["dependency_modules"]) == [f"uri/{EXTERNAL}"]
+
+
+class TestUnshiftedIsUnchanged:
+    def test_no_shifts_declares_a_single_t_entry(self, svc):
+        info = _cross(svc, {})
+        assert _periods(info) == [(f"uri/{EXTERNAL}", "T")]
+
+    def test_a_shift_on_an_unrelated_table_is_ignored(self, svc):
+        """A table no declared module owns contributes no period."""
+        info = _cross(svc, {"T_99": ["T-1Q"]})
+        assert _periods(info) == [(f"uri/{EXTERNAL}", "T")]
+
+
+class TestLegacyStringShape:
+    """A bare string is one period, not a sequence of characters."""
+
+    def test_string_value_is_read_as_a_single_period(self, svc):
+        info = _cross(svc, {"C_01.00": "T-1Q"})
+        assert _periods(info) == [(f"uri/{EXTERNAL}", "T-1Q")]
+
+    def test_string_value_matches_the_list_form(self, svc):
+        assert _periods(_cross(svc, {"C_01.00": "T-1Q"})) == _periods(
+            _cross(svc, {"C_01.00": ["T-1Q"]})
+        )

--- a/tests/unit/services/test_scope_calculator.py
+++ b/tests/unit/services/test_scope_calculator.py
@@ -924,7 +924,7 @@ class TestDetectCrossModuleDependencies:
         info = svc.detect_cross_module_dependencies(
             scope_result=sr,
             primary_module_vid=10,
-            time_shifts={"C_01.00": "T-1Q"},
+            time_shifts={"C_01.00": ["T-1Q"]},
         )
         dep = info["cross_instance_dependencies"][0]
         assert dep["modules"][0]["ref_period"] == "T-1Q"


### PR DESCRIPTION
## Summary

Fixes #326. Stacked on #327 (cr-325), which settles the sign convention and the `(module URI, reference period)` dedup key.

Two problems remain after that branch, both reachable from a single expression:

**The reference period was kept per declared module**, so the last shifted table of a dependency won. An operation reading two tables of one module at different instances — or one table both plain and shifted — was declared against a single instance and evaluated against the wrong one, silently, in a script that stayed structurally valid.

| one operation reads | declared before | declared now |
| --- | --- | --- |
| two tables of one module, shifted `-1`/`-4` | `T+4Q` | `T+1Q` and `T+4Q` |
| one table, shifted `-1` and plain | `T+1Q` | `T` and `T+1Q` |
| one table, shifted `-1` and `-4` | `T+4Q` | `T+1Q` and `T+4Q` |
| one table shifted `-1`, another plain | `T+1Q` | `T` and `T+1Q` |

Every distinct period is now its own `cross_instance_dependencies` entry — the schema carries a period per declared module, not per table, so a module needed at two instances is declared twice. `dependency_modules` stays one entry per URI with the union of the tables; definitions do not vary by instance. Periods are sorted, so what is declared no longer depends on the order operands are visited in, and `T` sorts first.

The extraction feeding it now records the periods a table is read at rather than one period, and records unshifted reads as `T`. Without that, a module read at both the current and a shifted instance is indistinguishable from one read only at the shifted one.

**A shift number that is not an integer literal** rendered as `T-nQ`, which names no resolvable instance. The operation now goes to `failed_operations` with a reason and the rest of the script still generates. New message code `4-7-5`, beside the existing `4-7-4` on the same argument. `time_shift(x, Q, 0, …)` is no shift and keeps `T`.


## Checklist

- [X] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [X] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [ ] Documentation updated (if applicable)

## Impact / Risk

- Breaking changes? (public API / CLI / REST endpoints / Django models)
- Database schema or migration concerns?
- Notes for release/changelog?

## Notes

<!-- Follow-ups, TODOs, or anything reviewers should know. -->
