### PR TITLE
feat: warn on comparisons against items outside a component's domain

### DIFF
--- a/src/dpmcore/dpm_xl/ast/domain_membership.py
+++ b/src/dpmcore/dpm_xl/ast/domain_membership.py
@@ -193,8 +193,11 @@ class DomainMembershipChecker(ASTTemplate):
         effect: str,
     ) -> None:
         reference, domains = component
-        item_domains = self._domains_of_items(literals)
-        for signature in literals:
+        # A set literal may repeat a member. The mismatch is one fact about
+        # the item, so it is reported once however often it is written.
+        signatures = list(dict.fromkeys(literals))
+        item_domains = self._domains_of_items(signatures)
+        for signature in signatures:
             found = item_domains.get(signature)
             # An item with no domain open at this release is reported as
             # not-found (1-1) before this pass runs; a set member the

--- a/src/dpmcore/dpm_xl/ast/domain_membership.py
+++ b/src/dpmcore/dpm_xl/ast/domain_membership.py
@@ -1,0 +1,331 @@
+"""Domain-membership check for comparisons against item literals.
+
+An enumerated component takes its values from exactly one *domain* (a
+``Category``). Comparing it with an item that belongs to a different domain is
+accepted by every other check -- the item exists (1-1) and ``Item`` is
+type-compatible with ``Item`` -- yet the comparison can never hold: ``=`` and
+``in`` are always false, ``!=`` is always true, and a ``sub`` clause on an
+out-of-domain item yields an empty recordset. The rule silently does something
+other than what it says.
+
+This pass reports that mismatch as a warning, not an error: EBA DPM 4.2.1
+ships operations that trip it (domain renames such as ``AS`` -> ``qAS`` leave
+legacy signatures behind in expressions that still validate clean), and those
+must keep validating.
+
+Domain resolution is the same for every component kind -- the component's
+property, then the category that property is typed on at the script's release.
+``Category.IsEnumerated`` is the gate: a property in a non-enumerated category
+(dates, identifiers, free text, "not applicable") describes no value set, so
+nothing is claimed about it. The dictionary offers nothing finer: the
+subcategory link on variable versions is unpopulated, so the check is domain
+membership and nothing more.
+
+The pass runs after semantic analysis has succeeded, so a genuine type error
+is reported on its own rather than alongside this warning.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Iterable
+
+from dpmcore.dpm_xl.ast.nodes import (
+    AST,
+    BinOp,
+    Dimension,
+    FilterOp,
+    GetOp,
+    ParExpr,
+    RenameOp,
+    Set,
+    SubAssignment,
+    SubOp,
+    TimeShiftOp,
+    VarID,
+    WhereClauseOp,
+)
+from dpmcore.dpm_xl.ast.nodes import (
+    Scalar as ScalarNode,
+)
+from dpmcore.dpm_xl.ast.template import ASTTemplate
+from dpmcore.dpm_xl.model_queries import (
+    ItemCategoryQuery,
+    PropertyCategoryQuery,
+    ViewOpenKeysQuery,
+)
+from dpmcore.dpm_xl.utils import tokens
+from dpmcore.dpm_xl.utils.operands_mapping import generate_operand_expression
+from dpmcore.dpm_xl.warning_collector import add_semantic_warning
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+# What an out-of-domain item does to each operator that accepts one.
+_EFFECTS: dict[str, str] = {
+    tokens.EQ: "the comparison is never true",
+    tokens.NEQ: "the comparison is always true",
+    tokens.IN: "this member of the set never matches",
+}
+
+_SUB_EFFECT = "the substitution matches no record"
+
+# Components whose structure carries the operand's Fact Component through
+# unchanged, so the domain of the result is the domain of the operand.
+_FACT_PRESERVING = (WhereClauseOp, RenameOp, TimeShiftOp, SubOp)
+
+
+def _unwrap(node: AST) -> AST:
+    """Strip redundant parentheses around *node*."""
+    while isinstance(node, ParExpr):
+        node = node.expression
+    return node
+
+
+def _item_literals(node: AST) -> list[str]:
+    """Return the item signatures *node* contributes as literals.
+
+    A set literal contributes one entry per item member: a set can be
+    partly dead, so each member is judged on its own. Members that are not
+    item literals (a parameter reference, a constant) carry no signature and
+    are simply not returned.
+    """
+    node = _unwrap(node)
+    if isinstance(node, ScalarNode) and node.scalar_type == "Item":
+        return [node.item]
+    if isinstance(node, Set):
+        return [
+            child.item
+            for child in map(_unwrap, node.children)
+            if isinstance(child, ScalarNode) and child.scalar_type == "Item"
+        ]
+    return []
+
+
+def _join(domains: Iterable[str]) -> str:
+    return ", ".join(sorted(domains))
+
+
+class DomainMembershipChecker(ASTTemplate):
+    """Warns on comparisons an item's domain makes impossible.
+
+    :parameter session: Session used to resolve domains.
+    :parameter ast: AST already enriched by ``OperandsChecking``.
+    :parameter release_id: Release the domains are resolved at.
+    """
+
+    def __init__(
+        self,
+        session: "Session",
+        ast: AST,
+        release_id: int | None,
+    ) -> None:
+        super().__init__()
+        self.session = session
+        self.release_id = release_id
+        # Operands of the clause operators currently being visited, innermost
+        # last, so a condition on the Fact Component ("f") resolves against
+        # the recordset the clause filters.
+        self._clause_operands: list[AST] = []
+        self._property_domains: dict[int, set[str]] = {}
+        self._item_domains: dict[str, set[str]] = {}
+        self._sub_property_ids: dict[str, int | None] = {}
+        self.visit(ast)
+
+    # -- traversal ------------------------------------------------- #
+
+    def visit_BinOp(self, node: BinOp) -> None:
+        effect = _EFFECTS.get(node.op) if node.op is not None else None
+        if effect is not None:
+            self._check_comparison(node, effect)
+        self.visit(node.left)
+        self.visit(node.right)
+
+    def visit_WhereClauseOp(self, node: WhereClauseOp) -> None:
+        self.visit(node.operand)
+        self._clause_operands.append(node.operand)
+        try:
+            self.visit(node.condition)
+        finally:
+            self._clause_operands.pop()
+
+    def visit_SubOp(self, node: SubOp) -> None:
+        self.visit(node.operand)
+        for substitution in node.substitutions:
+            self._check_substitution(substitution)
+            self.visit(substitution.value)
+
+    # -- checks ---------------------------------------------------- #
+
+    def _check_comparison(self, node: BinOp, effect: str) -> None:
+        """Report the members of a comparison the component can never take."""
+        for component_side, literal_side in (
+            (node.left, node.right),
+            (node.right, node.left),
+        ):
+            # Resolving the item literals first keeps the domain queries out
+            # of every comparison that has no item literal to judge.
+            literals = _item_literals(literal_side)
+            if not literals:
+                continue
+            component = self._component_domains(component_side)
+            if component is None:
+                continue
+            self._report(component, literals, effect)
+            return
+
+    def _check_substitution(self, substitution: SubAssignment) -> None:
+        """Report a ``sub`` clause value outside its target's domain."""
+        literals = _item_literals(substitution.value)
+        if not literals:
+            return
+        component = self._property_component(
+            substitution.property_code,
+            self._sub_property_id(substitution.property_code),
+        )
+        if component is None:
+            return
+        self._report(component, literals, _SUB_EFFECT)
+
+    def _report(
+        self,
+        component: tuple[str, set[str]],
+        literals: Iterable[str],
+        effect: str,
+    ) -> None:
+        reference, domains = component
+        item_domains = self._domains_of_items(literals)
+        for signature in literals:
+            found = item_domains.get(signature)
+            # An item with no domain open at this release is reported as
+            # not-found (1-1) before this pass runs; a set member the
+            # dictionary places in no enumerated category says nothing.
+            if not found or found & domains:
+                continue
+            add_semantic_warning(
+                f"Item [{signature}] belongs to domain {_join(found)}, "
+                f"but {reference} takes items from domain "
+                f"{_join(domains)}: {effect}."
+            )
+
+    # -- domain resolution ----------------------------------------- #
+
+    def _component_domains(self, node: AST) -> tuple[str, set[str]] | None:
+        """Return ``(component reference, domains)`` for *node*.
+
+        ``None`` whenever the domain cannot be pinned down -- an expression
+        that is not a component reference, a selection spanning a property
+        with no enumerated domain, an implicit open key.
+        """
+        node = _unwrap(node)
+        if isinstance(node, VarID):
+            return self._selection_domains(node)
+        if isinstance(node, Dimension):
+            return self._dimension_domains(node)
+        if isinstance(node, GetOp):
+            # ``[get X]`` promotes key component X to the Fact Component, so
+            # the result takes X's values, not the operand's.
+            return self._property_component(node.component, node.property_id)
+        if isinstance(node, _FACT_PRESERVING):
+            return self._component_domains(node.operand)
+        if isinstance(node, FilterOp):
+            return self._component_domains(node.selection)
+        return None
+
+    def _selection_domains(self, node: VarID) -> tuple[str, set[str]] | None:
+        """Domains of the Fact Component of a cell selection.
+
+        A selection can span several data points, each with its own variable
+        and so its own domain. The result is their union: an item is only
+        impossible when it belongs to none of them. A single data point
+        without an enumerated domain makes the whole selection unjudgeable.
+        """
+        data = getattr(node, "data", None)
+        if data is None or data.empty or "property_id" not in data.columns:
+            return None
+        properties = data["property_id"]
+        if properties.isnull().any():
+            # A data point with no variable is a grey cell and is rejected
+            # with 1-17 before this pass; one with no property is unjudgeable.
+            return None
+        property_ids = {int(value) for value in properties.unique()}
+        resolved = self._domains_of_properties(property_ids)
+        domains: set[str] = set()
+        for property_id in property_ids:
+            found = resolved.get(property_id)
+            if not found:
+                return None
+            domains |= found
+        return generate_operand_expression(node), domains
+
+    def _dimension_domains(
+        self, node: Dimension
+    ) -> tuple[str, set[str]] | None:
+        """Domains of an open key, or of the Fact Component for ``f``."""
+        if node.dimension_code == tokens.FACT:
+            if not self._clause_operands:
+                return None
+            return self._component_domains(self._clause_operands[-1])
+        return self._property_component(node.dimension_code, node.property_id)
+
+    def _property_component(
+        self, code: str, property_id: int | None
+    ) -> tuple[str, set[str]] | None:
+        """Domains of the component built on property *property_id*.
+
+        Implicit open keys (``refPeriod``, ``entityID``, ``baseCurrency``)
+        carry the sentinel ``-1`` and belong to no category.
+        """
+        if property_id is None or property_id < 0:
+            return None
+        domains = self._domains_of_properties([property_id]).get(property_id)
+        if not domains:
+            return None
+        return code, domains
+
+    def _sub_property_id(self, code: str) -> int | None:
+        """Resolve a ``sub`` clause target property code to its ID."""
+        if code not in self._sub_property_ids:
+            keys = ViewOpenKeysQuery.get_keys(
+                self.session, [code], self.release_id
+            )
+            matches = keys[keys["property_code"] == code]
+            self._sub_property_ids[code] = (
+                int(matches["property_id"].iloc[0])
+                if not matches.empty
+                else None
+            )
+        return self._sub_property_ids[code]
+
+    def _domains_of_properties(
+        self, property_ids: Iterable[int]
+    ) -> dict[int, set[str]]:
+        missing = [
+            property_id
+            for property_id in property_ids
+            if property_id not in self._property_domains
+        ]
+        if missing:
+            found = PropertyCategoryQuery.get_property_domains(
+                self.session, missing, self.release_id
+            )
+            for property_id in missing:
+                self._property_domains[property_id] = found.get(
+                    property_id, set()
+                )
+        return self._property_domains
+
+    def _domains_of_items(
+        self, signatures: Iterable[str]
+    ) -> dict[str, set[str]]:
+        missing = [
+            signature
+            for signature in signatures
+            if signature not in self._item_domains
+        ]
+        if missing:
+            found = ItemCategoryQuery.get_item_domains(
+                self.session, missing, self.release_id
+            )
+            for signature in missing:
+                self._item_domains[signature] = found.get(signature, set())
+        return self._item_domains

--- a/src/dpmcore/dpm_xl/model_queries.py
+++ b/src/dpmcore/dpm_xl/model_queries.py
@@ -29,9 +29,11 @@ from dpmcore.dpm_xl.utils.range_resolution import (
     resolve_range_codes,
 )
 from dpmcore.orm.glossary import (
+    Category,
     Item,
     ItemCategory,
     Property,
+    PropertyCategory,
 )
 from dpmcore.orm.infrastructure import (
     DataType,
@@ -313,6 +315,114 @@ class ItemCategoryQuery:
             .all()
         )
         return [r.item_id for r in rows]
+
+    @staticmethod
+    def get_item_domains(
+        session: "Session",
+        items: Sequence[str],
+        release_id: int | None = None,
+    ) -> dict[str, set[str]]:
+        """Map item signatures to the code(s) of the categories holding them.
+
+        The category is the item's *domain*: the set of values a component
+        typed on that category may take. Only enumerated categories are
+        returned -- a non-enumerated one (dates, identifiers, free text) is
+        not a value set. An item is normally in exactly one category per
+        release, but the mapping is release-versioned, so the value is a set.
+
+        Args:
+            session: SQLAlchemy session.
+            items: Item signatures to resolve.
+            release_id: Release the membership is resolved at.
+
+        Returns:
+            ``{signature: {category_code, ...}}``, omitting signatures with
+            no category open at ``release_id``.
+        """
+        if not items:
+            return {}
+        query = (
+            session.query(
+                ItemCategory.signature.label("Signature"),
+                Category.code.label("CategoryCode"),
+            )
+            .join(Category, Category.category_id == ItemCategory.category_id)
+            .filter(ItemCategory.signature.in_(items))
+            .filter(Category.is_enumerated == True)  # noqa: E712
+            .filter(Category.code.isnot(None))
+        )
+        query = filter_by_release(
+            query,
+            start_col=ItemCategory.start_release_id,
+            end_col=ItemCategory.end_release_id,
+            release_id=release_id,
+            active_only_fallback=True,
+        )
+        domains: dict[str, set[str]] = {}
+        for row in query.distinct().all():
+            domains.setdefault(row.Signature, set()).add(row.CategoryCode)
+        return domains
+
+
+# ------------------------------------------------------------------ #
+# PropertyCategory queries
+# ------------------------------------------------------------------ #
+
+
+class PropertyCategoryQuery:
+    """Query helpers around the PropertyCategory model."""
+
+    @staticmethod
+    def get_property_domains(
+        session: "Session",
+        property_ids: Sequence[int],
+        release_id: int | None = None,
+    ) -> dict[int, set[str]]:
+        """Map properties to the code(s) of the categories they are typed on.
+
+        A property's category is the domain of every component built on it:
+        the items that component may take. Only enumerated categories are
+        returned, so a property that holds dates, identifiers or free text
+        resolves to no domain at all. Like ``ItemCategory``, the link is
+        release-versioned, hence the set-valued result.
+
+        Args:
+            session: SQLAlchemy session.
+            property_ids: Property IDs to resolve.
+            release_id: Release the link is resolved at.
+
+        Returns:
+            ``{property_id: {category_code, ...}}``, omitting properties with
+            no category open at ``release_id``.
+        """
+        if not property_ids:
+            return {}
+        query = (
+            session.query(
+                PropertyCategory.property_id.label("PropertyID"),
+                Category.code.label("CategoryCode"),
+            )
+            .join(
+                Category,
+                Category.category_id == PropertyCategory.category_id,
+            )
+            .filter(PropertyCategory.property_id.in_(list(property_ids)))
+            .filter(Category.is_enumerated == True)  # noqa: E712
+            .filter(Category.code.isnot(None))
+        )
+        query = filter_by_release(
+            query,
+            start_col=PropertyCategory.start_release_id,
+            end_col=PropertyCategory.end_release_id,
+            release_id=release_id,
+            active_only_fallback=True,
+        )
+        domains: dict[int, set[str]] = {}
+        for row in query.distinct().all():
+            domains.setdefault(int(row.PropertyID), set()).add(
+                row.CategoryCode
+            )
+        return domains
 
 
 # ------------------------------------------------------------------ #
@@ -1813,6 +1923,7 @@ class ViewDatapointsQuery:
             aliases["tvh_col"].order.label("column_order"),
             aliases["tvh_sheet"].order.label("sheet_order"),
             VariableVersion.variable_id.label("variable_id"),
+            VariableVersion.property_id.label("property_id"),
             DataType.code.label("data_type"),
             TableVersion.table_vid.label("table_vid"),
             TableVersionCell.cell_id.label("cell_id"),

--- a/src/dpmcore/dpm_xl/model_queries.py
+++ b/src/dpmcore/dpm_xl/model_queries.py
@@ -201,6 +201,60 @@ def _filter_elements(
 
 
 # ------------------------------------------------------------------ #
+# Category-link domain resolution
+# ------------------------------------------------------------------ #
+
+
+def _enumerated_domains(
+    session: "Session",
+    model: Any,
+    key_col: Any,
+    keys: Sequence[Any],
+    release_id: int | None,
+) -> dict[Any, set[str]]:
+    """Map the keys of a category link table to enumerated category codes.
+
+    ``ItemCategory`` and ``PropertyCategory`` are the same shape: a
+    release-versioned link to ``Category``. Only enumerated categories are
+    returned -- a non-enumerated one (dates, identifiers, free text) is not
+    a value set. Both links are release-versioned, hence the set-valued
+    result.
+
+    Args:
+        session: SQLAlchemy session.
+        model: Link model holding ``category_id`` and the release columns.
+        key_col: Column of *model* the result is keyed on.
+        keys: Values of *key_col* to resolve.
+        release_id: Release the link is resolved at.
+
+    Returns:
+        ``{key: {category_code, ...}}``, omitting keys with no enumerated
+        category open at ``release_id``.
+    """
+    query = (
+        session.query(
+            key_col.label("DomainKey"),
+            Category.code.label("CategoryCode"),
+        )
+        .join(Category, Category.category_id == model.category_id)
+        .filter(key_col.in_(list(keys)))
+        .filter(Category.is_enumerated == True)  # noqa: E712
+        .filter(Category.code.isnot(None))
+    )
+    query = filter_by_release(
+        query,
+        start_col=model.start_release_id,
+        end_col=model.end_release_id,
+        release_id=release_id,
+        active_only_fallback=True,
+    )
+    domains: dict[Any, set[str]] = {}
+    for row in query.distinct().all():
+        domains.setdefault(row.DomainKey, set()).add(row.CategoryCode)
+    return domains
+
+
+# ------------------------------------------------------------------ #
 # ItemCategory queries
 # ------------------------------------------------------------------ #
 
@@ -341,27 +395,13 @@ class ItemCategoryQuery:
         """
         if not items:
             return {}
-        query = (
-            session.query(
-                ItemCategory.signature.label("Signature"),
-                Category.code.label("CategoryCode"),
-            )
-            .join(Category, Category.category_id == ItemCategory.category_id)
-            .filter(ItemCategory.signature.in_(items))
-            .filter(Category.is_enumerated == True)  # noqa: E712
-            .filter(Category.code.isnot(None))
+        return _enumerated_domains(
+            session,
+            ItemCategory,
+            ItemCategory.signature,
+            items,
+            release_id,
         )
-        query = filter_by_release(
-            query,
-            start_col=ItemCategory.start_release_id,
-            end_col=ItemCategory.end_release_id,
-            release_id=release_id,
-            active_only_fallback=True,
-        )
-        domains: dict[str, set[str]] = {}
-        for row in query.distinct().all():
-            domains.setdefault(row.Signature, set()).add(row.CategoryCode)
-        return domains
 
 
 # ------------------------------------------------------------------ #
@@ -397,32 +437,14 @@ class PropertyCategoryQuery:
         """
         if not property_ids:
             return {}
-        query = (
-            session.query(
-                PropertyCategory.property_id.label("PropertyID"),
-                Category.code.label("CategoryCode"),
-            )
-            .join(
-                Category,
-                Category.category_id == PropertyCategory.category_id,
-            )
-            .filter(PropertyCategory.property_id.in_(list(property_ids)))
-            .filter(Category.is_enumerated == True)  # noqa: E712
-            .filter(Category.code.isnot(None))
+        domains = _enumerated_domains(
+            session,
+            PropertyCategory,
+            PropertyCategory.property_id,
+            property_ids,
+            release_id,
         )
-        query = filter_by_release(
-            query,
-            start_col=PropertyCategory.start_release_id,
-            end_col=PropertyCategory.end_release_id,
-            release_id=release_id,
-            active_only_fallback=True,
-        )
-        domains: dict[int, set[str]] = {}
-        for row in query.distinct().all():
-            domains.setdefault(int(row.PropertyID), set()).add(
-                row.CategoryCode
-            )
-        return domains
+        return {int(key): codes for key, codes in domains.items()}
 
 
 # ------------------------------------------------------------------ #

--- a/src/dpmcore/services/semantic.py
+++ b/src/dpmcore/services/semantic.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, Callable, Optional, cast
 
 from sqlalchemy import func
 
+from dpmcore.dpm_xl.ast.domain_membership import DomainMembershipChecker
 from dpmcore.dpm_xl.ast.nodes import (
     AST,
     ParameterRef,
@@ -417,6 +418,13 @@ class SemanticService:
                 analyzer.release_id = release_id
 
                 results = analyzer.visit(ast)
+
+                # Runs last: a comparison against an item outside the
+                # component's domain is well-typed, so it only deserves a
+                # warning once the expression is otherwise valid.
+                DomainMembershipChecker(
+                    session=self.session, ast=ast, release_id=release_id
+                )
 
             if self.oc_parameters:
                 self._check_persisted_scope(

--- a/tests/integration/services/test_domain_membership.py
+++ b/tests/integration/services/test_domain_membership.py
@@ -1,0 +1,152 @@
+"""Out-of-domain item comparisons against the real dictionary (#332).
+
+Every domain named below is measured against the shipped DPM 4.2.1 fixture,
+not hand-built. At release ``4.2.1``:
+
+* ``{tC_14.00, c0060}`` takes items from ``qPO``, ``c0061`` from ``qST`` and
+  ``c0160`` from ``qTU`` -- so ``eba_PL:x72`` (``PL``), ``eba_RT:x14``
+  (``RT``) and ``eba_UE:x23`` (``UE``) are all impossible there, which is what
+  the shipped ``v7368_m`` and ``v7364_m`` do.
+* ``{tF_00.01, r0010, c0010}`` takes items from ``qAS`` while the pre-refit
+  ``eba_AS:x2`` is still in ``AS`` -- the domain rename that five more shipped
+  operations were never updated for.
+* ``C_09.01.a`` has the enumerated open key ``CEG``, whose domain is ``GA``.
+* ``{tF_40.01, c0095}`` takes items from ``qSR``.
+
+The warning must never become an error: the operations above ship in 4.2.1 and
+have to keep validating.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dpmcore.services.semantic import SemanticService
+
+RELEASE = "4.2.1"
+
+MARKER = "takes items from domain"
+
+
+@pytest.fixture
+def semantic(fixture_session):
+    return SemanticService(fixture_session)
+
+
+def _domain_warnings(semantic, expression):
+    result = semantic.validate(expression, release_code=RELEASE)
+    assert result.is_valid, result.error_message
+    return [
+        line for line in (result.warning or "").splitlines() if MARKER in line
+    ]
+
+
+class TestShippedOperations:
+    """The 4.2.1 operations the issue was raised from."""
+
+    def test_v7368_m_reports_its_dead_set_member_and_inequality(
+        self, semantic
+    ):
+        expression = (
+            "with {tC_14.00, interval: true}:"
+            "if ( {c0060} in { [eba_qPO:qx2001], [eba_PL:x72] }"
+            "     and {c0171} >= 0.95"
+            "     and {c0061} != [eba_RT:x14] )"
+            "then not( isnull({c0222}) )endif"
+        )
+
+        warnings = _domain_warnings(semantic, expression)
+
+        assert len(warnings) == 2
+        dead_member = next(w for w in warnings if "eba_PL:x72" in w)
+        assert "domain PL" in dead_member
+        assert "domain qPO" in dead_member
+        assert "this member of the set never matches" in dead_member
+        always_true = next(w for w in warnings if "eba_RT:x14" in w)
+        assert "domain qST" in always_true
+        assert "the comparison is always true" in always_true
+
+    def test_v7364_m_reports_both_members_of_an_unmatchable_set(
+        self, semantic
+    ):
+        expression = (
+            "with {tC_14.00, default: null, interval: false}: "
+            "if ( {c0446} = true ) then "
+            "( ({c0040} in { [eba_qST:qx2020], [eba_qST:qx2019], "
+            "[eba_qST:qx2018] } or ({c0040} = [eba_qST:qx2005] and "
+            "{c0160} in { [eba_qFI:qx2370], [eba_UE:x23] } )) ) endif"
+        )
+
+        warnings = _domain_warnings(semantic, expression)
+
+        # c0040 is qST, so the three qST members are silent; c0160 is qTU, so
+        # both of its members are impossible.
+        assert len(warnings) == 2
+        assert all("domain qTU" in w for w in warnings)
+        assert any("eba_qFI:qx2370" in w for w in warnings)
+        assert any("eba_UE:x23" in w for w in warnings)
+
+    def test_the_pre_refit_accounting_standard_rename_is_reported(
+        self, semantic
+    ):
+        expression = "{tF_00.01, r0010, c0010} = [eba_AS:x2]"
+
+        (warning,) = _domain_warnings(semantic, expression)
+
+        assert "domain AS" in warning
+        assert "domain qAS" in warning
+        assert "{ tF_00.01, r0010, c0010 }" in warning
+
+    def test_the_refit_item_for_the_same_cell_is_silent(self, semantic):
+        expression = "{tF_00.01, r0010, c0010} = [eba_qAS:qx2000]"
+
+        assert _domain_warnings(semantic, expression) == []
+
+
+class TestComponentKinds:
+    def test_an_open_key_in_a_where_clause_is_checked(self, semantic):
+        expression = "{tC_09.01.a, r0010, c0010}[where CEG = [eba_CU:EUR]]"
+
+        (warning,) = _domain_warnings(semantic, expression)
+
+        assert "but CEG takes items from domain GA" in warning
+        assert "domain CU" in warning
+
+    def test_an_open_key_holding_the_item_is_silent(self, semantic):
+        expression = "{tC_09.01.a, r0010, c0010}[where CEG = [eba_GA:AT]]"
+
+        assert _domain_warnings(semantic, expression) == []
+
+    def test_a_sub_clause_value_is_checked(self, semantic):
+        expression = "{tC_09.01.a, r0010, c0010}[sub CEG = [eba_CU:EUR]]"
+
+        (warning,) = _domain_warnings(semantic, expression)
+
+        assert "the substitution matches no record" in warning
+
+    def test_a_get_clause_checks_the_promoted_key(self, semantic):
+        expression = "{tC_09.01.a, r0010, c0010}[get CEG] = [eba_CU:EUR]"
+
+        (warning,) = _domain_warnings(semantic, expression)
+
+        assert "but CEG takes items from domain GA" in warning
+
+    def test_the_fact_component_inside_a_where_clause_is_checked(
+        self, semantic
+    ):
+        expression = (
+            "{tF_40.01, c0095}[where f in {[eba_CT:x12], [eba_CT:x18]}]"
+        )
+
+        warnings = _domain_warnings(semantic, expression)
+
+        assert len(warnings) == 2
+        assert all("domain qSR" in w for w in warnings)
+
+    def test_a_non_enumerated_component_is_never_judged(self, semantic):
+        """``refPeriod`` is a date, not a member of any domain."""
+        expression = (
+            '{tC_09.01.a, r0010, c0010}[where refPeriod = "2026-12-31"]'
+        )
+
+        assert _domain_warnings(semantic, expression) == []

--- a/tests/unit/dpm_xl/test_domain_queries.py
+++ b/tests/unit/dpm_xl/test_domain_queries.py
@@ -4,15 +4,21 @@ Both helpers are asked for the signatures/properties a single expression
 mentions, so an empty request is normal; it must not reach the database.
 """
 
+from unittest.mock import MagicMock
+
 from dpmcore.dpm_xl.model_queries import (
     ItemCategoryQuery,
     PropertyCategoryQuery,
 )
 
 
-def test_no_items_needs_no_session():
-    assert ItemCategoryQuery.get_item_domains(None, []) == {}
+def test_no_items_does_not_query():
+    session = MagicMock()
+    assert ItemCategoryQuery.get_item_domains(session, []) == {}
+    session.query.assert_not_called()
 
 
-def test_no_properties_needs_no_session():
-    assert PropertyCategoryQuery.get_property_domains(None, []) == {}
+def test_no_properties_does_not_query():
+    session = MagicMock()
+    assert PropertyCategoryQuery.get_property_domains(session, []) == {}
+    session.query.assert_not_called()

--- a/tests/unit/dpm_xl/test_domain_queries.py
+++ b/tests/unit/dpm_xl/test_domain_queries.py
@@ -1,0 +1,18 @@
+"""Empty-input guards on the domain lookups (issue #332).
+
+Both helpers are asked for the signatures/properties a single expression
+mentions, so an empty request is normal; it must not reach the database.
+"""
+
+from dpmcore.dpm_xl.model_queries import (
+    ItemCategoryQuery,
+    PropertyCategoryQuery,
+)
+
+
+def test_no_items_needs_no_session():
+    assert ItemCategoryQuery.get_item_domains(None, []) == {}
+
+
+def test_no_properties_needs_no_session():
+    assert PropertyCategoryQuery.get_property_domains(None, []) == {}

--- a/tests/unit/semantic/test_domain_membership_warning.py
+++ b/tests/unit/semantic/test_domain_membership_warning.py
@@ -206,6 +206,17 @@ class TestSetMembership:
 
         assert "[eba_PL:x72]" in warning
 
+    def test_a_repeated_member_is_reported_once(self):
+        node = BinOp(
+            _selection(901),
+            "in",
+            Set([_item("eba_PL:x72"), _item("eba_PL:x72")]),
+        )
+
+        (warning,) = _run(node)
+
+        assert "[eba_PL:x72]" in warning
+
     def test_non_item_members_are_ignored(self):
         """A parameter member has no signature; the item member still counts."""
         node = BinOp(

--- a/tests/unit/semantic/test_domain_membership_warning.py
+++ b/tests/unit/semantic/test_domain_membership_warning.py
@@ -1,0 +1,464 @@
+"""Tests for the out-of-domain item comparison warning (issue #332).
+
+Comparing an enumerated component with an item from a different domain is
+accepted by every other check but can never hold. These tests drive
+``DomainMembershipChecker`` over hand-built ASTs with the two dictionary
+lookups stubbed, so the traversal and the decision rules are exercised
+without a database.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from dpmcore.dpm_xl.ast import domain_membership
+from dpmcore.dpm_xl.ast.domain_membership import (
+    DomainMembershipChecker,
+    _item_literals,
+)
+from dpmcore.dpm_xl.ast.nodes import (
+    BinOp,
+    Constant,
+    Dimension,
+    FilterOp,
+    GetOp,
+    ParameterRef,
+    ParExpr,
+    RenameNode,
+    RenameOp,
+    Scalar,
+    Set,
+    SubAssignment,
+    SubOp,
+    VarID,
+    WhereClauseOp,
+)
+from dpmcore.dpm_xl.warning_collector import collect_warnings
+
+# property_id -> domain, as the dictionary would resolve it at a release.
+PROPERTY_DOMAINS = {
+    901: {"qPO"},
+    902: {"qST"},
+    903: {"qAS"},
+    # A property in a non-enumerated category resolves to no domain.
+    904: set(),
+}
+
+# item signature -> domain.
+ITEM_DOMAINS = {
+    "eba_qPO:qx2001": {"qPO"},
+    "eba_PL:x72": {"PL"},
+    "eba_RT:x14": {"RT"},
+    "eba_AS:x2": {"AS"},
+    "eba_qAS:qx1": {"qAS"},
+}
+
+
+@pytest.fixture(autouse=True)
+def stub_dictionary(monkeypatch):
+    """Answer both domain lookups from the tables above."""
+
+    def properties(session, property_ids, release_id=None):
+        return {
+            property_id: PROPERTY_DOMAINS[property_id]
+            for property_id in property_ids
+            if PROPERTY_DOMAINS.get(property_id)
+        }
+
+    def items(session, signatures, release_id=None):
+        return {
+            signature: ITEM_DOMAINS[signature]
+            for signature in signatures
+            if signature in ITEM_DOMAINS
+        }
+
+    monkeypatch.setattr(
+        domain_membership.PropertyCategoryQuery,
+        "get_property_domains",
+        staticmethod(properties),
+    )
+    monkeypatch.setattr(
+        domain_membership.ItemCategoryQuery,
+        "get_item_domains",
+        staticmethod(items),
+    )
+
+
+@pytest.fixture
+def fixture_keys(monkeypatch):
+    """Answer every ``sub`` target with property 901, recording the lookups."""
+    asked: list[str] = []
+
+    def get_keys(session, dimension_codes, release_id=None):
+        asked.extend(dimension_codes)
+        return pd.DataFrame(
+            [
+                {"property_id": 901, "property_code": code, "data_type": "e"}
+                for code in dimension_codes
+            ]
+        )
+
+    monkeypatch.setattr(
+        domain_membership.ViewOpenKeysQuery,
+        "get_keys",
+        staticmethod(get_keys),
+    )
+    return asked
+
+
+def _selection(*property_ids, table="C_14.00", cols=("0060",)):
+    """A cell selection resolving to one data point per property."""
+    node = VarID(
+        table=table,
+        rows=None,
+        cols=list(cols) if cols else None,
+        sheets=None,
+        interval=None,
+        default=None,
+    )
+    node.data = pd.DataFrame({"property_id": list(property_ids)})
+    return node
+
+
+def _item(signature):
+    return Scalar(item=signature, scalar_type="Item")
+
+
+def _run(node) -> list[str]:
+    with collect_warnings() as wc:
+        DomainMembershipChecker(session=None, ast=node, release_id=None)
+        return wc.get_warnings()
+
+
+class TestComparisonOperators:
+    def test_equality_against_a_foreign_domain_warns(self):
+        node = BinOp(_selection(901), "=", _item("eba_PL:x72"))
+
+        (warning,) = _run(node)
+
+        assert "[eba_PL:x72]" in warning
+        assert "domain PL" in warning
+        assert "domain qPO" in warning
+        assert "the comparison is never true" in warning
+
+    def test_inequality_reports_the_opposite_effect(self):
+        node = BinOp(_selection(902), "!=", _item("eba_RT:x14"))
+
+        (warning,) = _run(node)
+
+        assert "the comparison is always true" in warning
+
+    def test_item_inside_the_domain_is_silent(self):
+        node = BinOp(_selection(901), "=", _item("eba_qPO:qx2001"))
+
+        assert _run(node) == []
+
+    def test_operand_order_does_not_matter(self):
+        node = BinOp(_item("eba_PL:x72"), "=", _selection(901))
+
+        (warning,) = _run(node)
+
+        assert "the comparison is never true" in warning
+
+    def test_parentheses_do_not_hide_either_side(self):
+        node = BinOp(
+            ParExpr(_selection(901)), "=", ParExpr(_item("eba_PL:x72"))
+        )
+
+        assert len(_run(node)) == 1
+
+    def test_ordering_comparison_is_not_checked(self):
+        """Only ``=``, ``!=`` and ``in`` take an item literal."""
+        node = BinOp(_selection(901), ">", _item("eba_PL:x72"))
+
+        assert _run(node) == []
+
+    def test_two_literals_are_not_a_component(self):
+        node = BinOp(_item("eba_PL:x72"), "=", _item("eba_RT:x14"))
+
+        assert _run(node) == []
+
+
+class TestSetMembership:
+    def test_each_impossible_member_is_reported(self):
+        node = BinOp(
+            _selection(901),
+            "in",
+            Set([_item("eba_PL:x72"), _item("eba_RT:x14")]),
+        )
+
+        warnings = _run(node)
+
+        assert len(warnings) == 2
+        assert all(
+            "this member of the set never matches" in w for w in warnings
+        )
+
+    def test_a_partly_dead_set_reports_only_the_dead_member(self):
+        node = BinOp(
+            _selection(901),
+            "in",
+            Set([_item("eba_qPO:qx2001"), _item("eba_PL:x72")]),
+        )
+
+        (warning,) = _run(node)
+
+        assert "[eba_PL:x72]" in warning
+
+    def test_non_item_members_are_ignored(self):
+        """A parameter member has no signature; the item member still counts."""
+        node = BinOp(
+            _selection(901),
+            "in",
+            Set(
+                [
+                    ParameterRef(code="p_x", param_type="item"),
+                    _item("eba_PL:x72"),
+                ]
+            ),
+        )
+
+        (warning,) = _run(node)
+
+        assert "[eba_PL:x72]" in warning
+
+    def test_empty_set_is_silent(self):
+        node = BinOp(_selection(901), "in", Set([]))
+
+        assert _run(node) == []
+
+    def test_constant_set_is_silent(self):
+        node = BinOp(
+            _selection(901),
+            "in",
+            Set([Constant(type_="Integer", value=1)]),
+        )
+
+        assert _run(node) == []
+
+
+class TestComponentResolution:
+    def test_a_selection_spanning_two_domains_accepts_either(self):
+        """Warn only when the item belongs to none of the domains spanned."""
+        node = BinOp(_selection(901, 903), "=", _item("eba_qAS:qx1"))
+
+        assert _run(node) == []
+
+    def test_a_selection_spanning_two_domains_still_rejects_a_third(self):
+        node = BinOp(_selection(901, 903), "=", _item("eba_PL:x72"))
+
+        assert len(_run(node)) == 1
+
+    def test_a_non_enumerated_component_is_never_judged(self):
+        node = BinOp(_selection(904), "=", _item("eba_PL:x72"))
+
+        assert _run(node) == []
+
+    def test_one_unresolvable_data_point_silences_the_selection(self):
+        """The item cannot be ruled out when part of the span is unknown."""
+        node = BinOp(_selection(901, 904), "=", _item("eba_PL:x72"))
+
+        assert _run(node) == []
+
+    def test_a_selection_without_resolved_data_is_skipped(self):
+        node = VarID(
+            table="C_14.00",
+            rows=None,
+            cols=["0060"],
+            sheets=None,
+            interval=None,
+            default=None,
+        )
+
+        assert _run(BinOp(node, "=", _item("eba_PL:x72"))) == []
+
+    def test_a_grey_data_point_silences_the_selection(self):
+        node = _selection(901)
+        node.data = pd.DataFrame({"property_id": [901, None]})
+
+        assert _run(BinOp(node, "=", _item("eba_PL:x72"))) == []
+
+    def test_an_unknown_item_is_left_to_the_not_found_check(self):
+        node = BinOp(_selection(901), "=", _item("eba_ZZ:x999"))
+
+        assert _run(node) == []
+
+    def test_rename_preserves_the_fact_component_domain(self):
+        renamed = RenameOp(
+            _selection(901), [RenameNode(old_name="r", new_name="row")]
+        )
+
+        assert len(_run(BinOp(renamed, "=", _item("eba_PL:x72")))) == 1
+
+    def test_filter_preserves_the_fact_component_domain(self):
+        filtered = FilterOp(
+            selection=_selection(901),
+            condition=BinOp(_selection(901), ">", Constant("Integer", 0)),
+        )
+
+        assert len(_run(BinOp(filtered, "=", _item("eba_PL:x72")))) == 1
+
+    def test_an_item_is_looked_up_once_across_comparisons(self):
+        """The second comparison answers from the per-expression cache."""
+        node = BinOp(
+            BinOp(_selection(901), "=", _item("eba_PL:x72")),
+            "and",
+            BinOp(_selection(902), "=", _item("eba_PL:x72")),
+        )
+
+        assert len(_run(node)) == 2
+
+
+class TestOpenKeys:
+    def test_an_open_key_is_resolved_from_its_property(self):
+        condition = BinOp(
+            Dimension("qPO", property_id=901), "=", _item("eba_PL:x72")
+        )
+        node = WhereClauseOp(_selection(902), condition)
+
+        (warning,) = _run(node)
+
+        assert "but qPO takes items from domain qPO" in warning
+
+    def test_the_fact_component_resolves_against_the_clause_operand(self):
+        condition = BinOp(Dimension("f"), "=", _item("eba_PL:x72"))
+        node = WhereClauseOp(_selection(902), condition)
+
+        (warning,) = _run(node)
+
+        assert "domain qST" in warning
+
+    def test_an_implicit_open_key_is_skipped(self):
+        """``refPeriod`` and friends carry the ``-1`` sentinel."""
+        condition = BinOp(
+            Dimension("refPeriod", property_id=-1), "=", _item("eba_PL:x72")
+        )
+        node = WhereClauseOp(_selection(902), condition)
+
+        assert _run(node) == []
+
+    def test_an_unenriched_dimension_is_skipped(self):
+        condition = BinOp(Dimension("qPO"), "=", _item("eba_PL:x72"))
+        node = WhereClauseOp(_selection(902), condition)
+
+        assert _run(node) == []
+
+    def test_get_promotes_the_key_to_the_fact_component(self):
+        node = BinOp(GetOp(_selection(902), "qPO"), "=", _item("eba_PL:x72"))
+        node.left.property_id = 901
+
+        (warning,) = _run(node)
+
+        # The domain checked is the key's (qPO), not the operand's (qST).
+        assert "domain qPO" in warning
+
+    def test_a_bare_fact_dimension_outside_a_clause_is_skipped(self):
+        assert _run(BinOp(Dimension("f"), "=", _item("eba_PL:x72"))) == []
+
+    def test_an_open_key_with_no_enumerated_domain_is_skipped(self):
+        condition = BinOp(
+            Dimension("qDT", property_id=904), "=", _item("eba_PL:x72")
+        )
+        node = WhereClauseOp(_selection(902), condition)
+
+        assert _run(node) == []
+
+
+class TestSubClause:
+    def test_an_out_of_domain_substitution_warns(self, monkeypatch):
+        monkeypatch.setattr(
+            DomainMembershipChecker,
+            "_sub_property_id",
+            lambda self, code: 901,
+        )
+        node = SubOp(
+            _selection(902), [SubAssignment("qPO", _item("eba_PL:x72"))]
+        )
+
+        (warning,) = _run(node)
+
+        assert "the substitution matches no record" in warning
+
+    def test_an_in_domain_substitution_is_silent(self, monkeypatch):
+        monkeypatch.setattr(
+            DomainMembershipChecker,
+            "_sub_property_id",
+            lambda self, code: 901,
+        )
+        node = SubOp(
+            _selection(902), [SubAssignment("qPO", _item("eba_qPO:qx2001"))]
+        )
+
+        assert _run(node) == []
+
+    def test_an_unresolvable_target_is_skipped(self, monkeypatch):
+        monkeypatch.setattr(
+            DomainMembershipChecker,
+            "_sub_property_id",
+            lambda self, code: None,
+        )
+        node = SubOp(
+            _selection(902), [SubAssignment("qPO", _item("eba_PL:x72"))]
+        )
+
+        assert _run(node) == []
+
+    def test_a_non_item_value_is_skipped(self, monkeypatch):
+        called = []
+        monkeypatch.setattr(
+            DomainMembershipChecker,
+            "_sub_property_id",
+            lambda self, code: called.append(code),
+        )
+        node = SubOp(
+            _selection(902),
+            [SubAssignment("qPO", Constant(type_="Integer", value=1))],
+        )
+
+        assert _run(node) == []
+        assert called == []
+
+    def test_a_target_is_looked_up_once_per_expression(self, fixture_keys):
+        """The second ``sub`` on the same key answers from the cache."""
+        node = SubOp(
+            _selection(902),
+            [
+                SubAssignment("qPO", _item("eba_PL:x72")),
+                SubAssignment("qPO", _item("eba_RT:x14")),
+            ],
+        )
+
+        assert len(_run(node)) == 2
+        assert fixture_keys == ["qPO"]
+
+    def test_the_substituted_operand_keeps_its_own_domain(self, monkeypatch):
+        monkeypatch.setattr(
+            DomainMembershipChecker,
+            "_sub_property_id",
+            lambda self, code: 901,
+        )
+        sub = SubOp(
+            _selection(902),
+            [SubAssignment("qPO", _item("eba_qPO:qx2001"))],
+        )
+
+        (warning,) = _run(BinOp(sub, "=", _item("eba_PL:x72")))
+
+        assert "domain qST" in warning
+
+
+class TestItemLiterals:
+    def test_a_bare_item_yields_its_signature(self):
+        assert _item_literals(_item("eba_PL:x72")) == ["eba_PL:x72"]
+
+    def test_parentheses_are_stripped(self):
+        assert _item_literals(ParExpr(_item("eba_PL:x72"))) == ["eba_PL:x72"]
+
+    def test_a_set_yields_every_item_member(self):
+        node = Set([_item("eba_PL:x72"), _item("eba_RT:x14")])
+
+        assert _item_literals(node) == ["eba_PL:x72", "eba_RT:x14"]
+
+    def test_anything_else_yields_nothing(self):
+        assert _item_literals(Constant(type_="Integer", value=1)) == []


### PR DESCRIPTION
## Summary

Closes #332 

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [ ] Documentation updated (if applicable)

## Impact / Risk

- Breaking changes? (public API / CLI / REST endpoints / Django models)
- Database schema or migration concerns?
- Notes for release/changelog?

## Notes

<!-- Follow-ups, TODOs, or anything reviewers should know. -->
