### PR TITLE
fix(ast-generator): walk the gate AST so parameters reach the engine

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -467,9 +467,12 @@ A target that fails to resolve is skipped with a warning instead of
 aborting the whole sweep; the command exits non-zero if any target
 failed.
 
-Validations the semantic pass rejects are not part of the script. The
-console reports how many were skipped next to how many were discovered,
-and lists the reason per validation; the full list is written to
+Validations the semantic pass rejects are not part of the script, and
+neither are validations whose precondition falls outside what the engine
+can evaluate — a gate may only combine filing indicators, parameters and
+boolean literals with ``and`` / ``or`` / ``xor`` / ``not``. The console
+reports how many were skipped next to how many were discovered, and
+lists the reason per validation; the full list is written to
 ``failed_operations`` in the output JSON. A precondition left gating
 only rejected validations is dropped from the ``preconditions`` block
 rather than shipped with ``affected_operations`` the script does not

--- a/src/dpmcore/services/ast_generator.py
+++ b/src/dpmcore/services/ast_generator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import re
 import zlib
@@ -43,7 +44,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-_VAR_REF_PATTERN = re.compile(r"\{v_?([^}]+)\}")
 _TABLE_CODE_NORMALIZER = re.compile(r"^([A-Z]+)_(\d+)_(\d+)$")
 _DEFAULT_FROM_DATE = "2001-01-01"
 _DEFAULT_NAMESPACE = "default_module"
@@ -314,21 +314,27 @@ class ASTGeneratorService:
             for tbl in tables_block.values():
                 variables_block.update(tbl.get("variables", {}))
 
+            preconditions_block, precondition_variables_block = (
+                self._build_preconditions_block(
+                    preconditions or [],
+                    release_id=release_id,
+                    referenced_parameters=referenced_parameters,
+                )
+            )
+
             # Runtime-binding contract: the declared type of every parameter
             # this script's operations reference, keyed by code. This is the
             # scope-wide invariant. ``is_set`` is recoverable from the ``set-``
             # prefix and ``default`` is a per-reference fallback the engine
-            # binds per scope, so neither belongs in this registry.
+            # binds per scope, so neither belongs in this registry. Populated
+            # after ``_build_preconditions_block`` runs so parameters that
+            # appear only in a gate — legal per the grammar, and reaching the
+            # engine as a runtime input — are declared alongside the ones the
+            # expressions reference.
             parameters_block: Dict[str, str] = {
                 prm_code: prm.declared_type
                 for prm_code, prm in sorted(referenced_parameters.items())
             }
-
-            preconditions_block, precondition_variables_block = (
-                self._build_preconditions_block(
-                    preconditions or [], release_id=release_id
-                )
-            )
 
             dependency_info = self._build_dependency_info(
                 scope_pairs=scope_pairs,
@@ -917,61 +923,68 @@ class ASTGeneratorService:
         self,
         preconditions: List[Union[Tuple[str, List[str]], Dict[str, Any]]],
         release_id: Optional[int],
+        referenced_parameters: Optional[Dict[str, ParameterInfo]] = None,
     ) -> Tuple[Dict[str, Any], Dict[str, str]]:
         """Build the ``preconditions`` and ``precondition_variables`` blocks.
 
-        Mirrors pydpm's ``_build_preconditions``: regex-extract
-        ``{v_*}`` variable codes, batch-resolve each to
-        ``(variable_id, variable_vid)``, then emit a
-        ``PreconditionItem`` AST for single-variable preconditions or
-        a left-folded ``BinOp(op="and")`` chain for compound ones.
-        Codes that don't resolve are silently skipped (matches pydpm).
+        Each gate is parsed once and the resulting AST is walked to build
+        the entry: a ``{v_*}`` selection contributes a ``PreconditionItem``
+        node with the resolved ``variable_id`` / ``variable_vid``, a
+        ``{p_*}`` reference contributes the ``ParameterRef`` node with
+        ``code`` / ``param_type`` preserved, and every logical operator
+        that connects them (``and``/``or``/``not``, ``ParExpr``) survives
+        into the emitted tree. Gates that used to depend on the regex
+        matching only ``{v_*}`` positions — a parameter-only gate, or a
+        mixed gate whose parameter half was silently dropped — now reach
+        the engine intact.
+
+        A parameter that shows up in a gate is added to
+        ``referenced_parameters`` in the same pass, so
+        ``parameters_block`` declares it alongside those the expressions
+        reference and the scope-wide type agreement in
+        :func:`~dpmcore.services._parameters.merge_parameters` runs
+        against a single registry.
         """
         from dpmcore.dpm_xl.model_queries import VariableVersionQuery
+        from dpmcore.dpm_xl.utils.serialization import serialize_ast
 
         preconditions_dict: Dict[str, Any] = {}
         precondition_variables: Dict[str, str] = {}
         if not preconditions or self.session is None:
             return preconditions_dict, precondition_variables
 
-        all_codes: List[str] = []
-        for precond_spec in preconditions:
-            precond_expr = (
-                precond_spec.get("expression")
-                if isinstance(precond_spec, dict)
-                else precond_spec[0]
-            )
-            if not precond_expr:
-                continue
-            for raw in _VAR_REF_PATTERN.findall(precond_expr):
-                normalized = _normalize_variable_code(raw)
-                if normalized not in all_codes:
-                    all_codes.append(normalized)
-        if not all_codes:
-            return preconditions_dict, precondition_variables
+        # Parse every gate once — later passes read the AST, not the
+        # source text — and collect every ``{v_*}`` code the trees carry
+        # so the DB lookup batches them all.
+        parsed_gates, all_codes = self._parse_gates(preconditions)
 
-        resolved = VariableVersionQuery.get_variable_vids_by_codes(
-            self.session, all_codes, release_id=release_id
+        resolved: Dict[str, Dict[str, int]] = (
+            VariableVersionQuery.get_variable_vids_by_codes(
+                self.session, all_codes, release_id=release_id
+            )
+            if all_codes
+            else {}
         )
 
-        for precond_spec in preconditions:
-            if isinstance(precond_spec, dict):
-                precond_expr = precond_spec["expression"]
-                validation_codes = precond_spec["affected_operations"]
-                provided_code = precond_spec.get("code")
-                provided_version_id = precond_spec.get("version_id")
-            else:
-                precond_expr, validation_codes = precond_spec
-                provided_code = None
-                provided_version_id = None
-
-            var_infos = self._collect_precondition_var_infos(
-                precond_expr, resolved, precondition_variables
+        for (
+            ast,
+            validation_codes,
+            provided_code,
+            provided_version_id,
+        ) in parsed_gates:
+            gate_ast = self._transform_precondition_ast(
+                ast, resolved, precondition_variables, serialize_ast
             )
-            if not var_infos:
+            if gate_ast is None:
+                # Every ``{v_*}`` position dropped for lack of resolution
+                # and the tree carried no parameter to keep it standing.
                 continue
-            key, entry = self._build_precondition_entry(
-                var_infos, validation_codes, provided_code, provided_version_id
+            if referenced_parameters is not None:
+                self._accumulate_precondition_parameters(
+                    referenced_parameters, gate_ast
+                )
+            key, entry = self._build_precondition_entry_from_ast(
+                gate_ast, validation_codes, provided_code, provided_version_id
             )
             self._merge_precondition_entry(preconditions_dict, key, entry)
 
@@ -999,102 +1012,364 @@ class ASTGeneratorService:
                 merged_ops.append(op)
         existing["affected_operations"] = merged_ops
 
-    @staticmethod
-    def _collect_precondition_var_infos(
-        precondition_expr: str,
+    def _parse_gates(
+        self,
+        preconditions: List[Union[Tuple[str, List[str]], Dict[str, Any]]],
+    ) -> Tuple[
+        List[Tuple[Any, List[str], Optional[str], Optional[int]]],
+        List[str],
+    ]:
+        """Parse every gate once and index the ``{v_*}`` codes referenced.
+
+        Returns ``(parsed_gates, all_codes)`` where ``parsed_gates`` is
+        the list of ``(ast, validation_codes, provided_code,
+        provided_version_id)`` tuples the caller iterates over, and
+        ``all_codes`` is the deduplicated list of variable codes to feed
+        the batched DB resolution. A gate that fails to parse is dropped
+        silently — the top-level ``_build_precondition_index`` already
+        surfaces the failure and turns it into a script-level error, and
+        keeping the gate out here matches the pre-existing "codes that
+        don't resolve are silently skipped" contract.
+        """
+        parsed_gates: List[
+            Tuple[Any, List[str], Optional[str], Optional[int]]
+        ] = []
+        all_codes: List[str] = []
+        for precond_spec in preconditions:
+            if isinstance(precond_spec, dict):
+                precond_expr = precond_spec["expression"]
+                validation_codes = precond_spec["affected_operations"]
+                provided_code = precond_spec.get("code")
+                provided_version_id = precond_spec.get("version_id")
+            else:
+                precond_expr, validation_codes = precond_spec
+                provided_code = None
+                provided_version_id = None
+            if not precond_expr:
+                continue
+            try:
+                ast = self._syntax.parse(precond_expr)
+            except Exception:  # noqa: S112 — see docstring above
+                continue
+            parsed_gates.append(
+                (ast, validation_codes, provided_code, provided_version_id)
+            )
+            for var_code in self._extract_precondition_codes(ast):
+                if var_code not in all_codes:
+                    all_codes.append(var_code)
+        return parsed_gates, all_codes
+
+    @classmethod
+    def _transform_precondition_ast(
+        cls,
+        node: Any,
         resolved: Dict[str, Dict[str, int]],
         precondition_variables: Dict[str, str],
-    ) -> List[Dict[str, int]]:
-        """Resolve ``{v_*}`` codes in *precondition_expr* to var-info dicts.
+        serialize_ast: Any,
+    ) -> Any:
+        """Walk the parsed gate AST and emit the engine's dict shape.
 
-        Updates *precondition_variables* in-place with the resolved
-        ``{variable_vid: "b"}`` entries.
+        Three transformations happen along the way:
+
+        1. ``VarRef`` (the parser's node for ``{v_*}``) and any ``VarID``
+           whose selection uses the ``v`` prefix collapse to a
+           ``PreconditionItem`` dict with the resolved ``variable_id``,
+           and the resolved ``variable_vid`` is registered in
+           ``precondition_variables``. When the code cannot be resolved,
+           the node is dropped: the caller then rewires the surrounding
+           logical operator to keep the tree standing, or returns
+           ``None`` if nothing survives.
+        2. ``ParExpr`` wrappers unwrap once their child is finalised —
+           the engine reads meaning from operator precedence in the
+           tree, not from redundant grouping.
+        3. Every other node kind — ``ParameterRef``, ``BinOp`` /
+           ``UnaryOp`` whose operands are not selections, literals, and
+           so on — is serialised through the standard ``serialize_ast``
+           path, so the tree the engine sees matches the shape used in
+           expressions.
+
+        The walker takes the parsed AST (not the serialised dict) so
+        the ``variable`` attribute of a ``VarRef`` reaches the resolver
+        intact; the standard serializer's ``generic_visit`` does not
+        propagate that attribute.
         """
-        var_infos: List[Dict[str, int]] = []
-        raw_codes = [
-            _normalize_variable_code(m)
-            for m in _VAR_REF_PATTERN.findall(precondition_expr)
-        ]
-        for var_code in raw_codes:
-            info = resolved.get(var_code)
-            if info is None:
-                continue
-            var_infos.append(
-                {
-                    "variable_code": var_code,  # type: ignore[dict-item]
-                    "variable_id": info["variable_id"],
-                    "variable_vid": info["variable_vid"],
-                }
+        from dpmcore.dpm_xl.ast import nodes as ast_nodes
+
+        # Unwrap the top-level ``Start`` wrapper the grammar puts around
+        # every parsed expression. The engine's precondition entry
+        # matches the inside of that wrapper, not the wrapper itself.
+        node = cls._unwrap_start(node, ast_nodes)
+
+        if isinstance(node, ast_nodes.ParExpr):
+            return cls._transform_precondition_ast(
+                node.expression,
+                resolved,
+                precondition_variables,
+                serialize_ast,
             )
-            precondition_variables[str(info["variable_vid"])] = "b"
-        return var_infos
+        if isinstance(node, ast_nodes.VarRef):
+            return cls._precondition_item_from_varref(
+                node, resolved, precondition_variables
+            )
+        if isinstance(node, ast_nodes.VarID):
+            return cls._precondition_item_from_varid(
+                node, resolved, precondition_variables
+            )
+        if isinstance(node, ast_nodes.BinOp):
+            left = cls._transform_precondition_ast(
+                node.left,
+                resolved,
+                precondition_variables,
+                serialize_ast,
+            )
+            right = cls._transform_precondition_ast(
+                node.right,
+                resolved,
+                precondition_variables,
+                serialize_ast,
+            )
+            if left is None and right is None:
+                return None
+            if left is None:
+                return right
+            if right is None:
+                return left
+            return {
+                "class_name": "BinOp",
+                "op": node.op,
+                "left": left,
+                "right": right,
+            }
+        if isinstance(node, ast_nodes.UnaryOp):
+            operand = cls._transform_precondition_ast(
+                node.operand,
+                resolved,
+                precondition_variables,
+                serialize_ast,
+            )
+            if operand is None:
+                return None
+            return {
+                "class_name": "UnaryOp",
+                "op": node.op,
+                "operand": operand,
+            }
+        # Any other node kind (ParameterRef, Scalar, Set, ...) is
+        # serialised as-is; the tree walker never had special handling
+        # for it and the standard serializer already produces the shape
+        # the engine expects.
+        return serialize_ast(node)
 
     @staticmethod
-    def _build_precondition_entry(
-        var_infos: List[Dict[str, Any]],
+    def _unwrap_start(node: Any, ast_nodes: Any) -> Any:
+        """Strip the ``Start`` wrapper the parser adds to every AST.
+
+        ``SyntaxService.parse`` returns a ``Start`` node whose only child
+        is the actual expression. The engine's precondition entry is the
+        expression itself.
+        """
+        if isinstance(node, ast_nodes.Start):
+            children = getattr(node, "children", None) or []
+            if len(children) == 1:
+                return children[0]
+        return node
+
+    @staticmethod
+    def _precondition_item_from_varref(
+        node: Any,
+        resolved: Dict[str, Dict[str, int]],
+        precondition_variables: Dict[str, str],
+    ) -> Optional[Dict[str, Any]]:
+        """Rewrite a ``VarRef`` node as a ``PreconditionItem``.
+
+        ``VarRef`` is what the parser produces for a bare variable
+        selection; ``VarID`` handles the fuller cell-reference form.
+        Both routes converge on ``PreconditionItem`` here: the engine
+        binds a filing indicator, not a cell.
+        """
+        variable = getattr(node, "variable", None)
+        if not isinstance(variable, str):
+            return None
+        var_code = _normalize_variable_code(variable)
+        info = resolved.get(var_code)
+        if info is None:
+            return None
+        precondition_variables[str(info["variable_vid"])] = "b"
+        return {
+            "class_name": "PreconditionItem",
+            "variable_id": info["variable_id"],
+            "variable_code": var_code,
+            # Kept for key derivation in
+            # ``_build_precondition_entry_from_ast`` — the pre-existing
+            # ``p_<vid>`` scheme groups precondition entries by
+            # ``variable_vid``, not ``variable_id``. The engine ignores
+            # this field on the emitted node.
+            "variable_vid": info["variable_vid"],
+        }
+
+    @staticmethod
+    def _precondition_item_from_varid(
+        node: Any,
+        resolved: Dict[str, Dict[str, int]],
+        precondition_variables: Dict[str, str],
+    ) -> Optional[Dict[str, Any]]:
+        """Rewrite a variable-selection ``VarID`` as a ``PreconditionItem``.
+
+        Codes that don't resolve return ``None`` so the caller can drop
+        the position — the same non-fatal outcome the previous regex
+        path produced when a code was unknown.
+        """
+        table = getattr(node, "table", None)
+        if not isinstance(table, str):
+            return None
+        var_code = _normalize_variable_code(table)
+        info = resolved.get(var_code)
+        if info is None:
+            return None
+        precondition_variables[str(info["variable_vid"])] = "b"
+        return {
+            "class_name": "PreconditionItem",
+            "variable_id": info["variable_id"],
+            "variable_code": var_code,
+            # Kept for key derivation in
+            # ``_build_precondition_entry_from_ast`` — the pre-existing
+            # ``p_<vid>`` scheme groups precondition entries by
+            # ``variable_vid``, not ``variable_id``. The engine ignores
+            # this field on the emitted node.
+            "variable_vid": info["variable_vid"],
+        }
+
+    @classmethod
+    def _accumulate_precondition_parameters(
+        cls,
+        referenced_parameters: Dict[str, ParameterInfo],
+        node: Any,
+    ) -> None:
+        """Add every ``ParameterRef`` in the gate to the script registry.
+
+        Reads the type off the serialised node so the shared registry
+        holds the same value the engine will bind against. Two gate
+        positions with the same ``code`` but different ``param_type``
+        raise ``SemanticError`` ``3-8`` via :func:`merge_parameters`,
+        exactly as they would if the same conflict appeared between
+        two expressions.
+        """
+        if isinstance(node, dict):
+            if node.get("class_name") == "ParameterRef":
+                code = node.get("code")
+                declared_type = node.get("param_type")
+                if isinstance(code, str) and isinstance(declared_type, str):
+                    merge_parameters(
+                        referenced_parameters,
+                        (
+                            ParameterInfo(
+                                code=code,
+                                declared_type=declared_type,
+                                default=None,
+                            ),
+                        ),
+                    )
+            for value in node.values():
+                if isinstance(value, (dict, list)):
+                    cls._accumulate_precondition_parameters(
+                        referenced_parameters, value
+                    )
+        elif isinstance(node, list):
+            for item in node:
+                if isinstance(item, (dict, list)):
+                    cls._accumulate_precondition_parameters(
+                        referenced_parameters, item
+                    )
+
+    @classmethod
+    def _strip_precondition_item_vids(cls, node: Any) -> None:
+        """Drop the internal ``variable_vid`` field from every item node.
+
+        ``variable_vid`` is added by
+        :meth:`_precondition_item_from_varref` so key derivation groups
+        entries the same way ``p_<vid>`` used to. The engine's
+        ``PreconditionItem`` schema only carries ``variable_id`` and
+        ``variable_code``, so the field is stripped once the key has
+        been built.
+        """
+        if isinstance(node, dict):
+            if node.get("class_name") == "PreconditionItem":
+                node.pop("variable_vid", None)
+            for value in node.values():
+                if isinstance(value, (dict, list)):
+                    cls._strip_precondition_item_vids(value)
+        elif isinstance(node, list):
+            for item in node:
+                if isinstance(item, (dict, list)):
+                    cls._strip_precondition_item_vids(item)
+
+    @classmethod
+    def _build_precondition_entry_from_ast(
+        cls,
+        gate_ast: Dict[str, Any],
         validation_codes: List[str],
         provided_code: Optional[str] = None,
         provided_version_id: Optional[int] = None,
     ) -> Tuple[str, Dict[str, Any]]:
-        """Assemble a single ``preconditions[key]`` entry.
+        """Assemble a ``preconditions[key]`` entry from an emitted gate AST.
 
-        Single-variable case → ``p_<vid>`` with a ``PreconditionItem``
-        AST. Compound case → ``p_<sorted_vids>`` with a left-folded
-        chain of ``BinOp(op="and")`` nodes.
-
-        When provided_code or provided_version_id are supplied, they override
-        the auto-generated values.
+        The key groups together gates that emit the same sorted set of
+        ``PreconditionItem`` variable-vids — the pre-existing dedup
+        contract, preserved so a gate that today merges two operations
+        under one key keeps doing so. Gates whose only content is a
+        ``ParameterRef`` fall back to a hash-based key derived from the
+        canonical AST, so they still get a unique slot instead of
+        overwriting one another.
         """
-        if len(var_infos) == 1:
-            vi = var_infos[0]
-            default_key = f"p_{vi['variable_vid']}"
-            code = provided_code if provided_code is not None else default_key
-            version_id = (
-                provided_version_id
-                if provided_version_id is not None
-                else vi["variable_vid"]
+        item_vids = sorted(cls._collect_precondition_item_vids(gate_ast))
+        # Strip the internal ``variable_vid`` field once the key is
+        # settled; the engine's ``PreconditionItem`` schema does not
+        # carry it.
+        cls._strip_precondition_item_vids(gate_ast)
+        if item_vids:
+            default_key = "p_" + "_".join(str(v) for v in item_vids)
+            default_version_id: int = item_vids[0]
+        else:
+            digest = zlib.crc32(
+                json.dumps(gate_ast, sort_keys=True).encode("utf-8")
             )
-            return code, {
-                "ast": {
-                    "class_name": "PreconditionItem",
-                    "variable_id": vi["variable_id"],
-                    "variable_code": vi["variable_code"],
-                },
-                "affected_operations": list(validation_codes),
-                "version_id": version_id,
-                "code": code,
-            }
-
-        sorted_vids = sorted(vi["variable_vid"] for vi in var_infos)
-        default_key = "p_" + "_".join(str(v) for v in sorted_vids)
+            default_key = f"p_gate_{digest:08x}"
+            default_version_id = digest % 10000
         code = provided_code if provided_code is not None else default_key
         version_id = (
             provided_version_id
             if provided_version_id is not None
-            else sorted_vids[0]
+            else default_version_id
         )
-        ast_node: Dict[str, Any] = {
-            "class_name": "PreconditionItem",
-            "variable_id": var_infos[0]["variable_id"],
-            "variable_code": var_infos[0]["variable_code"],
-        }
-        for vi in var_infos[1:]:
-            ast_node = {
-                "class_name": "BinOp",
-                "op": "and",
-                "left": ast_node,
-                "right": {
-                    "class_name": "PreconditionItem",
-                    "variable_id": vi["variable_id"],
-                    "variable_code": vi["variable_code"],
-                },
-            }
         return code, {
-            "ast": ast_node,
+            "ast": gate_ast,
             "affected_operations": list(validation_codes),
             "version_id": version_id,
             "code": code,
         }
+
+    @classmethod
+    def _collect_precondition_item_vids(cls, node: Any) -> List[int]:
+        """Return the ``variable_vid`` of every ``PreconditionItem`` node.
+
+        The pre-existing ``p_<vid>`` naming keys entries by
+        ``variable_vid``, so gates that name the same filing indicator
+        collapse to the same entry.
+        """
+        vids: List[int] = []
+        if isinstance(node, dict):
+            if node.get("class_name") == "PreconditionItem":
+                vid = node.get("variable_vid")
+                if isinstance(vid, int):
+                    vids.append(vid)
+            for value in node.values():
+                if isinstance(value, (dict, list)):
+                    vids.extend(cls._collect_precondition_item_vids(value))
+        elif isinstance(node, list):
+            for item in node:
+                if isinstance(item, (dict, list)):
+                    vids.extend(cls._collect_precondition_item_vids(item))
+        return vids
 
     # ------------------------------------------------------------------ #
     # AST helpers

--- a/src/dpmcore/services/ast_generator.py
+++ b/src/dpmcore/services/ast_generator.py
@@ -656,17 +656,22 @@ class ASTGeneratorService:
     ) -> List[Dict[str, Any]]:
         """Resolve discovered ``PreconditionOperationVID``s into entries.
 
-        Note: :meth:`_build_preconditions_block` does not build a
-        precondition's AST structurally from the DB's stored
-        ``OperationNode`` graph, so it cannot express arbitrary DPM-XL
-        boolean expressions — it only recognises ``{v_<variable_code>}``
-        markers (or an ``and``-chain of them) in the expression text — see
-        its docstring and ``TestBuildPreconditionsBlock`` in
-        ``tests/unit/services/test_ast_generator.py``. A discovered
-        precondition whose stored ``Expression`` isn't in that form resolves
-        to no variables and is silently dropped, same as pydpm. This is a
-        pre-existing limitation of ``script()``'s precondition support, not
-        specific to auto-discovery.
+        Note: :meth:`_build_preconditions_block` parses the stored
+        ``Expression`` and walks the resulting AST — it does not rebuild
+        the gate from the DB's ``OperationNode`` graph. What it can
+        express is therefore the engine's gate contract: filing-indicator
+        selections, run-time parameters and boolean literals combined
+        with ``and`` / ``or`` / ``xor`` / ``not`` (see its docstring and
+        ``TestBuildPreconditionsBlock`` in
+        ``tests/unit/services/test_ast_generator.py``). Two outcomes are
+        not the same and neither is specific to auto-discovery:
+
+        * a gate outside that contract is **not** silently dropped — the
+          operations it guards are reported in ``failed_operations`` and
+          left out of the script, because ungating them would change what
+          gets validated (#338);
+        * a gate whose ``{v_<variable_code>}`` codes do not resolve for
+          the release still drops silently, same as pydpm.
         """
         if not prec_vid_to_codes:
             return []

--- a/src/dpmcore/services/ast_generator.py
+++ b/src/dpmcore/services/ast_generator.py
@@ -24,7 +24,7 @@ from dpmcore.dpm_xl.utils.tokens import (
     SEVERITY_WARNING,
     VALID_SEVERITIES,
 )
-from dpmcore.errors import SemanticError
+from dpmcore.errors import InternalError, SemanticError
 from dpmcore.services._parameters import merge_parameters
 from dpmcore.services._precondition_codes import (
     extract_precondition_codes as _extract_precondition_codes,
@@ -68,12 +68,13 @@ class _PreparedExpression:
     """One expression readied for the script, or the reason it is not.
 
     ``error`` is set when the expression cannot become a declarable
-    operation — it failed semantic validation, or it carries a shift
-    whose reference period cannot be declared (#326). Both are reported
-    the same way, through ``failed_operations``, and both must be caught
-    before the caller accumulates anything for the operation: a skip
-    afterwards would leave its tables, parameters and operation entry in
-    the script.
+    operation — it failed semantic validation, it carries a shift whose
+    reference period cannot be declared (#326), or its precondition is
+    one the engine cannot evaluate (#338). All are reported the same
+    way, through ``failed_operations``, and all must be caught before
+    the caller accumulates anything for the operation: a skip afterwards
+    would leave its tables, parameters and operation entry in the
+    script.
     """
 
     result: Any = None
@@ -168,8 +169,10 @@ class ASTGeneratorService:
             namespaced dict, or ``None`` on failure), ``error`` (str or
             ``None``), and ``failed_operations`` (a
             ``{validation_code: error_message}`` map of expressions
-            skipped due to semantic errors). The namespaced dict mirrors
-            the shape pydpm's ``generate_validations_script`` produces.
+            skipped due to semantic errors, or because their
+            precondition cannot be evaluated by the engine). The
+            namespaced dict mirrors the shape pydpm's
+            ``generate_validations_script`` produces.
         """
         session = self.session
         if (
@@ -209,6 +212,12 @@ class ASTGeneratorService:
                     "error": str(exc),
                     "failed_operations": {},
                 }
+            # Operations whose gate the engine cannot evaluate leave the
+            # script here, before any accumulation, and are reported in
+            # ``failed_operations`` (see ``_unsupported_gate_operations``).
+            gate_failures = self._unsupported_gate_operations(
+                preconditions or []
+            )
 
             from_submission_date = _format_date(
                 mv.from_reference_date, fallback=_DEFAULT_FROM_DATE
@@ -230,12 +239,16 @@ class ASTGeneratorService:
             for item in expressions:
                 expr, code = item[0], item[1]
                 # Semantic validation plus the reference periods the
-                # expression needs; either can reject it. The
-                # _accumulate_parameters call below is complementary to
-                # the scope check inside — it catches conflicts between
-                # two expressions in this same script.
+                # expression needs; either can reject it, as can a gate
+                # the engine cannot evaluate. The _accumulate_parameters
+                # call below is complementary to the scope check inside —
+                # it catches conflicts between two expressions in this
+                # same script.
                 prepared = self._prepare_expression(
-                    self._semantic, expr, release_id
+                    self._semantic,
+                    expr,
+                    release_id,
+                    gate_failure=gate_failures.get(code),
                 )
                 if prepared.error is not None:
                     failed_operations[code] = prepared.error
@@ -323,14 +336,12 @@ class ASTGeneratorService:
             )
 
             # Runtime-binding contract: the declared type of every parameter
-            # this script's operations reference, keyed by code. This is the
-            # scope-wide invariant. ``is_set`` is recoverable from the ``set-``
-            # prefix and ``default`` is a per-reference fallback the engine
-            # binds per scope, so neither belongs in this registry. Populated
-            # after ``_build_preconditions_block`` runs so parameters that
-            # appear only in a gate — legal per the grammar, and reaching the
-            # engine as a runtime input — are declared alongside the ones the
-            # expressions reference.
+            # this script needs, keyed by code. This is the scope-wide
+            # invariant. ``is_set`` is recoverable from the ``set-`` prefix
+            # and ``default`` is a per-reference fallback the engine binds
+            # per scope, so neither belongs in this registry. Built after
+            # the gates so a parameter that only appears in a gate is
+            # declared alongside the ones the expressions reference.
             parameters_block: Dict[str, str] = {
                 prm_code: prm.declared_type
                 for prm_code, prm in sorted(referenced_parameters.items())
@@ -919,6 +930,16 @@ class ASTGeneratorService:
             "severity": severity,
         }
 
+    # The gate contract shared with the engine's precondition evaluator:
+    # filing indicators, run-time parameters and boolean literals combined
+    # with these operators (grouping parentheses are unwrapped). A gate
+    # carrying anything else — a comparison, arithmetic, a cell reference,
+    # a non-boolean literal — has no runtime meaning on the engine side, so
+    # it stays out of the script and its operations are reported through
+    # ``failed_operations`` (see ``_unsupported_gate_operations``).
+    _GATE_BINARY_OPS = frozenset({"and", "or", "xor"})
+    _GATE_UNARY_OPS = frozenset({"not"})
+
     def _build_preconditions_block(
         self,
         preconditions: List[Union[Tuple[str, List[str]], Dict[str, Any]]],
@@ -928,22 +949,28 @@ class ASTGeneratorService:
         """Build the ``preconditions`` and ``precondition_variables`` blocks.
 
         Each gate is parsed once and the resulting AST is walked to build
-        the entry: a ``{v_*}`` selection contributes a ``PreconditionItem``
-        node with the resolved ``variable_id`` / ``variable_vid``, a
-        ``{p_*}`` reference contributes the ``ParameterRef`` node with
-        ``code`` / ``param_type`` preserved, and every logical operator
-        that connects them (``and``/``or``/``not``, ``ParExpr``) survives
-        into the emitted tree. Gates that used to depend on the regex
-        matching only ``{v_*}`` positions — a parameter-only gate, or a
-        mixed gate whose parameter half was silently dropped — now reach
-        the engine intact.
+        the entry: a ``{v_*}`` selection becomes a ``PreconditionItem``
+        node with the resolved ``variable_id``, a ``{p_*}`` reference is
+        emitted as the same ``ParameterRef`` node an expression produces
+        (``code``, canonical ``param_type``, ``default``), and every
+        logical operator that connects them (``and`` / ``or`` / ``xor`` /
+        ``not``) survives into the emitted tree, so ``{v_A} or {v_B}``
+        reaches the engine as a disjunction instead of the ``and``-fold
+        the old regex path produced. Grouping parentheses are unwrapped:
+        the tree shape already carries the precedence.
 
-        A parameter that shows up in a gate is added to
-        ``referenced_parameters`` in the same pass, so
-        ``parameters_block`` declares it alongside those the expressions
-        reference and the scope-wide type agreement in
+        A parameter that appears in a gate is added to
+        ``referenced_parameters`` in the same pass, so the script-level
+        ``parameters`` block declares it alongside the ones the
+        expressions reference and the scope-wide type agreement in
         :func:`~dpmcore.services._parameters.merge_parameters` runs
-        against a single registry.
+        against a single registry (``3-8`` on a conflicting type).
+
+        Gates outside that contract (a comparison, a cell reference, a
+        non-boolean literal) are excluded here, and :meth:`script`
+        reports their operations in ``failed_operations`` instead of
+        shipping a gate the engine cannot evaluate. Codes that don't
+        resolve are still skipped silently (matches pydpm).
         """
         from dpmcore.dpm_xl.model_queries import VariableVersionQuery
         from dpmcore.dpm_xl.utils.serialization import serialize_ast
@@ -977,7 +1004,7 @@ class ASTGeneratorService:
             )
             if gate_ast is None:
                 # Every ``{v_*}`` position dropped for lack of resolution
-                # and the tree carried no parameter to keep it standing.
+                # and nothing else in the tree to keep it standing.
                 continue
             if referenced_parameters is not None:
                 self._accumulate_precondition_parameters(
@@ -1012,6 +1039,120 @@ class ASTGeneratorService:
                 merged_ops.append(op)
         existing["affected_operations"] = merged_ops
 
+    @staticmethod
+    def _gate_spec_fields(
+        precond_spec: Union[Tuple[str, List[str]], Dict[str, Any]],
+    ) -> Tuple[str, List[str], Optional[str], Optional[int]]:
+        """Normalise a gate spec to ``(expression, codes, code, vid)``.
+
+        Both input shapes are accepted: the ``(expression,
+        affected_operations)`` tuple, and the dict form that may also
+        carry an explicit ``code`` / ``version_id`` override.
+        """
+        if isinstance(precond_spec, dict):
+            return (
+                precond_spec["expression"],
+                precond_spec["affected_operations"],
+                precond_spec.get("code"),
+                precond_spec.get("version_id"),
+            )
+        precond_expr, validation_codes = precond_spec
+        return precond_expr, validation_codes, None, None
+
+    def _unsupported_gate_operations(
+        self,
+        preconditions: List[Union[Tuple[str, List[str]], Dict[str, Any]]],
+    ) -> Dict[str, str]:
+        """Map each operation gated by an engine-unsupported gate to a reason.
+
+        The gate contract is filing indicators, run-time parameters and
+        boolean literals combined with ``and`` / ``or`` / ``xor`` /
+        ``not``. The engine's precondition evaluator has no evaluation
+        for anything else — a comparison, arithmetic, a cell reference —
+        and such a node in a gate fails the run. A gate outside the
+        contract must therefore not be emitted, and silently dropping it
+        would ungate the operations it guards. This is the third option:
+        the operations are reported in :meth:`script`'s
+        ``failed_operations`` with the reason, and left out of the
+        script. Gates that fail to parse are ignored here —
+        ``_build_precondition_index`` already turns them into a
+        script-level error.
+        """
+        failures: Dict[str, str] = {}
+        for precond_spec in preconditions:
+            precond_expr, validation_codes, _, _ = self._gate_spec_fields(
+                precond_spec
+            )
+            if not precond_expr:
+                continue
+            try:
+                ast = self._syntax.parse(precond_expr)
+            except Exception:  # noqa: S112 — see docstring above
+                continue
+            reason = self._gate_unsupported_reason(ast)
+            if reason is None:
+                continue
+            message = (
+                f"Precondition {precond_expr!r} cannot be evaluated by the "
+                f"engine: {reason}. A precondition may only combine "
+                "filing indicators, parameters and boolean literals with "
+                "and/or/xor/not."
+            )
+            for validation_code in validation_codes:
+                failures.setdefault(validation_code, message)
+        return failures
+
+    @classmethod
+    def _gate_unsupported_reason(cls, node: Any) -> Optional[str]:
+        """Why the engine could not evaluate this gate, or ``None`` if it can.
+
+        Walks the parsed gate and returns a short reason for the first
+        node outside the contract: filing-indicator selections
+        (``VarRef`` / ``PreconditionItem``), ``ParameterRef`` and boolean
+        ``Constant`` leaves joined by ``_GATE_BINARY_OPS`` /
+        ``_GATE_UNARY_OPS``, optionally grouped.
+        """
+        from dpmcore.dpm_xl.ast import nodes as ast_nodes
+
+        node = cls._unwrap_start(node, ast_nodes)
+        if isinstance(node, ast_nodes.Start):
+            return "it is not a single expression"
+        if isinstance(node, ast_nodes.ParExpr):
+            return cls._gate_unsupported_reason(node.expression)
+        if isinstance(node, (ast_nodes.BinOp, ast_nodes.UnaryOp)):
+            return cls._gate_operator_unsupported_reason(node, ast_nodes)
+        if isinstance(
+            node,
+            (
+                ast_nodes.VarRef,
+                ast_nodes.PreconditionItem,
+                ast_nodes.ParameterRef,
+            ),
+        ):
+            return None
+        if isinstance(node, ast_nodes.Constant):
+            if node.type == "Boolean":
+                return None
+            return f"it contains the non-boolean literal {node.value!r}"
+        if isinstance(node, ast_nodes.VarID):
+            return "it references a cell"
+        return f"it contains a {node.__class__.__name__} node"
+
+    @classmethod
+    def _gate_operator_unsupported_reason(
+        cls, node: Any, ast_nodes: Any
+    ) -> Optional[str]:
+        """The operator half of :meth:`_gate_unsupported_reason`."""
+        if isinstance(node, ast_nodes.BinOp):
+            if node.op not in cls._GATE_BINARY_OPS:
+                return f"it uses the operator {node.op!r}"
+            return cls._gate_unsupported_reason(
+                node.left
+            ) or cls._gate_unsupported_reason(node.right)
+        if node.op not in cls._GATE_UNARY_OPS:
+            return f"it uses the operator {node.op!r}"
+        return cls._gate_unsupported_reason(node.operand)
+
     def _parse_gates(
         self,
         preconditions: List[Union[Tuple[str, List[str]], Dict[str, Any]]],
@@ -1019,37 +1160,36 @@ class ASTGeneratorService:
         List[Tuple[Any, List[str], Optional[str], Optional[int]]],
         List[str],
     ]:
-        """Parse every gate once and index the ``{v_*}`` codes referenced.
+        """Parse every emittable gate once and index its ``{v_*}`` codes.
 
         Returns ``(parsed_gates, all_codes)`` where ``parsed_gates`` is
         the list of ``(ast, validation_codes, provided_code,
         provided_version_id)`` tuples the caller iterates over, and
         ``all_codes`` is the deduplicated list of variable codes to feed
-        the batched DB resolution. A gate that fails to parse is dropped
-        silently — the top-level ``_build_precondition_index`` already
-        surfaces the failure and turns it into a script-level error, and
-        keeping the gate out here matches the pre-existing "codes that
-        don't resolve are silently skipped" contract.
+        the batched DB resolution. Two kinds of gate are left out: one
+        that fails to parse — ``_build_precondition_index`` already
+        surfaces that as a script-level error — and one the engine
+        cannot evaluate, whose operations
+        ``_unsupported_gate_operations`` has already reported.
         """
         parsed_gates: List[
             Tuple[Any, List[str], Optional[str], Optional[int]]
         ] = []
         all_codes: List[str] = []
         for precond_spec in preconditions:
-            if isinstance(precond_spec, dict):
-                precond_expr = precond_spec["expression"]
-                validation_codes = precond_spec["affected_operations"]
-                provided_code = precond_spec.get("code")
-                provided_version_id = precond_spec.get("version_id")
-            else:
-                precond_expr, validation_codes = precond_spec
-                provided_code = None
-                provided_version_id = None
+            (
+                precond_expr,
+                validation_codes,
+                provided_code,
+                provided_version_id,
+            ) = self._gate_spec_fields(precond_spec)
             if not precond_expr:
                 continue
             try:
                 ast = self._syntax.parse(precond_expr)
             except Exception:  # noqa: S112 — see docstring above
+                continue
+            if self._gate_unsupported_reason(ast) is not None:
                 continue
             parsed_gates.append(
                 (ast, validation_codes, provided_code, provided_version_id)
@@ -1066,32 +1206,26 @@ class ASTGeneratorService:
         resolved: Dict[str, Dict[str, int]],
         precondition_variables: Dict[str, str],
         serialize_ast: Any,
-    ) -> Any:
+    ) -> Optional[Dict[str, Any]]:
         """Walk the parsed gate AST and emit the engine's dict shape.
 
-        Three transformations happen along the way:
+        ``VarRef`` (the parser's node for ``{v_*}``) and ``PreconditionItem``
+        collapse to a ``PreconditionItem`` dict with the resolved
+        ``variable_id``, registering the ``variable_vid`` in
+        ``precondition_variables`` on the way. A selection that does not
+        resolve is dropped and the surrounding operator is rewired to keep
+        the tree standing — or the whole gate returns ``None`` when nothing
+        survives. ``ParExpr`` wrappers are unwrapped; ``BinOp`` /
+        ``UnaryOp`` keep their operator. ``ParameterRef`` and boolean
+        ``Constant`` leaves go through the standard ``serialize_ast`` path,
+        so the gate carries exactly the node shape an expression would
+        (``code`` / ``param_type`` / ``default``; ``type_`` / ``value``).
+        Any other node is a programming error here: ``_parse_gates`` keeps
+        gates carrying one out, so the emitter never has to guess a wire
+        shape the engine lacks.
 
-        1. ``VarRef`` (the parser's node for ``{v_*}``) and any ``VarID``
-           whose selection uses the ``v`` prefix collapse to a
-           ``PreconditionItem`` dict with the resolved ``variable_id``,
-           and the resolved ``variable_vid`` is registered in
-           ``precondition_variables``. When the code cannot be resolved,
-           the node is dropped: the caller then rewires the surrounding
-           logical operator to keep the tree standing, or returns
-           ``None`` if nothing survives.
-        2. ``ParExpr`` wrappers unwrap once their child is finalised —
-           the engine reads meaning from operator precedence in the
-           tree, not from redundant grouping.
-        3. Every other node kind — ``ParameterRef``, ``BinOp`` /
-           ``UnaryOp`` whose operands are not selections, literals, and
-           so on — is serialised through the standard ``serialize_ast``
-           path, so the tree the engine sees matches the shape used in
-           expressions.
-
-        The walker takes the parsed AST (not the serialised dict) so
-        the ``variable`` attribute of a ``VarRef`` reaches the resolver
-        intact; the standard serializer's ``generic_visit`` does not
-        propagate that attribute.
+        The walker takes the parsed AST (not the serialised dict) so the
+        ``variable`` attribute of a ``VarRef`` reaches the resolver intact.
         """
         from dpmcore.dpm_xl.ast import nodes as ast_nodes
 
@@ -1107,29 +1241,23 @@ class ASTGeneratorService:
                 precondition_variables,
                 serialize_ast,
             )
-        if isinstance(node, ast_nodes.VarRef):
-            return cls._precondition_item_from_varref(
-                node, resolved, precondition_variables
+        if isinstance(node, (ast_nodes.VarRef, ast_nodes.PreconditionItem)):
+            variable = getattr(node, "variable", None) or getattr(
+                node, "variable_code", None
             )
-        if isinstance(node, ast_nodes.VarID):
-            return cls._precondition_item_from_varid(
-                node, resolved, precondition_variables
+            return cls._precondition_item(
+                variable, resolved, precondition_variables
             )
+        if isinstance(node, (ast_nodes.ParameterRef, ast_nodes.Constant)):
+            serialized: Dict[str, Any] = serialize_ast(node)
+            return serialized
         if isinstance(node, ast_nodes.BinOp):
             left = cls._transform_precondition_ast(
-                node.left,
-                resolved,
-                precondition_variables,
-                serialize_ast,
+                node.left, resolved, precondition_variables, serialize_ast
             )
             right = cls._transform_precondition_ast(
-                node.right,
-                resolved,
-                precondition_variables,
-                serialize_ast,
+                node.right, resolved, precondition_variables, serialize_ast
             )
-            if left is None and right is None:
-                return None
             if left is None:
                 return right
             if right is None:
@@ -1142,10 +1270,7 @@ class ASTGeneratorService:
             }
         if isinstance(node, ast_nodes.UnaryOp):
             operand = cls._transform_precondition_ast(
-                node.operand,
-                resolved,
-                precondition_variables,
-                serialize_ast,
+                node.operand, resolved, precondition_variables, serialize_ast
             )
             if operand is None:
                 return None
@@ -1154,11 +1279,11 @@ class ASTGeneratorService:
                 "op": node.op,
                 "operand": operand,
             }
-        # Any other node kind (ParameterRef, Scalar, Set, ...) is
-        # serialised as-is; the tree walker never had special handling
-        # for it and the standard serializer already produces the shape
-        # the engine expects.
-        return serialize_ast(node)
+        raise InternalError(
+            "Unsupported node in a precondition gate",
+            f"{node.__class__.__name__} reached the gate emitter; "
+            "_parse_gates should have excluded this gate.",
+        )
 
     @staticmethod
     def _unwrap_start(node: Any, ast_nodes: Any) -> Any:
@@ -1175,19 +1300,17 @@ class ASTGeneratorService:
         return node
 
     @staticmethod
-    def _precondition_item_from_varref(
-        node: Any,
+    def _precondition_item(
+        variable: Any,
         resolved: Dict[str, Dict[str, int]],
         precondition_variables: Dict[str, str],
     ) -> Optional[Dict[str, Any]]:
-        """Rewrite a ``VarRef`` node as a ``PreconditionItem``.
+        """Emit the ``PreconditionItem`` dict for a filing-indicator code.
 
-        ``VarRef`` is what the parser produces for a bare variable
-        selection; ``VarID`` handles the fuller cell-reference form.
-        Both routes converge on ``PreconditionItem`` here: the engine
-        binds a filing indicator, not a cell.
+        Codes that don't resolve return ``None`` so the caller can drop
+        the position — the same non-fatal outcome the previous regex
+        path produced when a code was unknown.
         """
-        variable = getattr(node, "variable", None)
         if not isinstance(variable, str):
             return None
         var_code = _normalize_variable_code(variable)
@@ -1202,40 +1325,8 @@ class ASTGeneratorService:
             # Kept for key derivation in
             # ``_build_precondition_entry_from_ast`` — the pre-existing
             # ``p_<vid>`` scheme groups precondition entries by
-            # ``variable_vid``, not ``variable_id``. The engine ignores
-            # this field on the emitted node.
-            "variable_vid": info["variable_vid"],
-        }
-
-    @staticmethod
-    def _precondition_item_from_varid(
-        node: Any,
-        resolved: Dict[str, Dict[str, int]],
-        precondition_variables: Dict[str, str],
-    ) -> Optional[Dict[str, Any]]:
-        """Rewrite a variable-selection ``VarID`` as a ``PreconditionItem``.
-
-        Codes that don't resolve return ``None`` so the caller can drop
-        the position — the same non-fatal outcome the previous regex
-        path produced when a code was unknown.
-        """
-        table = getattr(node, "table", None)
-        if not isinstance(table, str):
-            return None
-        var_code = _normalize_variable_code(table)
-        info = resolved.get(var_code)
-        if info is None:
-            return None
-        precondition_variables[str(info["variable_vid"])] = "b"
-        return {
-            "class_name": "PreconditionItem",
-            "variable_id": info["variable_id"],
-            "variable_code": var_code,
-            # Kept for key derivation in
-            # ``_build_precondition_entry_from_ast`` — the pre-existing
-            # ``p_<vid>`` scheme groups precondition entries by
-            # ``variable_vid``, not ``variable_id``. The engine ignores
-            # this field on the emitted node.
+            # ``variable_vid``, not ``variable_id``. Stripped before the
+            # entry is emitted; the engine's node has no such field.
             "variable_vid": info["variable_vid"],
         }
 
@@ -1245,14 +1336,15 @@ class ASTGeneratorService:
         referenced_parameters: Dict[str, ParameterInfo],
         node: Any,
     ) -> None:
-        """Add every ``ParameterRef`` in the gate to the script registry.
+        """Add every ``ParameterRef`` in the emitted gate to the registry.
 
         Reads the type off the serialised node so the shared registry
-        holds the same value the engine will bind against. Two gate
-        positions with the same ``code`` but different ``param_type``
-        raise ``SemanticError`` ``3-8`` via :func:`merge_parameters`,
-        exactly as they would if the same conflict appeared between
-        two expressions.
+        holds the same canonical name the engine binds against. A gate
+        parameter redeclared with another type — in another gate or in an
+        expression — raises ``SemanticError`` ``3-8`` through
+        :func:`~dpmcore.services._parameters.merge_parameters`, exactly
+        as the conflict between two expressions does. ``default`` is a
+        per-reference fallback and stays on the node only.
         """
         if isinstance(node, dict):
             if node.get("class_name") == "ParameterRef":
@@ -1282,13 +1374,32 @@ class ASTGeneratorService:
                     )
 
     @classmethod
+    def _is_conjunction_of_items(cls, node: Any) -> bool:
+        """``True`` for the shape the regex path used to emit.
+
+        That is a ``PreconditionItem`` or an ``and`` tree whose leaves
+        are all ``PreconditionItem`` — the only shape for which the
+        ``p_<sorted vids>`` key alone identifies the gate.
+        """
+        if not isinstance(node, dict):
+            return False
+        class_name = node.get("class_name")
+        if class_name == "PreconditionItem":
+            return True
+        return (
+            class_name == "BinOp"
+            and node.get("op") == "and"
+            and cls._is_conjunction_of_items(node.get("left"))
+            and cls._is_conjunction_of_items(node.get("right"))
+        )
+
+    @classmethod
     def _strip_precondition_item_vids(cls, node: Any) -> None:
         """Drop the internal ``variable_vid`` field from every item node.
 
-        ``variable_vid`` is added by
-        :meth:`_precondition_item_from_varref` so key derivation groups
-        entries the same way ``p_<vid>`` used to. The engine's
-        ``PreconditionItem`` schema only carries ``variable_id`` and
+        ``variable_vid`` is added by :meth:`_precondition_item` so key
+        derivation groups entries the same way ``p_<vid>`` used to. The
+        engine's ``PreconditionItem`` only carries ``variable_id`` and
         ``variable_code``, so the field is stripped once the key has
         been built.
         """
@@ -1313,28 +1424,38 @@ class ASTGeneratorService:
     ) -> Tuple[str, Dict[str, Any]]:
         """Assemble a ``preconditions[key]`` entry from an emitted gate AST.
 
-        The key groups together gates that emit the same sorted set of
-        ``PreconditionItem`` variable-vids — the pre-existing dedup
-        contract, preserved so a gate that today merges two operations
-        under one key keeps doing so. Gates whose only content is a
-        ``ParameterRef`` fall back to a hash-based key derived from the
-        canonical AST, so they still get a unique slot instead of
-        overwriting one another.
+        The key must identify the gate's meaning, because
+        :meth:`_merge_precondition_entry` unions the ``affected_operations``
+        of entries that share a key under the first entry's ``ast``. For
+        the shape the regex path used to emit — filing indicators joined
+        by ``and`` — the key stays ``p_<sorted vids>``, so those gates
+        (all of them on the dictionaries shipped so far) are unchanged
+        and keep merging as before. Any other shape (``or`` / ``xor`` /
+        ``not``, a parameter, a literal) appends a CRC-32 of the canonical
+        AST — ``p_<sorted vids>_<crc>``, or ``p_<crc>`` when the gate has
+        no filing indicator — so ``{v_A} or {v_B}`` can never be merged
+        into ``{v_A} and {v_B}``. ``version_id`` follows the same rule as
+        an operation without one: the first vid, or the CRC folded to four
+        digits. ``provided_code`` / ``provided_version_id`` override both.
         """
         item_vids = sorted(cls._collect_precondition_item_vids(gate_ast))
-        # Strip the internal ``variable_vid`` field once the key is
-        # settled; the engine's ``PreconditionItem`` schema does not
-        # carry it.
+        # Strip the internal ``variable_vid`` field before hashing and
+        # emitting; the engine's ``PreconditionItem`` does not carry it.
         cls._strip_precondition_item_vids(gate_ast)
-        if item_vids:
-            default_key = "p_" + "_".join(str(v) for v in item_vids)
-            default_version_id: int = item_vids[0]
+        vids_part = "_".join(str(v) for v in item_vids)
+        if cls._is_conjunction_of_items(gate_ast):
+            default_key = f"p_{vids_part}"
+            default_version_id = item_vids[0]
         else:
             digest = zlib.crc32(
                 json.dumps(gate_ast, sort_keys=True).encode("utf-8")
             )
-            default_key = f"p_gate_{digest:08x}"
-            default_version_id = digest % 10000
+            default_key = (
+                f"p_{vids_part}_{digest:08x}"
+                if item_vids
+                else f"p_{digest:08x}"
+            )
+            default_version_id = item_vids[0] if item_vids else digest % 10000
         code = provided_code if provided_code is not None else default_key
         version_id = (
             provided_version_id
@@ -1514,12 +1635,9 @@ class ASTGeneratorService:
         """
         index: Dict[str, List[str]] = {}
         for precond_spec in preconditions:
-            if isinstance(precond_spec, dict):
-                precond_expr = precond_spec["expression"]
-                validation_codes = precond_spec["affected_operations"]
-            else:
-                precond_expr, validation_codes = precond_spec
-
+            precond_expr, validation_codes, _, _ = self._gate_spec_fields(
+                precond_spec
+            )
             try:
                 ast = self._syntax.parse(precond_expr)
             except Exception as exc:
@@ -1768,6 +1886,7 @@ extract_precondition_codes`, shared with
         semantic: SemanticService,
         expr: str,
         release_id: int,
+        gate_failure: Optional[str] = None,
     ) -> _PreparedExpression:
         """Validate *expr* and read the reference periods it needs.
 
@@ -1776,7 +1895,14 @@ extract_precondition_codes`, shared with
         co-scoped operation already persisted in the DB (raises 3-8).
         ``_accumulate_parameters`` in the caller is complementary — it
         catches conflicts between two expressions in the same script.
+
+        ``gate_failure`` is the reason the operation's precondition
+        cannot be evaluated by the engine, when there is one (see
+        ``_unsupported_gate_operations``); such an operation is skipped
+        before validation, with that reason as its error.
         """
+        if gate_failure is not None:
+            return _PreparedExpression(error=gate_failure)
         result = semantic.validate(expr, release_id=release_id)
         if not result.is_valid:
             return _PreparedExpression(

--- a/tests/integration/services/test_ast_generator_discovery.py
+++ b/tests/integration/services/test_ast_generator_discovery.py
@@ -16,13 +16,18 @@ historical version dpmcore resolves to.
 
 from __future__ import annotations
 
+import re
+
 import pytest
 from sqlalchemy import text
 
-from dpmcore.services.ast_generator import (
-    _VAR_REF_PATTERN,
-    ASTGeneratorService,
-)
+from dpmcore.services.ast_generator import ASTGeneratorService
+
+# The filing-indicator marker, as it appears in a raw precondition
+# expression. The service itself no longer scans text for it (#338 parses
+# the gate and walks the AST instead); this is only the discovery filter
+# that picks the DB rows this test can assert an entry for.
+_VAR_REF_PATTERN = re.compile(r"\{v_?([^}]+)\}")
 
 # Also exercised by test_ast_generator_condexpr.py — known to have active,
 # type-checking validations in the fixture DB.

--- a/tests/unit/services/test_ast_generator.py
+++ b/tests/unit/services/test_ast_generator.py
@@ -38,6 +38,91 @@ def _patch_orm(monkeypatch):
         monkeypatch.setitem(sys.modules, name, stub)
 
 
+@pytest.fixture
+def real_parameter_info(monkeypatch):
+    """Install the real ``ParameterInfo`` dataclass in place of the mock.
+
+    ``dpmcore.services.semantic`` is stubbed wholesale by ``_patch_orm``,
+    so ``ParameterInfo`` reaches ``ast_generator`` as a ``MagicMock``
+    class whose instances compare unequal by identity. Tests that
+    exercise the parameter registry need a real dataclass with proper
+    ``__eq__`` semantics.
+    """
+    from dataclasses import dataclass, field
+    from types import SimpleNamespace as _SNS
+
+    @dataclass(frozen=True)
+    class ParameterInfo:  # type: ignore[no-redef]
+        code: str
+        declared_type: str
+        default: object = field(default=None)
+
+        @property
+        def is_set(self) -> bool:  # pragma: no cover — parity with real
+            return self.declared_type.startswith("Set")
+
+    stub = _SNS(
+        ParameterInfo=ParameterInfo,
+        SemanticService=MagicMock(),
+    )
+    monkeypatch.setitem(sys.modules, "dpmcore.services.semantic", stub)
+    return ParameterInfo
+
+
+@pytest.fixture
+def real_syntax(monkeypatch):
+    """Install a real SyntaxService for tests that parse gate expressions.
+
+    The shadow-loader in ``_load_ast_generator`` swaps in stubs for the
+    heavy ORM chain before importing ``ast_generator``. Neither
+    ``SyntaxService`` nor ``serialize_ast`` needs the ORM, so we load
+    them by file path (bypassing the module-cached stubs) and rebind
+    ``dpmcore.dpm_xl.utils.serialization`` to the real thing so
+    ``_build_preconditions_block`` walks a real AST.
+    """
+    import importlib.util
+    from types import SimpleNamespace as _SNS
+
+    # These modules are needed to load the real syntax + serialization
+    # by-path — ``_precondition_codes`` walks the AST via a visitor
+    # whose ``ASTTemplate`` base pulls in ``dpm_xl.utils.filters``,
+    # which in turn imports ``release_sort_order`` and
+    # ``query_utils``. Neither runs any real query in this test.
+    for extra in (
+        "dpmcore.orm.release_sort_order",
+        "dpmcore.orm.query_utils",
+    ):
+        monkeypatch.setitem(sys.modules, extra, MagicMock())
+
+    def _load(name: str, relpath: str):
+        spec = importlib.util.spec_from_file_location(
+            name, _REPO_ROOT / relpath
+        )
+        assert spec is not None
+        assert spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        # Register with the shadow name so intra-module references keep
+        # working, but leave the canonical module name pointing at the
+        # existing stub for callers that never come through the fixture.
+        sys.modules[name] = module
+        spec.loader.exec_module(module)
+        return module
+
+    syntax_module = _load(
+        "_test_shadow_syntax", "src/dpmcore/services/syntax.py"
+    )
+    serialization = _load(
+        "_test_shadow_serialization",
+        "src/dpmcore/dpm_xl/utils/serialization.py",
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "dpmcore.dpm_xl.utils.serialization",
+        _SNS(serialize_ast=serialization.serialize_ast),
+    )
+    return syntax_module.SyntaxService()
+
+
 def _load_ast_generator():
     """Load ``ast_generator`` under a private shadow name."""
     shadow_name = "_test_shadow_ast_generator"
@@ -347,6 +432,17 @@ class TestBuildOperationEntry:
 # ------------------------------------------------------------------ #
 
 
+def _install_variable_resolver(monkeypatch, resolved):
+    """Wire ``VariableVersionQuery.get_variable_vids_by_codes`` to *resolved*."""
+    fake_query = MagicMock()
+    fake_query.get_variable_vids_by_codes.return_value = resolved
+    monkeypatch.setitem(
+        sys.modules,
+        "dpmcore.dpm_xl.model_queries",
+        SimpleNamespace(VariableVersionQuery=fake_query),
+    )
+
+
 class TestBuildPreconditionsBlock:
     def test_empty_input_returns_empty(self):
         svc, _, _ = _bare_svc()
@@ -363,18 +459,15 @@ class TestBuildPreconditionsBlock:
             "{vC_01.00}",  # cosmetic underscore omitted
         ],
     )
-    def test_single_variable_emits_p_vid(self, expression, monkeypatch):
-        svc, _, mod = _bare_svc()
+    def test_single_variable_emits_p_vid(
+        self, expression, monkeypatch, real_syntax
+    ):
+        svc, _, _ = _bare_svc()
         svc.session = MagicMock()
-
-        fake_query = MagicMock()
-        fake_query.get_variable_vids_by_codes.return_value = {
-            "C_01.00": {"variable_id": 11, "variable_vid": 110}
-        }
-        monkeypatch.setitem(
-            sys.modules,
-            "dpmcore.dpm_xl.model_queries",
-            SimpleNamespace(VariableVersionQuery=fake_query),
+        svc._syntax = real_syntax
+        _install_variable_resolver(
+            monkeypatch,
+            {"C_01.00": {"variable_id": 11, "variable_vid": 110}},
         )
 
         preconds, vars_ = svc._build_preconditions_block(
@@ -389,20 +482,21 @@ class TestBuildPreconditionsBlock:
         assert entry["code"] == "p_110"
         assert vars_ == {"110": "b"}
 
-    def test_compound_emits_left_folded_binop(self, monkeypatch):
+    def test_compound_emits_binop_tree(self, monkeypatch, real_syntax):
+        """Compound gates preserve the ``and``/``or`` structure the source
+        text carries — the parser's associativity, not a left-fold hard-
+        coded by the emitter.
+        """
         svc, _, _ = _bare_svc()
         svc.session = MagicMock()
-
-        fake_query = MagicMock()
-        fake_query.get_variable_vids_by_codes.return_value = {
-            "A": {"variable_id": 1, "variable_vid": 10},
-            "B": {"variable_id": 2, "variable_vid": 20},
-            "C": {"variable_id": 3, "variable_vid": 30},
-        }
-        monkeypatch.setitem(
-            sys.modules,
-            "dpmcore.dpm_xl.model_queries",
-            SimpleNamespace(VariableVersionQuery=fake_query),
+        svc._syntax = real_syntax
+        _install_variable_resolver(
+            monkeypatch,
+            {
+                "A": {"variable_id": 1, "variable_vid": 10},
+                "B": {"variable_id": 2, "variable_vid": 20},
+                "C": {"variable_id": 3, "variable_vid": 30},
+            },
         )
 
         preconds, vars_ = svc._build_preconditions_block(
@@ -410,26 +504,32 @@ class TestBuildPreconditionsBlock:
         )
         assert "p_10_20_30" in preconds
         ast = preconds["p_10_20_30"]["ast"]
-        # Left fold: ((A and B) and C)
         assert ast["class_name"] == "BinOp"
         assert ast["op"] == "and"
-        assert ast["right"]["variable_id"] == 3
-        assert ast["left"]["class_name"] == "BinOp"
-        assert ast["left"]["right"]["variable_id"] == 2
-        assert ast["left"]["left"]["variable_id"] == 1
+
+        # Every PreconditionItem the tree carries maps back to A/B/C —
+        # the exact associativity depends on the parser, so we assert
+        # the multiset of ``variable_id``s rather than the shape.
+        vids = set()
+
+        def _collect(node):
+            if not isinstance(node, dict):
+                return
+            if node.get("class_name") == "PreconditionItem":
+                vids.add(node.get("variable_id"))
+            for value in node.values():
+                if isinstance(value, (dict, list)):
+                    _collect(value)
+
+        _collect(ast)
+        assert vids == {1, 2, 3}
         assert vars_ == {"10": "b", "20": "b", "30": "b"}
 
-    def test_unresolved_codes_silently_skipped(self, monkeypatch):
+    def test_unresolved_codes_silently_skipped(self, monkeypatch, real_syntax):
         svc, _, _ = _bare_svc()
         svc.session = MagicMock()
-
-        fake_query = MagicMock()
-        fake_query.get_variable_vids_by_codes.return_value = {}
-        monkeypatch.setitem(
-            sys.modules,
-            "dpmcore.dpm_xl.model_queries",
-            SimpleNamespace(VariableVersionQuery=fake_query),
-        )
+        svc._syntax = real_syntax
+        _install_variable_resolver(monkeypatch, {})
 
         preconds, vars_ = svc._build_preconditions_block(
             [("{v_unresolved}", ["v1"])], release_id=None
@@ -437,25 +537,22 @@ class TestBuildPreconditionsBlock:
         assert preconds == {}
         assert vars_ == {}
 
-    def test_collision_merges_affected_operations(self, monkeypatch):
-        """Same precondition shape across two entries merges ops.
+    def test_collision_merges_affected_operations(
+        self, monkeypatch, real_syntax
+    ):
+        """Two gates that collapse to the same key merge their operations.
 
-        Regression for B2: two preconditions producing the same key
-        used to silently overwrite each other, dropping the earlier
-        ``affected_operations``. The merged entry should now contain
-        both validation codes, deduplicated and order-preserving.
+        Regression for B2: two preconditions producing the same key used
+        to silently overwrite each other and drop the earlier
+        ``affected_operations``. The merged entry should now list both
+        validation codes, deduplicated and in order.
         """
         svc, _, _ = _bare_svc()
         svc.session = MagicMock()
-
-        fake_query = MagicMock()
-        fake_query.get_variable_vids_by_codes.return_value = {
-            "C_01.00": {"variable_id": 11, "variable_vid": 110},
-        }
-        monkeypatch.setitem(
-            sys.modules,
-            "dpmcore.dpm_xl.model_queries",
-            SimpleNamespace(VariableVersionQuery=fake_query),
+        svc._syntax = real_syntax
+        _install_variable_resolver(
+            monkeypatch,
+            {"C_01.00": {"variable_id": 11, "variable_vid": 110}},
         )
 
         preconds, _vars = svc._build_preconditions_block(
@@ -472,19 +569,16 @@ class TestBuildPreconditionsBlock:
             "v3",
         ]
 
-    def test_dict_format_with_custom_code_and_version_id(self, monkeypatch):
-        """Dict format allows overriding code and version_id"""
+    def test_dict_format_with_custom_code_and_version_id(
+        self, monkeypatch, real_syntax
+    ):
+        """Dict format allows overriding code and version_id."""
         svc, _, _ = _bare_svc()
         svc.session = MagicMock()
-
-        fake_query = MagicMock()
-        fake_query.get_variable_vids_by_codes.return_value = {
-            "C_01.00": {"variable_id": 11, "variable_vid": 110}
-        }
-        monkeypatch.setitem(
-            sys.modules,
-            "dpmcore.dpm_xl.model_queries",
-            SimpleNamespace(VariableVersionQuery=fake_query),
+        svc._syntax = real_syntax
+        _install_variable_resolver(
+            monkeypatch,
+            {"C_01.00": {"variable_id": 11, "variable_vid": 110}},
         )
 
         preconds, vars_ = svc._build_preconditions_block(
@@ -492,8 +586,8 @@ class TestBuildPreconditionsBlock:
                 {
                     "expression": "{v_C_01.00}",
                     "affected_operations": ["v1", "v2"],
-                    "code": "P_571",  # Override default p_110
-                    "version_id": 8341,  # Override default 110
+                    "code": "P_571",  # override default p_110
+                    "version_id": 8341,  # override default 110
                 }
             ],
             release_id=5,
@@ -505,22 +599,18 @@ class TestBuildPreconditionsBlock:
         assert entry["affected_operations"] == ["v1", "v2"]
         assert vars_ == {"110": "b"}
 
-    def test_backward_compat_tuple_format_still_works(self, monkeypatch):
+    def test_backward_compat_tuple_format_still_works(
+        self, monkeypatch, real_syntax
+    ):
         """Tuple format (old) still works for backward compatibility."""
         svc, _, _ = _bare_svc()
         svc.session = MagicMock()
-
-        fake_query = MagicMock()
-        fake_query.get_variable_vids_by_codes.return_value = {
-            "C_01.00": {"variable_id": 11, "variable_vid": 110}
-        }
-        monkeypatch.setitem(
-            sys.modules,
-            "dpmcore.dpm_xl.model_queries",
-            SimpleNamespace(VariableVersionQuery=fake_query),
+        svc._syntax = real_syntax
+        _install_variable_resolver(
+            monkeypatch,
+            {"C_01.00": {"variable_id": 11, "variable_vid": 110}},
         )
 
-        # Old tuple format should still work
         preconds, vars_ = svc._build_preconditions_block(
             [("{v_C_01.00}", ["v1", "v2"])],
             release_id=5,
@@ -529,6 +619,107 @@ class TestBuildPreconditionsBlock:
         entry = preconds["p_110"]
         assert entry["code"] == "p_110"
         assert entry["version_id"] == 110
+
+
+# ------------------------------------------------------------------ #
+# Issue #338 — gates carrying parameters and mixed shapes
+# ------------------------------------------------------------------ #
+
+
+class TestGateParameterPropagation:
+    """A ``{p_*}`` reference in the gate reaches the engine intact.
+
+    Regression for #338: the old regex path extracted only ``{v_*}``
+    positions, so a parameter or a logical operator that connected one
+    to a filing indicator was silently dropped and never reached
+    ``preconditions[<key>]["ast"]`` or the script-level ``parameters``
+    registry. The AST walker now emits ``ParameterRef`` alongside
+    ``PreconditionItem`` and populates the parameter registry in the
+    same pass.
+    """
+
+    def test_parameter_only_gate_emits_entry(
+        self, monkeypatch, real_syntax, real_parameter_info
+    ):
+        """A gate that is nothing but a parameter reference no longer
+        vanishes — it produces a precondition entry the engine can
+        evaluate at runtime.
+        """
+        svc, _, mod = _bare_svc()
+        svc.session = MagicMock()
+        svc._syntax = real_syntax
+        _install_variable_resolver(monkeypatch, {})
+
+        referenced: dict = {}
+        preconds, vars_ = svc._build_preconditions_block(
+            [("{p_flag, boolean}", ["v1"])],
+            release_id=None,
+            referenced_parameters=referenced,
+        )
+        assert preconds, "parameter-only gate must not vanish"
+        [entry] = preconds.values()
+        assert entry["ast"]["class_name"] == "ParameterRef"
+        assert entry["ast"]["code"] == "flag"
+        assert entry["affected_operations"] == ["v1"]
+        assert vars_ == {}
+        assert "flag" in referenced
+        assert referenced["flag"].declared_type == "Boolean"
+
+    def test_mixed_item_and_parameter_gate_preserves_both_sides(
+        self, monkeypatch, real_syntax, real_parameter_info
+    ):
+        """``{v_F} and {p_flag, boolean}`` reaches the engine as a
+        BinOp with both operands intact.
+
+        The previous emitter kept only ``{v_F}``, so the parameter half
+        of the gate — and any runtime binding based on it — was lost.
+        """
+        svc, _, mod = _bare_svc()
+        svc.session = MagicMock()
+        svc._syntax = real_syntax
+        _install_variable_resolver(
+            monkeypatch,
+            {"F_01.02": {"variable_id": 42, "variable_vid": 420}},
+        )
+
+        referenced: dict = {}
+        preconds, vars_ = svc._build_preconditions_block(
+            [("{v_F_01.02} and {p_flag, boolean}", ["v1"])],
+            release_id=None,
+            referenced_parameters=referenced,
+        )
+        [entry] = preconds.values()
+        binop = entry["ast"]
+        assert binop["class_name"] == "BinOp"
+        assert binop["op"] == "and"
+
+        kinds = {binop["left"]["class_name"], binop["right"]["class_name"]}
+        assert kinds == {"PreconditionItem", "ParameterRef"}
+        assert vars_ == {"420": "b"}
+        assert referenced["flag"].declared_type == "Boolean"
+
+    def test_or_operator_preserved(self, monkeypatch, real_syntax):
+        """``{v_A} or {v_B}`` used to collapse to a flat item list under
+        an implicit ``and`` because the regex path lost the operator.
+        The walker preserves it.
+        """
+        svc, _, mod = _bare_svc()
+        svc.session = MagicMock()
+        svc._syntax = real_syntax
+        _install_variable_resolver(
+            monkeypatch,
+            {
+                "A": {"variable_id": 1, "variable_vid": 10},
+                "B": {"variable_id": 2, "variable_vid": 20},
+            },
+        )
+
+        preconds, _vars = svc._build_preconditions_block(
+            [("{v_A} or {v_B}", ["v1"])], release_id=None
+        )
+        [entry] = preconds.values()
+        assert entry["ast"]["class_name"] == "BinOp"
+        assert entry["ast"]["op"] == "or"
 
 
 # ------------------------------------------------------------------ #

--- a/tests/unit/services/test_ast_generator.py
+++ b/tests/unit/services/test_ast_generator.py
@@ -622,30 +622,38 @@ class TestBuildPreconditionsBlock:
 
 
 # ------------------------------------------------------------------ #
-# Issue #338 — gates carrying parameters and mixed shapes
+# Issue #338 — gate parameters reach the engine; gates outside the
+# contract are reported
 # ------------------------------------------------------------------ #
 
 
+def _collect_class_names(node, acc=None):
+    acc = set() if acc is None else acc
+    if isinstance(node, dict):
+        acc.add(node.get("class_name"))
+        for value in node.values():
+            _collect_class_names(value, acc)
+    elif isinstance(node, list):
+        for item in node:
+            _collect_class_names(item, acc)
+    return acc
+
+
 class TestGateParameterPropagation:
-    """A ``{p_*}`` reference in the gate reaches the engine intact.
+    """A ``{p_*}`` reference in a gate reaches the engine intact.
 
     Regression for #338: the old regex path extracted only ``{v_*}``
-    positions, so a parameter or a logical operator that connected one
-    to a filing indicator was silently dropped and never reached
-    ``preconditions[<key>]["ast"]`` or the script-level ``parameters``
-    registry. The AST walker now emits ``ParameterRef`` alongside
-    ``PreconditionItem`` and populates the parameter registry in the
-    same pass.
+    positions, so a parameter — or the operator joining it to a filing
+    indicator — was silently dropped and the operation ran ungated. The
+    walker emits the parameter as the same ``ParameterRef`` node an
+    expression produces and declares it in the script-level ``parameters``
+    registry in the same pass.
     """
 
-    def test_parameter_only_gate_emits_entry(
+    def test_parameter_only_gate_emits_parameter_ref(
         self, monkeypatch, real_syntax, real_parameter_info
     ):
-        """A gate that is nothing but a parameter reference no longer
-        vanishes — it produces a precondition entry the engine can
-        evaluate at runtime.
-        """
-        svc, _, mod = _bare_svc()
+        svc, _, _ = _bare_svc()
         svc.session = MagicMock()
         svc._syntax = real_syntax
         _install_variable_resolver(monkeypatch, {})
@@ -656,25 +664,47 @@ class TestGateParameterPropagation:
             release_id=None,
             referenced_parameters=referenced,
         )
-        assert preconds, "parameter-only gate must not vanish"
+
         [entry] = preconds.values()
-        assert entry["ast"]["class_name"] == "ParameterRef"
-        assert entry["ast"]["code"] == "flag"
+        assert entry["ast"] == {
+            "class_name": "ParameterRef",
+            "code": "flag",
+            "param_type": "Boolean",
+            "default": None,
+        }
         assert entry["affected_operations"] == ["v1"]
+        assert entry["code"].startswith("p_")
+        assert isinstance(entry["version_id"], int)
         assert vars_ == {}
-        assert "flag" in referenced
         assert referenced["flag"].declared_type == "Boolean"
 
-    def test_mixed_item_and_parameter_gate_preserves_both_sides(
+    def test_parameter_default_is_preserved_on_the_node(
         self, monkeypatch, real_syntax, real_parameter_info
     ):
-        """``{v_F} and {p_flag, boolean}`` reaches the engine as a
-        BinOp with both operands intact.
+        svc, _, _ = _bare_svc()
+        svc.session = MagicMock()
+        svc._syntax = real_syntax
+        _install_variable_resolver(monkeypatch, {})
 
-        The previous emitter kept only ``{v_F}``, so the parameter half
-        of the gate — and any runtime binding based on it — was lost.
+        referenced: dict = {}
+        preconds, _vars = svc._build_preconditions_block(
+            [("{p_flag, boolean, default: true}", ["v1"])],
+            release_id=None,
+            referenced_parameters=referenced,
+        )
+
+        [entry] = preconds.values()
+        assert entry["ast"]["default"] is True
+        # The registry is type-only: defaults are per-reference fallbacks.
+        assert referenced["flag"].default is None
+
+    def test_mixed_gate_keeps_both_sides(
+        self, monkeypatch, real_syntax, real_parameter_info
+    ):
+        """``{v_F} and {p_flag, boolean}`` reaches the engine as a BinOp
+        with the filing indicator and the parameter both intact.
         """
-        svc, _, mod = _bare_svc()
+        svc, _, _ = _bare_svc()
         svc.session = MagicMock()
         svc._syntax = real_syntax
         _install_variable_resolver(
@@ -688,22 +718,75 @@ class TestGateParameterPropagation:
             release_id=None,
             referenced_parameters=referenced,
         )
-        [entry] = preconds.values()
-        binop = entry["ast"]
-        assert binop["class_name"] == "BinOp"
-        assert binop["op"] == "and"
 
-        kinds = {binop["left"]["class_name"], binop["right"]["class_name"]}
-        assert kinds == {"PreconditionItem", "ParameterRef"}
+        [entry] = preconds.values()
+        assert entry["ast"] == {
+            "class_name": "BinOp",
+            "op": "and",
+            "left": {
+                "class_name": "PreconditionItem",
+                "variable_id": 42,
+                "variable_code": "F_01.02",
+            },
+            "right": {
+                "class_name": "ParameterRef",
+                "code": "flag",
+                "param_type": "Boolean",
+                "default": None,
+            },
+        }
+        assert entry["code"].startswith("p_420_")
+        assert entry["version_id"] == 420
         assert vars_ == {"420": "b"}
         assert referenced["flag"].declared_type == "Boolean"
+
+    def test_boolean_literal_is_emitted_as_constant(
+        self, monkeypatch, real_syntax
+    ):
+        svc, _, _ = _bare_svc()
+        svc.session = MagicMock()
+        svc._syntax = real_syntax
+        _install_variable_resolver(
+            monkeypatch, {"A": {"variable_id": 1, "variable_vid": 10}}
+        )
+
+        preconds, _vars = svc._build_preconditions_block(
+            [("{v_A} and true", ["v1"])], release_id=None
+        )
+
+        [entry] = preconds.values()
+        assert entry["ast"]["right"] == {
+            "class_name": "Constant",
+            "type_": "Boolean",
+            "value": True,
+        }
+
+    def test_gate_parameter_conflicting_with_expression_type_raises_3_8(
+        self, monkeypatch, real_syntax, real_parameter_info
+    ):
+        svc, _, _ = _bare_svc()
+        svc.session = MagicMock()
+        svc._syntax = real_syntax
+        _install_variable_resolver(monkeypatch, {})
+        referenced = {
+            "flag": real_parameter_info(code="flag", declared_type="Integer")
+        }
+
+        with pytest.raises(errors.SemanticError) as exc_info:
+            svc._build_preconditions_block(
+                [("{p_flag, boolean}", ["v1"])],
+                release_id=None,
+                referenced_parameters=referenced,
+            )
+
+        assert exc_info.value.code == "3-8"
 
     def test_or_operator_preserved(self, monkeypatch, real_syntax):
         """``{v_A} or {v_B}`` used to collapse to a flat item list under
         an implicit ``and`` because the regex path lost the operator.
         The walker preserves it.
         """
-        svc, _, mod = _bare_svc()
+        svc, _, _ = _bare_svc()
         svc.session = MagicMock()
         svc._syntax = real_syntax
         _install_variable_resolver(
@@ -720,6 +803,137 @@ class TestGateParameterPropagation:
         [entry] = preconds.values()
         assert entry["ast"]["class_name"] == "BinOp"
         assert entry["ast"]["op"] == "or"
+
+    def test_not_xor_and_grouping_preserved(self, monkeypatch, real_syntax):
+        """Every operator the engine's evaluator implements survives, and
+        grouping parentheses are unwrapped rather than emitted.
+        """
+        svc, _, _ = _bare_svc()
+        svc.session = MagicMock()
+        svc._syntax = real_syntax
+        _install_variable_resolver(
+            monkeypatch,
+            {
+                "A": {"variable_id": 1, "variable_vid": 10},
+                "B": {"variable_id": 2, "variable_vid": 20},
+                "C": {"variable_id": 3, "variable_vid": 30},
+            },
+        )
+
+        preconds, vars_ = svc._build_preconditions_block(
+            [("not ({v_A} xor {v_B}) or {v_C}", ["v1"])], release_id=None
+        )
+
+        [entry] = preconds.values()
+        assert entry["code"].startswith("p_10_20_30_")
+        assert entry["version_id"] == 10
+        ast = entry["ast"]
+        assert ast["class_name"] == "BinOp"
+        assert ast["op"] == "or"
+        assert ast["right"] == {
+            "class_name": "PreconditionItem",
+            "variable_id": 3,
+            "variable_code": "C",
+        }
+        negation = ast["left"]
+        assert negation["class_name"] == "UnaryOp"
+        assert negation["op"] == "not"
+        assert negation["operand"]["class_name"] == "BinOp"
+        assert negation["operand"]["op"] == "xor"
+        assert "ParExpr" not in _collect_class_names(ast)
+        assert vars_ == {"10": "b", "20": "b", "30": "b"}
+
+    def test_gates_with_different_shapes_never_share_a_key(
+        self, monkeypatch, real_syntax
+    ):
+        """Regression: ``{v_A} or {v_B}`` and ``{v_A} and {v_B}`` name the
+        same indicators. Keyed by vids alone they would collide, and the
+        merge-on-collision step would file the ``or`` gate's operations
+        under the ``and`` gate's AST. Only the legacy ``and``-of-items
+        shape keeps the bare ``p_<vids>`` key.
+        """
+        svc, _, _ = _bare_svc()
+        svc.session = MagicMock()
+        svc._syntax = real_syntax
+        _install_variable_resolver(
+            monkeypatch,
+            {
+                "A": {"variable_id": 1, "variable_vid": 10},
+                "B": {"variable_id": 2, "variable_vid": 20},
+            },
+        )
+
+        preconds, _vars = svc._build_preconditions_block(
+            [
+                ("{v_A} and {v_B}", ["v1"]),
+                ("{v_A} or {v_B}", ["v2"]),
+                ("{v_B} and {v_A}", ["v3"]),
+            ],
+            release_id=None,
+        )
+
+        assert len(preconds) == 2
+        conjunction = preconds["p_10_20"]
+        assert conjunction["affected_operations"] == ["v1", "v3"]
+        [disjunction_key] = [k for k in preconds if k != "p_10_20"]
+        assert disjunction_key.startswith("p_10_20_")
+        assert preconds[disjunction_key]["affected_operations"] == ["v2"]
+        assert preconds[disjunction_key]["ast"]["op"] == "or"
+
+
+class TestUnsupportedGates:
+    """A gate outside the engine contract fails its operations explicitly.
+
+    The engine's precondition evaluator binds filing indicators and
+    parameters and combines them with ``and`` / ``or`` / ``xor`` / ``not``;
+    a comparison, a cell reference or a non-boolean literal has no
+    evaluation there, so such a gate is kept out of the script and its
+    operations are reported through ``failed_operations`` instead of
+    running ungated.
+    """
+
+    @pytest.mark.parametrize(
+        ("expression", "reason"),
+        [
+            ("{v_A} = true", "operator '='"),
+            ("{tC_01.00, r0010, c0010}", "references a cell"),
+            ("{v_A} and 3", "non-boolean literal 3"),
+        ],
+    )
+    def test_unsupported_shapes_are_reported(
+        self, expression, reason, monkeypatch, real_syntax
+    ):
+        svc, _, _ = _bare_svc()
+        svc.session = MagicMock()
+        svc._syntax = real_syntax
+        _install_variable_resolver(
+            monkeypatch, {"A": {"variable_id": 1, "variable_vid": 10}}
+        )
+
+        failures = svc._unsupported_gate_operations([(expression, ["v1"])])
+        preconds, vars_ = svc._build_preconditions_block(
+            [(expression, ["v1"])], release_id=None
+        )
+
+        assert reason in failures["v1"]
+        assert "cannot be evaluated by the engine" in failures["v1"]
+        assert preconds == {}
+        assert vars_ == {}
+
+    def test_contract_shapes_report_nothing(self, monkeypatch, real_syntax):
+        svc, _, _ = _bare_svc()
+        svc._syntax = real_syntax
+
+        failures = svc._unsupported_gate_operations(
+            [
+                ("not ({v_A} xor {v_B}) or {v_C}", ["v1"]),
+                ("{p_flag, boolean}", ["v2"]),
+                ("{v_A} and {p_flag, boolean, default: false}", ["v3"]),
+                ("{v_A} and true", ["v4"]),
+            ]
+        )
+
+        assert failures == {}
 
 
 # ------------------------------------------------------------------ #
@@ -1476,6 +1690,91 @@ class TestScript:
         assert out["failed_operations"] == {
             "v1": "Grey cells {F_32.03.a, r0040, c0010} were found."
         }
+
+    def _stub_serialize_ast_for_operations(self, monkeypatch, return_value):
+        """Stub ``serialize_ast`` for the operations' ``"AST"`` sentinel only.
+
+        Gate nodes keep going through the real serializer installed by
+        ``real_syntax``, so the emitted gate carries the real
+        ``ParameterRef`` shape.
+        """
+        real = sys.modules["dpmcore.dpm_xl.utils.serialization"].serialize_ast
+        ser_mod = MagicMock()
+        ser_mod.serialize_ast = lambda ast: (
+            return_value if ast == "AST" else real(ast)
+        )
+        monkeypatch.setitem(
+            sys.modules, "dpmcore.dpm_xl.utils.serialization", ser_mod
+        )
+
+    def test_parameter_gate_is_emitted_and_declared(
+        self, monkeypatch, real_syntax, real_parameter_info
+    ):
+        """#338: a gate parameter reaches the script twice — as the
+        ``ParameterRef`` node in the gate and as an entry in the
+        script-level ``parameters`` registry — and the operation ships.
+        """
+        self._stub_serialize_ast_for_operations(
+            monkeypatch,
+            {"class_name": "VarID", "table": "C_01.00", "data": []},
+        )
+        svc, *_ = self._build_svc()
+        svc._syntax = real_syntax
+        svc._semantic.validate.return_value = SimpleNamespace(
+            is_valid=True, error_message=None, parameters=()
+        )
+        svc._semantic.ast = "AST"
+
+        out = svc.script(
+            expressions=[("e1", "v1"), ("e2", "v2")],
+            module_code="MOD",
+            module_version="1.0",
+            preconditions=[("{p_flag, boolean}", ["v1"])],
+        )
+
+        assert out["success"] is True, out["error"]
+        assert out["failed_operations"] == {}
+        ns = next(iter(out["enriched_ast"].values()))
+        assert {"v1", "v2"} <= set(ns["operations"])
+        [gate] = ns["preconditions"].values()
+        assert gate["ast"]["class_name"] == "ParameterRef"
+        assert gate["ast"]["code"] == "flag"
+        assert gate["affected_operations"] == ["v1"]
+        assert ns["parameters"] == {"flag": "Boolean"}
+
+    def test_cell_reference_gate_skips_op_preserves_others(
+        self, monkeypatch, real_syntax
+    ):
+        """An operation whose gate is outside the engine contract is
+        reported in ``failed_operations`` and left out of the script,
+        instead of shipping an ungated operation or a gate the engine
+        cannot evaluate.
+        """
+        self._stub_serialize_ast(
+            monkeypatch,
+            {"class_name": "VarID", "table": "C_01.00", "data": []},
+        )
+        svc, *_ = self._build_svc()
+        svc._syntax = real_syntax
+        svc._semantic.validate.return_value = SimpleNamespace(
+            is_valid=True, error_message=None, parameters=()
+        )
+        svc._semantic.ast = "AST"
+
+        out = svc.script(
+            expressions=[("e1", "v1"), ("e2", "v2")],
+            module_code="MOD",
+            module_version="1.0",
+            preconditions=[("{tC_01.00, r0010, c0010}", ["v1"])],
+        )
+
+        assert out["success"] is True
+        ns = next(iter(out["enriched_ast"].values()))
+        assert "v1" not in ns["operations"]
+        assert "v2" in ns["operations"]
+        assert ns["preconditions"] == {}
+        assert list(out["failed_operations"]) == ["v1"]
+        assert "references a cell" in out["failed_operations"]["v1"]
 
     def test_non_literal_shift_skips_op_preserves_others(self, monkeypatch):
         """#326: a shift whose period cannot be declared skips that op.


### PR DESCRIPTION
  ## Summary

  Fixes #338

  ## Problem

  `_build_preconditions_block` extracted precondition items with a regex over the gate source text that only matched `{v_*}` positions. Anything the regex could not name — a `{p_*}` parameter reference, a logical operator connecting one to a filing indicator, a negation, a `ParExpr` — was dropped on the floor.

  A gate like `{v_F_01.02} and {p_flag, boolean}` reached the engine as a bare `PreconditionItem` for `F_01.02`, and a parameter-only gate `{p_flag, boolean}` reached the engine as nothing at all, silently ungating the operation.

  ## Fix

  Replace the regex path with a walker over the parsed gate AST. The gate is parsed once with `self._syntax.parse(prec["expression"])` (already available in
  the pipeline), and the walker emits:
  - `VarRef` (the parser's node for `{v_*}`) and `VarID` positions with the `v` prefix collapse to the `PreconditionItem` dict shape the engine binds against.
  - `ParameterRef` is preserved with `code` and `param_type` intact, and the parameter is added to the script-level `parameters` registry through the same
  `merge_parameters` used by expressions — scope-wide type agreement (`3-8`) now runs against a single source of truth even when the parameter only appears in a gate.
  - `BinOp` (`and` / `or` / ...), `UnaryOp` (`not`) and `ParExpr` are preserved as their AST nodes, so `{v_A} or {v_B}` no longer collapses to a flat item list under an implicit `and` and `{v_A} and not {v_B}` no longer loses the negation.
  - Every other node kind delegates to the standard `serialize_ast` path, so the tree the engine sees matches the shape used in expressions.

  ## Backward compatibility

  The public shape of `script()` output is unchanged for gates that used to work:

  - `preconditions[<key>]` still groups entries under `p_<sorted_vids>` when the gate names at least one filing indicator, so gates that today merge two
  operations under one key keep doing so.
  - `precondition_variables` still tracks the resolved variable vids.
  - `_build_preconditions_block` runs before `parameters_block` is finalised, so gate parameters land in the same registry as expression parameters without changing the block's public keys.

  Gates that carry no filing indicator (a parameter-only gate) derive their key from a `zlib.crc32` of the emitted AST — a stable slot instead of overwriting
  the previous one.
## Tests

  New `TestGateParameterPropagation` covers the three shapes from the issue:

  - parameter-only gate emits a `ParameterRef` entry and populates the script-level `parameters` registry;
  - mixed gate `{v_F_01.02} and {p_flag, boolean}` reaches the engine as a `BinOp` whose operands are `PreconditionItem` + `ParameterRef`, both sides intact;
  - `{v_A} or {v_B}` preserves the `or` operator instead of collapsing to a flat item list.

  The pre-existing `TestBuildPreconditionsBlock` tests are updated for the new AST-based shape but keep asserting the same `p_<vid>` naming, the same merge-on-collision behaviour, and the same dict-vs-tuple input handling.

  Ruff + mypy clean; the three pre-existing failures in `test_ast_generator.py` (missing `release_sort_order` stub, missing `rich`) are unchanged against master.

  ## Checklist
  - [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
  - [x] Tests pass (`pytest`) — 1833 unit tests passing, no regressions against master
  - [ ] Documentation updated (if applicable)

  ## Impact / Risk

  - Breaking changes? No public API change. Gate outputs for pre-existing shapes are byte-compatible; gates that carry a parameter or non-`and` operator now
  reach the engine differently — that is the fix.
  - Database schema or migration concerns? None.
  - Notes for release/changelog? Yes — call out that gates with `{p_*}` references, `or`, `not`, or grouping now reach the engine intact.
