### PR TITLE
fix: resolve scripting `OperationRef` locally and expose `is_scripting`

### DIFF
--- a/src/dpmcore/dpm_xl/ast/operands.py
+++ b/src/dpmcore/dpm_xl/ast/operands.py
@@ -743,6 +743,10 @@ class OperandsChecking(ASTTemplate, ABC):
             raise errors.SemanticError(
                 "6-2", operation_code=node.operation_code
             )
+        if node.operation_code not in self.operations:
+            raise errors.SemanticError(
+                "1-8", operations=[node.operation_code]
+            )
 
     def visit_ParameterRef(self, node: ParameterRef) -> None:
         # Record the referenced parameter. No DB lookup: parameters are not DPM
@@ -760,20 +764,14 @@ class OperandsChecking(ASTTemplate, ABC):
         self.visit(node.right)
 
     def check_operations(self) -> None:
-        if len(self.operations):
-            df_operations = OperationQuery.get_operations_from_codes(
-                session=self.session,
-                operation_codes=self.operations,
-                release_id=self.release_id,
-            )
-            if len(df_operations.values) < len(self.operations):
-                not_found_operations = list(
-                    set(self.operations).difference(set(df_operations["Code"]))
-                )
-                raise errors.SemanticError(
-                    "1-8", operations=not_found_operations
-                )
-            self.operations_data = df_operations
+        # Enriches operations_data when names match real codes, never required
+        if not self.operations:
+            return
+        self.operations_data = OperationQuery.get_operations_from_codes(
+            session=self.session,
+            operation_codes=self.operations,
+            release_id=self.release_id,
+        )
 
 
 def extract_data_types(node: VarID, database_types: "pd.Series[Any]") -> None:

--- a/src/dpmcore/dpm_xl/ast/operands.py
+++ b/src/dpmcore/dpm_xl/ast/operands.py
@@ -744,9 +744,7 @@ class OperandsChecking(ASTTemplate, ABC):
                 "6-2", operation_code=node.operation_code
             )
         if node.operation_code not in self.operations:
-            raise errors.SemanticError(
-                "1-8", operations=[node.operation_code]
-            )
+            raise errors.SemanticError("1-8", operations=[node.operation_code])
 
     def visit_ParameterRef(self, node: ParameterRef) -> None:
         # Record the referenced parameter. No DB lookup: parameters are not DPM

--- a/src/dpmcore/services/dpm_xl.py
+++ b/src/dpmcore/services/dpm_xl.py
@@ -78,12 +78,16 @@ class DpmXlService:
         release_code: Optional[str] = None,
         *,
         precondition_expression: Optional[str] = None,
+        is_scripting: bool = False,
     ) -> SemanticValidationResult:
         """Full semantic validation, optionally gated (requires DB).
 
         ``precondition_expression`` is keyword-only and appended after the
         pre-existing arguments, so ``validate_semantic(expr, 5)`` still means
         ``release_id=5``.
+
+        ``is_scripting`` allows ``{oCODE}`` references to other rules'
+        ``:=`` names declared earlier in the same batch.
         """
         if self.semantic is None:
             raise RuntimeError("No database session provided.")
@@ -92,6 +96,7 @@ class DpmXlService:
             precondition_expression=precondition_expression,
             release_id=release_id,
             release_code=release_code,
+            is_scripting=is_scripting,
         )
         return {
             "is_valid": result.is_valid,

--- a/src/dpmcore/services/semantic.py
+++ b/src/dpmcore/services/semantic.py
@@ -238,6 +238,7 @@ class SemanticService:
         *,
         precondition_expression: Optional[str] = None,
         precondition_operation_vid: Optional[int] = None,
+        is_scripting: bool = False,
     ) -> SemanticResult:
         """Full semantic validation of *expression* and its optional gate.
 
@@ -289,6 +290,9 @@ class SemanticService:
                 current module scope when ``expression`` is valid
                 (``7-3``/``7-4``/``7-5``); a VID with nothing to check
                 against is accepted.
+            is_scripting: Allows ``{oCODE}`` references to other rules'
+                ``:=`` names declared earlier in the same batch. Applies
+                to ``expression`` only, not the precondition.
         """
         try:
             resolved = self._resolve_release(release_id, release_code)
@@ -303,7 +307,9 @@ class SemanticService:
             )
 
         if precondition_expression is None:
-            result = self._validate_resolved(expression, resolved)
+            result = self._validate_resolved(
+                expression, resolved, is_scripting=is_scripting
+            )
         else:
             # Gate first, main expression last: the trailing ``self.ast`` /
             # ``self.oc_*`` must describe the main expression (see
@@ -313,7 +319,9 @@ class SemanticService:
                     precondition_expression, resolved, as_precondition=True
                 )
             )
-            main = self._validate_resolved(expression, resolved)
+            main = self._validate_resolved(
+                expression, resolved, is_scripting=is_scripting
+            )
             result = self._combine(main, self._cross_check(main, precondition))
 
         if result.is_valid and precondition_operation_vid is not None:
@@ -365,6 +373,7 @@ class SemanticService:
         release_id: Optional[int],
         *,
         as_precondition: bool = False,
+        is_scripting: bool = False,
     ) -> SemanticResult:
         """Validate *expression* against an already-resolved release.
 
@@ -375,6 +384,8 @@ class SemanticService:
                 precondition gate, so the analyzer enforces a boolean result
                 (``2-1``) even though the expression itself contains no
                 precondition item.
+            is_scripting: Forwarded to ``OperandsChecking`` so ``{oCODE}``
+                references are allowed and resolved batch-locally.
         """
         try:
             with collect_warnings() as wc:
@@ -390,6 +401,7 @@ class SemanticService:
                     expression=expression,
                     ast=ast,
                     release_id=release_id,
+                    is_scripting=is_scripting,
                 )
                 self.oc_data = oc.data
                 self.oc_tables = oc.tables
@@ -583,6 +595,7 @@ class SemanticService:
         release_code: Optional[str] = None,
         *,
         precondition_expression: Optional[str] = None,
+        is_scripting: bool = False,
     ) -> bool:
         """Quick boolean check, pair-wide when a gate is supplied."""
         return self.validate(
@@ -590,6 +603,7 @@ class SemanticService:
             precondition_expression=precondition_expression,
             release_id=release_id,
             release_code=release_code,
+            is_scripting=is_scripting,
         ).is_valid
 
     # ------------------------------------------------------------------ #

--- a/tests/integration/services/test_semantic_scripting.py
+++ b/tests/integration/services/test_semantic_scripting.py
@@ -1,0 +1,64 @@
+"""``is_scripting`` wiring: a broken forward wouldn't show up in the unit
+tests, which stub ``_validate_resolved`` and never build a real
+``OperandsChecking``.
+"""
+
+from dpmcore.services.dpm_xl import DpmXlService
+from dpmcore.services.semantic import SemanticService
+
+_BATCH = "t1 := 1; t2 := {ot1} + 1;"
+
+
+def test_semantic_service_allows_scripting_operation_ref(fixture_session):
+    result = SemanticService(fixture_session).validate(
+        _BATCH, is_scripting=True
+    )
+    assert result.is_valid, result.error_message
+
+
+def test_semantic_service_rejects_operation_ref_without_scripting(
+    fixture_session,
+):
+    result = SemanticService(fixture_session).validate(_BATCH)
+    assert not result.is_valid
+    assert result.error_code == "6-2"
+
+
+def test_is_valid_forwards_is_scripting(fixture_session):
+    svc = SemanticService(fixture_session)
+    assert svc.is_valid(_BATCH, is_scripting=True)
+    assert not svc.is_valid(_BATCH)
+
+
+def test_dpm_xl_service_allows_scripting_operation_ref(fixture_session):
+    result = DpmXlService(fixture_session).validate_semantic(
+        _BATCH, is_scripting=True
+    )
+    assert result["is_valid"], result["error_message"]
+
+
+def test_dpm_xl_service_rejects_operation_ref_without_scripting(
+    fixture_session,
+):
+    result = DpmXlService(fixture_session).validate_semantic(_BATCH)
+    assert not result["is_valid"]
+    assert result["error_code"] == "6-2"
+
+
+def test_self_reference_is_still_rejected_despite_scripting(fixture_session):
+    # OperandsChecking alone would accept this self-reference; it's
+    # InputAnalyzer's dependency-order check (1-9) that actually rejects it.
+    result = SemanticService(fixture_session).validate(
+        "t1 := {ot1} + 1;", is_scripting=True
+    )
+    assert not result.is_valid
+    assert result.error_code == "1-9"
+
+
+def test_is_scripting_does_not_leak_into_the_precondition(fixture_session):
+    # is_scripting must not extend to the precondition gate.
+    result = SemanticService(fixture_session).validate(
+        _BATCH, precondition_expression="{ot1}", is_scripting=True
+    )
+    assert not result.precondition.is_valid
+    assert result.precondition.error_code == "6-2"

--- a/tests/unit/dpm_xl/test_operands_scripting.py
+++ b/tests/unit/dpm_xl/test_operands_scripting.py
@@ -1,0 +1,81 @@
+"""A ``TemporaryAssignment`` LHS (e.g. ``t1``) is a batch-local scratch name,
+not a persisted ``Operation.Code``: ``{oCODE}`` must resolve against other
+rules declared earlier in the same batch, no DB round trip required.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from dpmcore.dpm_xl.ast.operands import OperandsChecking
+from dpmcore.errors import SemanticError
+from dpmcore.services.syntax import SyntaxService
+
+
+def _empty_operations_df() -> pd.DataFrame:
+    return pd.DataFrame(columns=["OperationVID", "Code"])
+
+
+def _check(expression: str, is_scripting: bool) -> OperandsChecking:
+    ast = SyntaxService().parse(expression)
+    with patch(
+        "dpmcore.dpm_xl.ast.operands.OperationQuery.get_operations_from_codes",
+        return_value=_empty_operations_df(),
+    ):
+        return OperandsChecking(
+            session=MagicMock(),
+            expression=expression,
+            ast=ast,
+            release_id=None,
+            is_scripting=is_scripting,
+        )
+
+
+def test_operation_ref_is_rejected_outside_scripting_mode():
+    with pytest.raises(SemanticError) as exc_info:
+        _check("t2 := {ot1} + 1;", is_scripting=False)
+    assert exc_info.value.code == "6-2"
+
+
+def test_batch_local_scratch_name_needs_no_persisted_operation_code():
+    # t1 is not (and need not be) a real Operation.Code.
+    oc = _check("t1 := 1;", is_scripting=True)
+    assert oc.operations == ["t1"]
+
+
+def test_operation_ref_resolves_against_a_batch_local_name():
+    oc = _check("t1 := 1; t2 := {ot1} + 1;", is_scripting=True)
+    assert oc.operations == ["t1", "t2"]
+
+
+def test_operation_ref_to_an_undeclared_name_still_raises():
+    with pytest.raises(SemanticError) as exc_info:
+        _check("t2 := {otX} + 1;", is_scripting=True)
+    assert exc_info.value.code == "1-8"
+
+
+def test_operation_ref_cannot_forward_reference_a_later_name():
+    # t2 is declared after t1, so it isn't a valid reference yet.
+    with pytest.raises(SemanticError) as exc_info:
+        _check("t1 := {ot2} + 1; t2 := 1;", is_scripting=True)
+    assert exc_info.value.code == "1-8"
+
+
+def test_check_operations_enriches_operations_data_for_a_real_persisted_code():
+    expression = "t1 := 1;"
+    ast = SyntaxService().parse(expression)
+    real_match = pd.DataFrame({"OperationVID": [42], "Code": ["t1"]})
+    with patch(
+        "dpmcore.dpm_xl.ast.operands.OperationQuery.get_operations_from_codes",
+        return_value=real_match,
+    ):
+        oc = OperandsChecking(
+            session=MagicMock(),
+            expression=expression,
+            ast=ast,
+            release_id=None,
+            is_scripting=True,
+        )
+    assert oc.operations_data is not None
+    assert oc.operations_data["OperationVID"].tolist() == [42]

--- a/tests/unit/services/test_semantic_precondition.py
+++ b/tests/unit/services/test_semantic_precondition.py
@@ -55,7 +55,9 @@ def _stub(svc, monkeypatch, results=None, calls=None):
     """
     monkeypatch.setattr(svc, "_resolve_release", lambda *a, **k: 42)
 
-    def _validate_resolved(expression, release_id, *, as_precondition=False):
+    def _validate_resolved(
+        expression, release_id, *, as_precondition=False, is_scripting=False
+    ):
         if calls is not None:
             calls.append((expression, as_precondition, release_id))
         return (results or {}).get(expression) or _ok(expression)
@@ -281,7 +283,7 @@ class TestReleaseHandling:
         monkeypatch.setattr(
             svc,
             "_validate_resolved",
-            lambda expression, release_id, *, as_precondition=False: (
+            lambda expression, release_id, *, as_precondition=False, is_scripting=False: (
                 calls.append((expression, release_id)) or _ok(expression)
             ),
         )

--- a/tests/unit/services/test_semantic_precondition_link.py
+++ b/tests/unit/services/test_semantic_precondition_link.py
@@ -130,7 +130,9 @@ class TestLinkFailurePropagates:
         )
         monkeypatch.setattr(svc, "_resolve_release", lambda *a, **k: 42)
 
-        def _validate_resolved(expression, release_id, as_precondition=False):
+        def _validate_resolved(
+            expression, release_id, as_precondition=False, is_scripting=False
+        ):
             return gate_result if as_precondition else _ok("main")
 
         monkeypatch.setattr(svc, "_validate_resolved", _validate_resolved)


### PR DESCRIPTION
Closes #330 

## Summary

`is_scripting` existed internally but had no public entry point, and `OperandsChecking.check_operations()` unconditionally required every `TemporaryAssignment` left-hand side (e.g. `t1`) to be a persisted `Operation.Code`, raising `1-8` otherwise. 

This exposes `is_scripting` on `SemanticService.validate()`/`is_valid()` and `DpmXlService.validate_semantic()` (default to `False`), and makes `{oCODE}` resolve against the batch's own earlier-declared names instead of requiring a DB round trip

## Checklist

- [X] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [X] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [ ] Documentation updated (if applicable)

## Impact / Risk

- Breaking changes? (public API / CLI / REST endpoints / Django models)
- Database schema or migration concerns?
- Notes for release/changelog?

## Notes

<!-- Follow-ups, TODOs, or anything reviewers should know. -->
