### PR TITLE
`PersistentAssignment` target cell should not become an operand in MLGeneration

### DIFF
--- a/src/dpmcore/dpm_xl/ast/ml_generation.py
+++ b/src/dpmcore/dpm_xl/ast/ml_generation.py
@@ -259,16 +259,13 @@ class MLGeneration(ASTTemplate):
         self.session_queries.close()
 
     def visit_PersistentAssignment(self, node: PersistentAssignment) -> None:
-
+        # node.left is the target cell, not an operand: never visited, so it
+        # never becomes a leaf (matches TemporaryAssignment below).
         operation_node = self.create_operation_node(node)
 
-        node.left.argument = "left"
         node.right.argument = "right"
-
-        node.left.parent = operation_node
         node.right.parent = operation_node
 
-        self.visit(node.left)
         self.visit(node.right)
 
     def visit_TemporaryAssignment(self, node: TemporaryAssignment) -> None:

--- a/tests/unit/ast/test_ml_generation_persistent_assignment.py
+++ b/tests/unit/ast/test_ml_generation_persistent_assignment.py
@@ -1,0 +1,80 @@
+"""``node.left`` is the target cell, not an operand: legacy never creates
+a node for it. ``visit_PersistentAssignment`` must match that regardless
+of whether the cell resolves in ``extract_operand_data``.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from dpmcore.dpm_xl.ast.ml_generation import MLGeneration
+from dpmcore.dpm_xl.ast.nodes import PersistentAssignment, VarID
+from dpmcore.orm.operations import OperationNode
+
+
+@pytest.fixture
+def ml_generation():
+    ml = MLGeneration.__new__(MLGeneration)
+    ml.session = MagicMock()
+    ml.op_version_id = 99
+    ml.is_scripting = False
+    ml.data = None
+    ml.create_operation_node = MagicMock(
+        side_effect=lambda n, is_leaf=False: OperationNode()
+    )
+    return ml
+
+
+def _persistent_assignment():
+    target = VarID(
+        table="tFND", rows=["r0010"], cols=["c0010"], sheets=None,
+        interval=None, default=None,
+    )
+    formula = VarID(
+        table="tFND", rows=["r0020"], cols=["c0010"], sheets=None,
+        interval=None, default=None,
+    )
+    return PersistentAssignment(left=target, op="<-", right=formula)
+
+
+def test_left_hand_side_never_becomes_a_leaf_even_when_it_resolves(
+    ml_generation,
+):
+    # The target cell happens to also resolve in extract_operand_data (e.g.
+    # some other rule in the batch reads it) -- legacy discards it anyway.
+    ml_generation.extract_operand_data = MagicMock(
+        return_value=[
+            {"x": None, "y": None, "z": None, "variable_id": 1, "cell_id": 7,
+             "row_code": "r0010", "column_code": "c0010", "sheet_code": None},
+        ]
+    )
+
+    ml_generation.visit_PersistentAssignment(_persistent_assignment())
+
+    # create_operation_node: once for the assignment itself, once for the
+    # right-hand formula. Never for the left-hand target cell.
+    assert ml_generation.create_operation_node.call_count == 2
+    ml_generation.extract_operand_data.assert_called_once()
+    right_call_table = ml_generation.extract_operand_data.call_args[0][0]
+    assert right_call_table == "tFND"
+
+
+def test_left_hand_side_never_becomes_a_leaf_when_it_does_not_resolve(
+    ml_generation,
+):
+    ml_generation.extract_operand_data = MagicMock(return_value=[])
+
+    ml_generation.visit_PersistentAssignment(_persistent_assignment())
+
+    assert ml_generation.create_operation_node.call_count == 2
+    assert ml_generation.session.add.call_count == 0
+
+
+def test_right_hand_side_is_still_visited_and_linked(ml_generation):
+    ml_generation.extract_operand_data = MagicMock(return_value=[])
+
+    node = _persistent_assignment()
+    ml_generation.visit_PersistentAssignment(node)
+
+    assert node.right.argument == "right"
+    assert node.right.parent is not None

--- a/tests/unit/ast/test_ml_generation_persistent_assignment.py
+++ b/tests/unit/ast/test_ml_generation_persistent_assignment.py
@@ -27,12 +27,20 @@ def ml_generation():
 
 def _persistent_assignment():
     target = VarID(
-        table="tFND", rows=["r0010"], cols=["c0010"], sheets=None,
-        interval=None, default=None,
+        table="tFND",
+        rows=["r0010"],
+        cols=["c0010"],
+        sheets=None,
+        interval=None,
+        default=None,
     )
     formula = VarID(
-        table="tFND", rows=["r0020"], cols=["c0010"], sheets=None,
-        interval=None, default=None,
+        table="tFND",
+        rows=["r0020"],
+        cols=["c0010"],
+        sheets=None,
+        interval=None,
+        default=None,
     )
     return PersistentAssignment(left=target, op="<-", right=formula)
 
@@ -44,8 +52,16 @@ def test_left_hand_side_never_becomes_a_leaf_even_when_it_resolves(
     # some other rule in the batch reads it) -- legacy discards it anyway.
     ml_generation.extract_operand_data = MagicMock(
         return_value=[
-            {"x": None, "y": None, "z": None, "variable_id": 1, "cell_id": 7,
-             "row_code": "r0010", "column_code": "c0010", "sheet_code": None},
+            {
+                "x": None,
+                "y": None,
+                "z": None,
+                "variable_id": 1,
+                "cell_id": 7,
+                "row_code": "r0010",
+                "column_code": "c0010",
+                "sheet_code": None,
+            },
         ]
     )
 


### PR DESCRIPTION
Closes #336 

## Summary

`visit_PersistentAssignment` stops visiting `node.left`, so it no longer reaches `visit_VarID` and can no longer produce a leaf `OperationNode`/`OperandReference` for the target cell. This mirrors `visit_TemporaryAssignment`, which already never visits its own `node.left`. The `argument`/`parent` attributes previously set on `node.left` are dropped too, since nothing reads them anymore.

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [ ] Documentation updated (if applicable)

## Impact / Risk

- Breaking changes? (public API / CLI / REST endpoints / Django models)
- Database schema or migration concerns?
- Notes for release/changelog?

## Notes

<!-- Follow-ups, TODOs, or anything reviewers should know. -->
