### PR TITLE
Match AST node children by attribute, not `isinstance`, in `MLGeneration`

### DIFF
--- a/src/dpmcore/dpm_xl/ast/ml_generation.py
+++ b/src/dpmcore/dpm_xl/ast/ml_generation.py
@@ -754,7 +754,12 @@ class MLGeneration(ASTTemplate):
         op_node = self.create_operation_node(node, is_leaf=True)
 
         for child in node.children:
-            if not isinstance(child, Scalar):
+            # A ``hasattr`` check, not ``isinstance(child, Scalar)``: a caller
+            # may feed MLGeneration an AST built by its own parser, as long as
+            # node classes match dpmcore's by name (see NodeVisitor.visit,
+            # which dispatches the same way) - the concrete Scalar class may
+            # not be the same object.
+            if not hasattr(child, "item"):
                 continue
             item_id = ItemCategoryQuery.get_item_category_id_from_signature(
                 signature=child.item, session=self.session_queries

--- a/src/dpmcore/dpm_xl/ast/ml_generation.py
+++ b/src/dpmcore/dpm_xl/ast/ml_generation.py
@@ -189,7 +189,7 @@ class MLGeneration(ASTTemplate):
         interval = bool(interval_attr) if interval_attr is not None else False
         fallback_value = gather_element(node, "default")
 
-        if isinstance(fallback_value, Constant):
+        if hasattr(fallback_value, "value"):
             fallback_value = fallback_value.value
 
         if fallback_value is not None and isinstance(fallback_value, str):

--- a/tests/unit/ast/test_ml_generation.py
+++ b/tests/unit/ast/test_ml_generation.py
@@ -363,3 +363,52 @@ def test_visit_set_creates_operand_references_for_children_from_another_ast_impl
     op_refs = [o for o in added if isinstance(o, OperandReference)]
     assert len(op_refs) == 1
     assert op_refs[0].item_id == 1
+
+
+def test_create_operation_node_unwraps_a_constant_default(ml_generation):
+    """A ``default(...)`` fallback value must be unwrapped to its raw value."""
+    ml_generation.session = MagicMock()
+    ml_generation.op_version_id = 99
+    ml_generation.df_operators = pd.DataFrame(
+        columns=["Symbol", "OperatorID", "Name"]
+    )
+    ml_generation.df_arguments = pd.DataFrame(
+        columns=["Name", "OperatorID", "ArgumentID"]
+    )
+    node = Constant(type_="Integer", value=1)
+    node.default = Constant(type_="Integer", value=0)
+
+    result = MLGeneration.create_operation_node(ml_generation, node)
+
+    assert result.fallback_value == 0
+
+
+def test_create_operation_node_unwraps_a_default_from_another_ast_implementation(
+    ml_generation,
+):
+    """Regression test: ``create_operation_node`` used to require dpmcore's own
+    concrete ``Constant`` class via ``isinstance``, so a structurally identical
+    ``Constant`` from another parser was kept wrapped instead of unwrapped to
+    its raw value.
+    """
+
+    class Constant:  # a different, unrelated "Constant" class - not dpmcore's
+        def __init__(self, value):
+            self.value = value
+
+    ml_generation.session = MagicMock()
+    ml_generation.op_version_id = 99
+    ml_generation.df_operators = pd.DataFrame(
+        columns=["Symbol", "OperatorID", "Name"]
+    )
+    ml_generation.df_arguments = pd.DataFrame(
+        columns=["Name", "OperatorID", "ArgumentID"]
+    )
+    node = VarID(
+        table=None, rows=None, cols=None, sheets=None, interval=False,
+        default=Constant(value=0),
+    )
+
+    result = MLGeneration.create_operation_node(ml_generation, node)
+
+    assert result.fallback_value == 0

--- a/tests/unit/ast/test_ml_generation.py
+++ b/tests/unit/ast/test_ml_generation.py
@@ -16,6 +16,7 @@ from dpmcore.dpm_xl.ast.nodes import (
     Dimension,
     IntersectSetOp,
     OrderItem,
+    Scalar,
     Set,
     SetdiffOp,
     SetOfOp,
@@ -301,3 +302,64 @@ def test_visit_dimension_on_the_fact_emits_a_leaf_without_operand_refs(
     assert node.scalar == FACT
     assert ml_generation.create_operation_node.call_count == 1
     assert ml_generation.session.add.call_count == 0
+
+
+def test_visit_set_creates_an_operand_reference_per_item_child(
+    ml_generation, monkeypatch
+):
+    """``x in {[a],[b]}`` must emit one item ``OperandReference`` per element."""
+    ml_generation.session = MagicMock()
+    ml_generation.session_queries = MagicMock()
+    ml_generation.create_operation_node = MagicMock(
+        return_value=OperationNode()
+    )
+    monkeypatch.setattr(
+        "dpmcore.dpm_xl.ast.ml_generation.ItemCategoryQuery.get_item_category_id_from_signature",
+        lambda signature, session: [{"a": 1, "b": 2}[signature]],
+    )
+    node = Set(
+        children=[
+            Scalar(item="a", scalar_type="Item"),
+            Scalar(item="b", scalar_type="Item"),
+        ]
+    )
+
+    ml_generation.visit_Set(node)
+
+    added = [call.args[0] for call in ml_generation.session.add.call_args_list]
+    item_ids = sorted(
+        o.item_id for o in added if isinstance(o, OperandReference)
+    )
+    assert item_ids == [1, 2]
+
+
+def test_visit_set_creates_operand_references_for_children_from_another_ast_implementation(
+    ml_generation, monkeypatch
+):
+    """Regression test: ``visit_Set`` used to require dpmcore's own concrete
+    ``Scalar`` class via ``isinstance``, so a structurally identical ``Scalar``
+    from another parser silently produced zero ``OperandReference`` rows.
+    """
+
+    class Scalar:  # a different, unrelated "Scalar" class - not dpmcore's
+        def __init__(self, item, scalar_type):
+            self.item = item
+            self.scalar_type = scalar_type
+
+    ml_generation.session = MagicMock()
+    ml_generation.session_queries = MagicMock()
+    ml_generation.create_operation_node = MagicMock(
+        return_value=OperationNode()
+    )
+    monkeypatch.setattr(
+        "dpmcore.dpm_xl.ast.ml_generation.ItemCategoryQuery.get_item_category_id_from_signature",
+        lambda signature, session: [1],
+    )
+    node = Set(children=[Scalar(item="eba_MC:x1281", scalar_type="Item")])
+
+    ml_generation.visit_Set(node)
+
+    added = [call.args[0] for call in ml_generation.session.add.call_args_list]
+    op_refs = [o for o in added if isinstance(o, OperandReference)]
+    assert len(op_refs) == 1
+    assert op_refs[0].item_id == 1

--- a/tests/unit/ast/test_ml_generation.py
+++ b/tests/unit/ast/test_ml_generation.py
@@ -405,7 +405,11 @@ def test_create_operation_node_unwraps_a_default_from_another_ast_implementation
         columns=["Name", "OperatorID", "ArgumentID"]
     )
     node = VarID(
-        table=None, rows=None, cols=None, sheets=None, interval=False,
+        table=None,
+        rows=None,
+        cols=None,
+        sheets=None,
+        interval=False,
         default=Constant(value=0),
     )
 


### PR DESCRIPTION
Closes #339 

## Summary

Two spots in `MLGeneration` used `isinstance` against dpmcore's own concrete AST node classes, so a structurally identical node from a caller's own parser (different class, same attributes) was silently mishandled:

- `visit_Set` used `isinstance(child, Scalar)`, so a foreign `Scalar` child was dropped instead of producing an `OperandReference`.
- `create_operation_node` used `isinstance(fallback_value, Constant)`, so a foreign `Constant` default value was kept wrapped instead of unwrapped to its raw value.

Fixed both by checking for the attribute that actually matters instead: `hasattr(child, "item")` and `hasattr(fallback_value, "value")` respectively. `Scalar` is the only AST node with `.item`, and a `default(...)` value is the only thing with `.value`, so neither check can match unrelated nodes.

This matches the rest of the module: `NodeVisitor.visit` dispatches on `type(node).__name__` (`ast/visitor.py`), and `gather_element` in `ml_generation.py` already reads attributes via `hasattr` rather than checking the node's class.

## Checklist

- [X] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [X] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [X] Documentation updated (if applicable)

## Impact / Risk

- Breaking changes? (public API / CLI / REST endpoints / Django models)
- Database schema or migration concerns?
- Notes for release/changelog?

## Notes

<!-- Follow-ups, TODOs, or anything reviewers should know. -->
