### PR TITLE
fix(layout-exporter): render Z-axis sheets, report signs faithfully, …

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -456,16 +456,24 @@ annotations, and categorisation tooltips.
 Each generated workbook contains:
 
 - An **Index** sheet with a hyperlinked table of contents
-- One sheet per table (alphabetically sorted), each with:
+- One sheet per table (alphabetically sorted) — or one sheet per
+  Z-axis sheet for tables whose cells are sheet-scoped, named
+  ``<table code> (<sheet code>)`` and listed individually in the
+  Index — each with:
 
   - Table title and optional sheet (Z-axis) header
   - Hierarchical column headers with merged cells
   - Row headers with indentation reflecting the hierarchy
-  - Data cells showing the ``variable_vid`` (data point ID);
-    excluded cells are greyed out
+  - Data cells showing the ``variable_id`` (data point ID), the data
+    type and the sign recorded on the cell (a cell with no sign shows
+    none); excluded cells are greyed out and void cells get a darker
+    grey
+  - Cells reporting a data point that is also reported elsewhere in the
+    workbook ("identities") highlighted in yellow, with the other
+    locations listed in the cell comment
   - Dimensional annotations below the grid (for column dimensions)
     and to the right (for row dimensions), colour-coded per dimension
-  - Excel comments on headers and cells showing dimensional
-    categorisations (``Dimension = Member``)
+  - Excel comments on headers and cells showing the variable IDs,
+    identities and dimensional categorisations (``Dimension = Member``)
   - Outline groups for expanding/collapsing hierarchical rows and columns
   - Frozen panes at the data-area origin

--- a/specification/03-services.md
+++ b/specification/03-services.md
@@ -588,7 +588,9 @@ class LayoutExporterService(BaseService):
         """Export all tables in a module to a single workbook.
 
         The workbook contains an Index sheet with hyperlinks, followed
-        by one sheet per table in alphabetical order.
+        by one worksheet per table in alphabetical order — or one
+        worksheet per Z-axis sheet for tables whose cells are
+        sheet-scoped.
         """
         ...
 
@@ -669,6 +671,25 @@ sort_key = parent_sort_key + order + trailing_separator
 
 Where `trailing_separator` is `.` if the header appears before its children,
 or `:` if it appears after (`:` > `.` in ASCII, so the parent sorts last).
+
+### 8.3 Z-axis sheets
+
+Cells of a table with a Z axis are keyed by the sheet they belong to, so such
+a table is rendered as one worksheet per Z sheet, named
+`<table code> (<sheet code>)`. Tables whose cells carry no sheet get a single
+worksheet on which every Z header is annotated as fixed context.
+
+### 8.4 Greyed cells
+
+Excluded cells are filled mid-grey. Void cells are excluded too, so they get a
+darker grey to stay distinguishable from the merely non-reportable ones.
+
+### 8.5 Signs and identities
+
+Only the sign stored on the cell is rendered: a cell with no sign in DPM
+Studio shows no sign in the export. Cells whose data point is reported by
+more than one cell of the workbook — identities — are highlighted in yellow,
+and their comment lists the other locations.
 
 ## 9. Migration Service
 

--- a/src/dpmcore/services/layout_exporter/excel_writer.py
+++ b/src/dpmcore/services/layout_exporter/excel_writer.py
@@ -7,14 +7,16 @@ comments, and outline groups.
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any, NamedTuple, Optional
 
 from openpyxl import Workbook
 from openpyxl.comments import Comment
 from openpyxl.styles import Alignment, Border, Font, PatternFill, Side
 from openpyxl.utils import get_column_letter
+from openpyxl.worksheet.hyperlink import Hyperlink
 
 from dpmcore.services.layout_exporter.models import (
+    CellData,
     DimensionMember,
     ExportConfig,
     LayoutHeader,
@@ -31,6 +33,22 @@ _GREY_FILL = PatternFill(
 _EXCLUDED_FILL = PatternFill(
     start_color="999999", end_color="999999", fill_type="solid"
 )
+# Void cells are excluded too, so they get a darker grey to stand out
+# from the cells that are merely not reportable.
+_VOID_FILL = PatternFill(
+    start_color="595959", end_color="595959", fill_type="solid"
+)
+# Cells whose datapoint is shared with another cell of the workbook:
+# "identities" in DPM terms — the same figure reported in two places.
+_IDENTITY_FILL = PatternFill(
+    start_color="FFFF00", end_color="FFFF00", fill_type="solid"
+)
+# Excel worksheet titles are limited to 31 characters.
+_MAX_SHEET_TITLE = 31
+# Cap the identity list in a tooltip; a few datapoints are reported in
+# dozens of cells and the comment box would be unreadable.
+_MAX_IDENTITIES_IN_TOOLTIP = 15
+
 _TITLE_FONT = Font(bold=True, size=11)
 _HEADER_FONT = Font(bold=True, size=10)
 _DATA_FONT = Font(size=9)
@@ -67,6 +85,14 @@ _DIM_COLORS = [
 ]
 
 
+class _IndexEntry(NamedTuple):
+    """One worksheet written for a table (one per Z-axis sheet)."""
+
+    title: str
+    layout: TableLayout
+    sheet_label: str
+
+
 class ExcelLayoutWriter:
     """Writes one or more TableLayouts to an openpyxl Workbook."""
 
@@ -78,6 +104,9 @@ class ExcelLayoutWriter:
         """Initialise with the layouts to render and optional config."""
         self.layouts = layouts
         self.config = config or ExportConfig()
+        # {variable_vid: [cell location, ...]} for shared datapoints;
+        # filled in write().
+        self.identities: dict[int, list[str]] = {}
         self.wb = Workbook()
         # Remove default sheet (Workbook() always creates one).
         if self.wb.sheetnames:  # pragma: no branch
@@ -88,16 +117,35 @@ class ExcelLayoutWriter:
         # Sort layouts alphabetically by table code
         sorted_layouts = sorted(self.layouts, key=lambda lo: lo.table_code)
 
+        # Identities are shared datapoints, so they are computed over
+        # the whole workbook — one module for export_module().
+        self.identities = _build_identity_index(sorted_layouts)
+
+        entries: list[_IndexEntry] = []
+        used_titles: set[str] = set()
         for layout in sorted_layouts:
-            self._write_table(layout)
+            for active_sheets, sheet_id, sheet in _sheet_renderings(layout):
+                title = _worksheet_title(
+                    layout.table_code,
+                    sheet,
+                    used_titles,
+                )
+                self._write_table(layout, active_sheets, sheet_id, title)
+                entries.append(
+                    _IndexEntry(
+                        title=title,
+                        layout=layout,
+                        sheet_label=sheet.label if sheet else "",
+                    ),
+                )
 
         # Add index sheet at the beginning
-        self._write_index(sorted_layouts)
+        self._write_index(entries)
 
         return self.wb
 
-    def _write_index(self, sorted_layouts: list[TableLayout]) -> None:
-        """Write an index sheet with hyperlinks to each table."""
+    def _write_index(self, entries: list[_IndexEntry]) -> None:
+        """Write an index sheet with hyperlinks to each worksheet."""
         ws = self.wb.create_sheet(title="Index", index=0)
 
         # Title
@@ -106,40 +154,78 @@ class ExcelLayoutWriter:
             size=14,
         )
 
+        # A "Sheet" column is only meaningful when at least one table
+        # was split into one worksheet per Z-axis sheet.
+        has_sheets = any(e.sheet_label for e in entries)
+
         # Column headers
-        for col, header in enumerate(
-            ["#", "Table Code", "Table Name"],
-            start=1,
-        ):
+        headers = ["#", "Table Code", "Table Name"]
+        if has_sheets:
+            headers.append("Sheet")
+        for col, header in enumerate(headers, start=1):
             cell = ws.cell(row=3, column=col, value=header)
             cell.font = _HEADER_FONT
             cell.fill = _GREY_FILL
             cell.border = _BORDER_ALL
 
         # Table entries with hyperlinks
-        for i, layout in enumerate(sorted_layouts):
+        for i, entry in enumerate(entries):
             row = 4 + i
             ws.cell(row=row, column=1, value=i + 1).border = _BORDER_ALL
 
-            sheet_name = layout.table_code[:31]
-            code_cell = ws.cell(row=row, column=2, value=layout.table_code)
+            code_cell = ws.cell(
+                row=row, column=2, value=entry.layout.table_code
+            )
             code_cell.border = _BORDER_ALL
             code_cell.font = Font(color="0000CC", underline="single")
-            code_cell.hyperlink = f"#{sheet_name}!A1"
+            # An internal link needs a quoted location: titles carry
+            # dots, spaces and parentheses, which Excel rejects
+            # unquoted.
+            code_cell.hyperlink = Hyperlink(
+                ref=code_cell.coordinate,
+                location=f"'{entry.title}'!A1",
+            )
 
-            name_cell = ws.cell(row=row, column=3, value=layout.table_name)
+            name_cell = ws.cell(
+                row=row, column=3, value=entry.layout.table_name
+            )
             name_cell.border = _BORDER_ALL
+
+            if has_sheets:
+                sheet_cell = ws.cell(
+                    row=row, column=4, value=entry.sheet_label
+                )
+                sheet_cell.border = _BORDER_ALL
 
         # Column widths
         ws.column_dimensions["A"].width = 6
         ws.column_dimensions["B"].width = 18
         ws.column_dimensions["C"].width = 80
+        if has_sheets:
+            ws.column_dimensions["D"].width = 50
 
-    def _write_table(self, layout: TableLayout) -> None:  # noqa: C901
-        """Write a single table layout to a worksheet."""
-        # Truncate sheet name to 31 chars (Excel limit)
-        sheet_name = layout.table_code[:31]
-        ws = self.wb.create_sheet(title=sheet_name)
+    def _write_table(  # noqa: C901
+        self,
+        layout: TableLayout,
+        active_sheets: list[LayoutHeader],
+        sheet_id: Optional[int],
+        title: str,
+    ) -> None:
+        """Write one grid of a table layout to a worksheet.
+
+        ``active_sheets`` are the Z-axis headers annotated on this
+        worksheet and ``sheet_id`` the sheet its data cells are read
+        from: one worksheet per Z sheet for sheet-scoped tables, a
+        single worksheet carrying every Z header otherwise.
+        """
+        ws = self.wb.create_sheet(title=title)
+
+        # True when this worksheet renders one specific Z sheet (rather
+        # than a single grid whose Z headers are fixed context).
+        per_sheet = bool(active_sheets) and (
+            active_sheets[0].header_id == sheet_id
+        )
+        sheet_code = active_sheets[0].code if per_sheet else ""
 
         cfg = self.config
         code_row_offset = 1 if cfg.show_code_row else 0
@@ -147,15 +233,16 @@ class ExcelLayoutWriter:
 
         # Layout geometry
         # Row 1: title
-        # Row 2: empty (gap)
-        # Row 3: sheet header (if sheets) or empty
-        # Row 4: "Columns" label + row annotation dimension headers
-        # Row 5+: column header depth levels (start + 1 + depth)
+        # Row 2: Z-axis annotation label (if sheets) or empty
+        # Row 3+: one row per annotated Z header, then a gap row
+        # Next: "Columns" label + row annotation dimension headers
+        # Next: column header depth levels (start + 1 + depth)
         # Then: column code row (if enabled)
         # Then: data rows
 
-        # "Columns" row: row 4 without sheets, row 5 when sheets exist
-        col_header_start_row = 5 if layout.sheets else 4
+        # "Columns" row: row 4 without sheets, one row lower per
+        # annotated Z header.
+        col_header_start_row = 4 + len(active_sheets)
         col_label_rows = layout.max_col_depth + 1
         col_code_row = (
             col_header_start_row + 1 + col_label_rows
@@ -213,29 +300,36 @@ class ExcelLayoutWriter:
             )
 
         # --- Sheet header (Z-axis) ---
-        # For tables with sheets, rows 2-4 are used for Z-axis annotation:
+        # For tables with sheets:
         #   Row 2: annotation label (dimension name in data columns)
-        #   Row 3: "Sheet per {label}" + annotation value in data columns
-        #   Row 4: empty gap
-        if layout.sheets:
-            for sh in layout.sheets:
-                # Row 2: annotation label in data_start_col
-                # Use "(member_code:domain_code) label" format for ATY dim
-                for dm in sh.categorisations:
-                    label_text = (
-                        f"({dm.member_code}:{dm.domain_code}) "
-                        f"{dm.member_label}"
-                    )
-                    ann_label_cell = ws.cell(
-                        row=2, column=data_start_col, value=label_text
-                    )
-                    ann_label_cell.font = Font(bold=True, size=9)
-                    ann_label_cell.alignment = Alignment(horizontal="left")
-                    break  # only write for first (ATY) categorisation
+        #   Row 3+: "Sheet: {label}" (one worksheet per sheet) or
+        #           "Sheet per {label}" (Z header as fixed context),
+        #           plus the annotation value in the data columns
+        #   Following row: empty gap
+        if active_sheets:
+            # Row 2: annotation label in data_start_col
+            # Use "(member_code:domain_code) label" format for ATY dim
+            for dm in active_sheets[0].categorisations:
+                label_text = (
+                    f"({dm.member_code}:{dm.domain_code}) {dm.member_label}"
+                )
+                ann_label_cell = ws.cell(
+                    row=2, column=data_start_col, value=label_text
+                )
+                ann_label_cell.font = Font(bold=True, size=9)
+                ann_label_cell.alignment = Alignment(horizontal="left")
+                break  # only write for first (ATY) categorisation
 
-                # Row 3: sheet header label + annotation value
-                sheet_text = f"Sheet per {sh.label}"
-                sc = ws.cell(row=3, column=row_label_col, value=sheet_text)
+            for sheet_idx, sh in enumerate(active_sheets):
+                sheet_row = 3 + sheet_idx
+
+                # Sheet header label + annotation value
+                prefix = "Sheet: " if per_sheet else "Sheet per "
+                sc = ws.cell(
+                    row=sheet_row,
+                    column=row_label_col,
+                    value=f"{prefix}{sh.label}",
+                )
                 sc.font = _HEADER_FONT
                 sc.fill = _GREY_FILL
                 sc.border = _BORDER_ALL
@@ -243,7 +337,7 @@ class ExcelLayoutWriter:
                     horizontal="center", vertical="center"
                 )
 
-                # Row 3 annotation value: SubCategory info
+                # Annotation value: SubCategory info
                 if sh.subcategory_code and sh.subcategory_cat_code:
                     cat = sh.subcategory_cat_code
                     sc_code = sh.subcategory_code
@@ -252,7 +346,7 @@ class ExcelLayoutWriter:
                     if sh.is_key:
                         ann_val += " <Key value> "
                     ann_val_cell = ws.cell(
-                        row=3, column=data_start_col, value=ann_val
+                        row=sheet_row, column=data_start_col, value=ann_val
                     )
                     ann_val_cell.font = Font(size=9)
                     ann_val_cell.alignment = Alignment(horizontal="left")
@@ -432,29 +526,6 @@ class ExcelLayoutWriter:
                     height=150,
                 )
 
-        # Per-column flag: does this column have any explicitly signed cell?
-        # NULL-sign monetary cells default to 'positive' only in such columns,
-        # OR when the row is a "Closing balance".
-        col_positive_only: dict[int, bool] = {
-            _ch.header_id: any(
-                _cd.sign
-                for _cd in layout.cells.values()
-                if _cd.col_header_id == _ch.header_id
-            )
-            for _ch in layout.columns
-            if not _ch.is_abstract
-        }
-
-        # Per-row explicit sign (used to check parent sign).
-        row_explicit_sign: dict[int, str] = {}
-        for _cd in layout.cells.values():
-            if (
-                _cd.sign
-                and _cd.row_header_id is not None
-                and _cd.row_header_id not in row_explicit_sign
-            ):
-                row_explicit_sign[_cd.row_header_id] = _cd.sign
-
         # --- Open-row tables ---
         if layout.is_open_row:
             self._write_open_row_data(
@@ -465,16 +536,11 @@ class ExcelLayoutWriter:
                 col_positions,
                 row_label_col,
                 cfg,
+                sheet_id,
+                sheet_code,
             )
 
         # --- Data cells ---
-        default_sheet_id = None
-        if not layout.sheets:
-            # Find the sheet_id used in cells (usually None or a default)
-            for key in layout.cells:
-                default_sheet_id = key[2]
-                break
-
         for rh in layout.rows:
             if rh.is_abstract:
                 continue
@@ -487,7 +553,6 @@ class ExcelLayoutWriter:
                 excel_col = data_start_col - 1 + col_offset
 
                 # Try to find cell data
-                sheet_id = default_sheet_id
                 cell_data = layout.cells.get(
                     (rh.header_id, ch.header_id, sheet_id),
                 )
@@ -496,7 +561,9 @@ class ExcelLayoutWriter:
                 cell.font = _DATA_FONT
                 cell.border = _BORDER_ALL
 
-                if cell_data is None or cell_data.is_excluded:
+                if cell_data is not None and cell_data.is_void:
+                    cell.fill = _VOID_FILL
+                elif cell_data is None or cell_data.is_excluded:
                     cell.fill = _EXCLUDED_FILL
                 elif cell_data.variable_vid:
                     # Build cell content: VariableID + data type + sign
@@ -514,27 +581,11 @@ class ExcelLayoutWriter:
                             cell_lines.append(
                                 _DATA_TYPE_SYMBOLS[cell_data.data_type_code]
                             )
-                    # Determine sign to display
-                    _sign = cell_data.sign
-                    if not _sign and cell_data.data_type_code == "m":
-                        _label = rh.label or ""
-                        # Suppress NULL→positive default when the
-                        # parent row has an explicit sign: these are
-                        # rollforward-table movements whose sign is
-                        # genuinely undetermined (positive or negative).
-                        _parent_id = rh.parent_header_id
-                        _suppress = bool(
-                            row_explicit_sign.get(_parent_id, "")
-                            if _parent_id is not None
-                            else ""
-                        )
-                        if not _suppress and (
-                            col_positive_only.get(ch.header_id, False)
-                            or _label.startswith("Closing balance")
-                        ):
-                            _sign = "positive"
-                    if _sign:
-                        cell_lines.append(_sign)
+                    # Only the sign stored on the cell is shown: a
+                    # NULL sign is "No Sign" in DPM Studio and must not
+                    # be reported as positive (DRR-1967, DRR-1970).
+                    if cell_data.sign:
+                        cell_lines.append(cell_data.sign)
                     cell.value = "\n".join(cell_lines)
                     cell.alignment = Alignment(
                         horizontal="center",
@@ -542,19 +593,28 @@ class ExcelLayoutWriter:
                         wrap_text=True,
                     )
 
+                    # Identities: highlight datapoints reported by more
+                    # than one cell of the workbook.
+                    location = _cell_location(
+                        layout.table_code,
+                        rh.code,
+                        ch.code,
+                        sheet_code,
+                    )
+                    others = self._other_identity_locations(
+                        cell_data.variable_vid,
+                        location,
+                    )
+                    if others:
+                        cell.fill = _IDENTITY_FILL
+
                     # Cell tooltip
-                    if cfg.add_cell_comments and cell_data.dp_categorisations:
-                        tooltip = (
-                            f"VariableVID = {cell_data.variable_vid}\n"
-                            + _format_categorisations(
-                                cell_data.dp_categorisations,
-                            )
-                        )
+                    if cfg.add_cell_comments:
                         cell.comment = Comment(
-                            tooltip,
+                            _cell_tooltip(cell_data, others),
                             "dpmcore",
                             width=400,
-                            height=180,
+                            height=200,
                         )
 
         # --- Annotations ---
@@ -569,6 +629,7 @@ class ExcelLayoutWriter:
                 num_visible_cols,
                 row_label_col,
                 col_header_start_row,
+                sheet_id,
             )
 
         # --- Outline groups ---
@@ -602,6 +663,8 @@ class ExcelLayoutWriter:
         col_positions: dict[int, int],
         row_label_col: int,
         cfg: ExportConfig,
+        sheet_id: Optional[int],
+        sheet_code: str,
     ) -> None:
         """Write the single 'Open Rows' data row for open-row tables."""
         open_rows_cell = ws.cell(
@@ -615,12 +678,6 @@ class ExcelLayoutWriter:
             horizontal="left", vertical="center"
         )
         open_rows_cell.font = _HEADER_FONT
-
-        default_sheet_id = None
-        if not layout.sheets:
-            for key in layout.cells:
-                default_sheet_id = key[2]
-                break
 
         for ch in layout.columns:
             if ch.is_abstract:
@@ -650,9 +707,7 @@ class ExcelLayoutWriter:
                     wrap_text=True,
                 )
             else:
-                cell_data = layout.cells.get(
-                    (None, ch.header_id, default_sheet_id)
-                )
+                cell_data = layout.cells.get((None, ch.header_id, sheet_id))
                 if (
                     cell_data is not None
                     and not cell_data.is_excluded
@@ -680,8 +735,42 @@ class ExcelLayoutWriter:
                         vertical="center",
                         wrap_text=True,
                     )
+
+                    location = _cell_location(
+                        layout.table_code,
+                        "",
+                        ch.code,
+                        sheet_code,
+                    )
+                    others = self._other_identity_locations(
+                        cell_data.variable_vid,
+                        location,
+                    )
+                    if others:
+                        cell.fill = _IDENTITY_FILL
+                    if cfg.add_cell_comments:
+                        cell.comment = Comment(
+                            _cell_tooltip(cell_data, others),
+                            "dpmcore",
+                            width=400,
+                            height=200,
+                        )
+                elif cell_data is not None and cell_data.is_void:
+                    cell.fill = _VOID_FILL
                 else:
                     cell.fill = _EXCLUDED_FILL
+
+    def _other_identity_locations(
+        self,
+        variable_vid: int,
+        location: str,
+    ) -> list[str]:
+        """Other cells of the workbook reporting the same datapoint."""
+        return [
+            loc
+            for loc in self.identities.get(variable_vid, [])
+            if loc != location
+        ]
 
     def _write_annotations(  # noqa: C901
         self,
@@ -694,6 +783,7 @@ class ExcelLayoutWriter:
         num_visible_cols: int,
         row_label_col: int,
         col_header_start_row: int,
+        sheet_id: Optional[int] = None,
     ) -> None:
         """Write dimensional annotations around the data grid."""
         col_dims = _collect_axis_dimensions(layout.columns)
@@ -706,8 +796,8 @@ class ExcelLayoutWriter:
         col_dim_set = set(col_dims)
         row_dp_cats: dict[int, list[DimensionMember]] = {}
         for cell_key, cell_data in layout.cells.items():
-            row_id, _col_id, _sheet_id = cell_key
-            if row_id is None:
+            row_id, _col_id, cell_sheet_id = cell_key
+            if row_id is None or cell_sheet_id != sheet_id:
                 continue
             if cell_data.dp_categorisations:
                 extra = [
@@ -842,6 +932,125 @@ class ExcelLayoutWriter:
 
                 # Set annotation column width
                 ws.column_dimensions[get_column_letter(ann_col)].width = 25
+
+
+def _sheet_renderings(
+    layout: TableLayout,
+) -> list[tuple[list[LayoutHeader], Optional[int], Optional[LayoutHeader]]]:
+    """Split a layout into the worksheets it needs.
+
+    Cells of a Z-axis table are keyed by the sheet they belong to, so
+    such a table is rendered as one worksheet per Z sheet. Tables whose
+    cells carry no sheet get a single worksheet on which every Z header
+    is annotated as fixed context.
+
+    Returns ``(annotated Z headers, sheet id for cell lookup, sheet)``
+    per worksheet; ``sheet`` is None for a single-worksheet table.
+    """
+    cell_sheet_ids = {key[2] for key in layout.cells if key[2] is not None}
+    if layout.sheets and cell_sheet_ids:
+        per_sheet: list[
+            tuple[list[LayoutHeader], Optional[int], Optional[LayoutHeader]]
+        ] = [
+            ([sh], sh.header_id, sh)
+            for sh in layout.sheets
+            if sh.header_id in cell_sheet_ids
+        ]
+        if per_sheet:
+            return per_sheet
+
+    # Single grid: the sheet id the cells were keyed with (usually None).
+    default_sheet_id = None
+    for key in layout.cells:
+        default_sheet_id = key[2]
+        break
+    return [(layout.sheets, default_sheet_id, None)]
+
+
+def _worksheet_title(
+    table_code: str,
+    sheet: Optional[LayoutHeader],
+    used: set[str],
+) -> str:
+    """Build a unique worksheet title of at most 31 characters."""
+    suffix = f" ({sheet.code or sheet.label})" if sheet is not None else ""
+    title = table_code[: _MAX_SHEET_TITLE - len(suffix)] + suffix
+    if title in used:
+        # Distinct sheets can collide once truncated; keep them apart.
+        counter = 2
+        while True:
+            tag = f"~{counter}"
+            candidate = title[: _MAX_SHEET_TITLE - len(tag)] + tag
+            if candidate not in used:
+                title = candidate
+                break
+            counter += 1
+    used.add(title)
+    return title
+
+
+def _cell_location(
+    table_code: str,
+    row_code: str,
+    col_code: str,
+    sheet_code: str,
+) -> str:
+    """Human-readable cell address used to report identities."""
+    parts = [table_code]
+    if sheet_code:
+        parts.append(f"s{sheet_code}")
+    if row_code:
+        parts.append(f"r{row_code}")
+    if col_code:
+        parts.append(f"c{col_code}")
+    return " ".join(parts)
+
+
+def _build_identity_index(layouts: list[TableLayout]) -> dict[int, list[str]]:
+    """Map VariableVID to the cells reporting it, for shared datapoints.
+
+    Cells sharing a datapoint are "identities": the same figure is
+    reported in more than one place. Only variables used by at least
+    two cells are returned.
+    """
+    locations: dict[int, list[str]] = {}
+    for layout in layouts:
+        codes: dict[int, str] = {
+            h.header_id: h.code
+            for h in layout.rows + layout.columns + layout.sheets
+        }
+        for (row_id, col_id, sheet_id), cd in layout.cells.items():
+            if not cd.variable_vid or cd.is_excluded or cd.is_void:
+                continue
+            locations.setdefault(cd.variable_vid, []).append(
+                _cell_location(
+                    layout.table_code,
+                    codes.get(row_id, "") if row_id is not None else "",
+                    codes.get(col_id, ""),
+                    codes.get(sheet_id, "") if sheet_id is not None else "",
+                ),
+            )
+    return {vvid: locs for vvid, locs in locations.items() if len(locs) > 1}
+
+
+def _cell_tooltip(cell_data: CellData, identities: list[str]) -> str:
+    """Tooltip for a data cell: variable ids, identities, dimensions."""
+    lines = []
+    if cell_data.variable_id:
+        lines.append(f"VariableID = {cell_data.variable_id}")
+    lines.append(f"VariableVID = {cell_data.variable_vid}")
+    if identities:
+        shown = identities[:_MAX_IDENTITIES_IN_TOOLTIP]
+        lines.append("")
+        lines.append("Identity - same datapoint also reported in:")
+        lines.extend(f"  {loc}" for loc in shown)
+        hidden = len(identities) - len(shown)
+        if hidden:
+            lines.append(f"  ... and {hidden} more")
+    if cell_data.dp_categorisations:
+        lines.append("")
+        lines.append(_format_categorisations(cell_data.dp_categorisations))
+    return "\n".join(lines)
 
 
 def _collect_axis_dimensions(

--- a/tests/integration/services/layout_exporter/test_excel_writer.py
+++ b/tests/integration/services/layout_exporter/test_excel_writer.py
@@ -727,8 +727,8 @@ def test_write_table_with_multi_depth_columns_and_rows(
     assert has_outline
 
 
-def test_write_table_closing_balance_sign_branch(memory_session, tmp_path):
-    """Row labelled 'Closing balance' triggers positive default for monetary."""
+def test_write_table_blank_sign_stays_blank(memory_session, tmp_path):
+    """A blank sign on a monetary cell is not filled in (DRR-1970)."""
     seed_releases(memory_session)
     seed_data_types(memory_session)
     seed_property_category(memory_session)
@@ -798,17 +798,19 @@ def test_write_table_closing_balance_sign_branch(memory_session, tmp_path):
     )
     wb = load_workbook(out)
     ws = wb["T_CB"]
-    # Look for "positive" appended to a cell (the monetary one)
+    # No cell may show a sign the database does not hold
     has_positive = False
     for row in ws.iter_rows(values_only=True):
         for v in row:
             if isinstance(v, str) and "positive" in v:
                 has_positive = True
-    assert has_positive
+    assert not has_positive
 
 
-def test_write_table_col_positive_only_default(memory_session, tmp_path):
-    """When column has at least one signed cell, NULL→positive default."""
+def test_write_table_sign_not_inherited_within_column(
+    memory_session, tmp_path
+):
+    """A signed cell does not give its sign to blank-sign siblings."""
     seed_releases(memory_session)
     seed_data_types(memory_session)
     seed_property_category(memory_session)
@@ -911,7 +913,7 @@ def test_write_table_col_positive_only_default(memory_session, tmp_path):
         for v in row:
             if isinstance(v, str) and "positive" in v:
                 pos_count += 1
-    assert pos_count >= 2  # both cells should display 'positive'
+    assert pos_count == 1  # only the cell actually signed positive
 
 
 def test_write_table_parent_sign_suppression(memory_session, tmp_path):

--- a/tests/unit/services/layout_exporter/test_excel_writer_units.py
+++ b/tests/unit/services/layout_exporter/test_excel_writer_units.py
@@ -555,7 +555,7 @@ def test_data_cell_no_data_type_no_sign():
 
 
 def test_data_cell_sign_suppressed_by_parent_explicit_sign():
-    """Monetary cell with parent that has an explicit sign: no auto-positive."""
+    """Monetary cell with a NULL sign renders no sign of its own."""
     layout = _empty_layout(
         rows=[
             _h(1, direction="y", code="P"),
@@ -598,8 +598,8 @@ def test_data_cell_sign_suppressed_by_parent_explicit_sign():
     assert all("positive" not in v for v in found_child)
 
 
-def test_data_cell_closing_balance_default_positive():
-    """Row labelled 'Closing balance ...' triggers default positive sign."""
+def test_data_cell_null_sign_never_reported_as_positive():
+    """A NULL sign is 'No Sign' and is never rendered (DRR-1967)."""
     layout = _empty_layout(
         rows=[_h(1, direction="y", code="R", label="Closing balance Q4")],
         columns=[_h(10, direction="x", code="X")],
@@ -622,7 +622,7 @@ def test_data_cell_closing_balance_default_positive():
         for row in ws.iter_rows()
         for c in row
     )
-    assert has_pos
+    assert not has_pos
 
 
 def test_abstract_row_without_visible_columns():
@@ -732,3 +732,395 @@ def test_apply_col_groups_skips_abstract():
     ws = wb["T"]
     # Smoke check: column dimensions object is accessible.
     assert ws.column_dimensions is not None
+
+
+# --------------------------------------------------------------------------- #
+# Z-axis sheets and identities
+# --------------------------------------------------------------------------- #
+
+
+def _sheet_scoped_layout(table_code="T"):
+    """Two Z sheets whose cells are keyed by the sheet they belong to."""
+    return TableLayout(
+        table_vid=1,
+        table_code=table_code,
+        table_name=table_code,
+        rows=[_h(1, direction="y", code="0010", label="Row")],
+        columns=[_h(10, direction="x", code="0010", label="Col")],
+        sheets=[
+            _h(20, direction="z", code="0010", label="Sheet A"),
+            _h(21, direction="z", code="0020", label="Sheet B"),
+        ],
+        cells={
+            (1, 10, 20): CellData(
+                row_header_id=1,
+                col_header_id=10,
+                sheet_header_id=20,
+                variable_vid=901,
+                variable_id=901,
+                data_type_code="m",
+                sign="positive",
+            ),
+            (1, 10, 21): CellData(
+                row_header_id=1,
+                col_header_id=10,
+                sheet_header_id=21,
+                variable_vid=902,
+                variable_id=902,
+                data_type_code="m",
+            ),
+        },
+    )
+
+
+def test_sheet_scoped_table_writes_one_worksheet_per_sheet():
+    """Regression for DRR-1946/1947/1949: cells were all greyed out."""
+    wb = ExcelLayoutWriter([_sheet_scoped_layout()], ExportConfig()).write()
+
+    assert [n for n in wb.sheetnames if n != "Index"] == [
+        "T (0010)",
+        "T (0020)",
+    ]
+    for name, expected_vid, expected_label in (
+        ("T (0010)", "901", "Sheet: Sheet A"),
+        ("T (0020)", "902", "Sheet: Sheet B"),
+    ):
+        ws = wb[name]
+        values = [
+            c.value
+            for row in ws.iter_rows()
+            for c in row
+            if isinstance(c.value, str)
+        ]
+        assert any(v.startswith(expected_vid) for v in values), name
+        assert expected_label in values
+        # The datapoint cell carries its id, so it is not greyed out.
+        data_cell = next(
+            c
+            for row in ws.iter_rows()
+            for c in row
+            if isinstance(c.value, str) and c.value.startswith(expected_vid)
+        )
+        assert data_cell.fill.start_color.rgb != "00999999"
+
+
+def test_sheet_scoped_table_index_lists_each_sheet():
+    """The index names the Z sheet each worksheet renders."""
+    wb = ExcelLayoutWriter([_sheet_scoped_layout()], ExportConfig()).write()
+    ws = wb["Index"]
+
+    assert ws.cell(row=3, column=4).value == "Sheet"
+    assert ws.cell(row=4, column=4).value == "Sheet A"
+    assert ws.cell(row=5, column=4).value == "Sheet B"
+    assert ws.cell(row=5, column=2).hyperlink.location == "'T (0020)'!A1"
+
+
+def test_z_headers_without_sheet_scoped_cells_stay_on_one_worksheet():
+    """Z headers that are fixed context keep a single grid."""
+    layout = _empty_layout(
+        rows=[_h(1, direction="y", code="0010", label="Row")],
+        columns=[_h(10, direction="x", code="0010", label="Col")],
+        sheets=[
+            _h(20, direction="z", code="0010", label="Axis A"),
+            _h(21, direction="z", code="0020", label="Axis B"),
+        ],
+        cells={
+            (1, 10, None): CellData(
+                row_header_id=1,
+                col_header_id=10,
+                sheet_header_id=None,
+                variable_vid=901,
+                variable_id=901,
+                data_type_code="m",
+            ),
+        },
+    )
+    wb = ExcelLayoutWriter([layout], ExportConfig()).write()
+
+    assert [n for n in wb.sheetnames if n != "Index"] == ["T"]
+    ws = wb["T"]
+    values = [
+        c.value
+        for row in ws.iter_rows()
+        for c in row
+        if isinstance(c.value, str)
+    ]
+    # Both Z headers are annotated, one per row, and the grid follows.
+    assert "Sheet per Axis A" in values
+    assert "Sheet per Axis B" in values
+    assert any(v.startswith("901") for v in values)
+
+
+def test_worksheet_title_truncates_and_disambiguates():
+    used: set[str] = set()
+    long_code = "T" * 40
+    sheet = _h(1, direction="z", code="0010")
+    first = ew._worksheet_title(long_code, sheet, used)
+    second = ew._worksheet_title(long_code, sheet, used)
+
+    assert len(first) == 31
+    assert first.endswith(" (0010)")
+    assert second != first
+    assert len(second) == 31
+
+
+def test_shared_datapoint_is_highlighted_and_reported():
+    """Regression for DRR-1947/1949: identities in yellow, with a comment."""
+    first = TableLayout(
+        table_vid=1,
+        table_code="T_A",
+        table_name="A",
+        rows=[_h(1, direction="y", code="0010", label="Row")],
+        columns=[_h(10, direction="x", code="0010", label="Col")],
+        cells={
+            (1, 10, None): CellData(
+                row_header_id=1,
+                col_header_id=10,
+                sheet_header_id=None,
+                variable_vid=700,
+                variable_id=70,
+                data_type_code="m",
+            ),
+        },
+    )
+    second = TableLayout(
+        table_vid=2,
+        table_code="T_B",
+        table_name="B",
+        rows=[_h(2, direction="y", code="0020", label="Row")],
+        columns=[_h(20, direction="x", code="0030", label="Col")],
+        cells={
+            (2, 20, None): CellData(
+                row_header_id=2,
+                col_header_id=20,
+                sheet_header_id=None,
+                variable_vid=700,
+                variable_id=70,
+                data_type_code="m",
+            ),
+        },
+    )
+    wb = ExcelLayoutWriter([first, second], ExportConfig()).write()
+
+    cell = next(
+        c
+        for row in wb["T_A"].iter_rows()
+        for c in row
+        if isinstance(c.value, str) and c.value.startswith("70")
+    )
+    assert cell.fill.start_color.rgb == "00FFFF00"
+    assert "VariableVID = 700" in cell.comment.text
+    assert "T_B r0020 c0030" in cell.comment.text
+
+
+def test_unshared_datapoint_is_not_highlighted():
+    """A datapoint used by a single cell is left unfilled."""
+    layout = _empty_layout(
+        rows=[_h(1, direction="y", code="0010", label="Row")],
+        columns=[_h(10, direction="x", code="0010", label="Col")],
+        cells={
+            (1, 10, None): CellData(
+                row_header_id=1,
+                col_header_id=10,
+                sheet_header_id=None,
+                variable_vid=700,
+                variable_id=70,
+                data_type_code="m",
+            ),
+        },
+    )
+    wb = ExcelLayoutWriter([layout], ExportConfig()).write()
+    cell = next(
+        c
+        for row in wb["T"].iter_rows()
+        for c in row
+        if isinstance(c.value, str) and c.value.startswith("70")
+    )
+    assert cell.fill.fill_type is None
+    assert "Identity" not in cell.comment.text
+
+
+def _open_row_layout(table_code, vvid, col_code="0010"):
+    """Open-row table with one non-key column carrying a datapoint."""
+    return TableLayout(
+        table_vid=1,
+        table_code=table_code,
+        table_name=table_code,
+        columns=[_h(10, direction="x", code=col_code, label="Col")],
+        cells={
+            (None, 10, None): CellData(
+                row_header_id=None,
+                col_header_id=10,
+                sheet_header_id=None,
+                variable_vid=vvid,
+                variable_id=vvid,
+                data_type_code="m",
+            ),
+        },
+        is_open_row=True,
+    )
+
+
+def _only_data_cell(ws, prefix):
+    return next(
+        c
+        for row in ws.iter_rows()
+        for c in row
+        if isinstance(c.value, str) and c.value.startswith(prefix)
+    )
+
+
+def test_open_row_shared_datapoint_is_highlighted():
+    """Identities are reported on open-row tables too."""
+    layouts = [
+        _open_row_layout("T_A", 800),
+        _open_row_layout("T_B", 800, col_code="0020"),
+    ]
+    wb = ExcelLayoutWriter(layouts, ExportConfig()).write()
+
+    cell = _only_data_cell(wb["T_A"], "800")
+    assert cell.fill.start_color.rgb == "00FFFF00"
+    assert "T_B c0020" in cell.comment.text
+
+
+def test_open_row_cell_comments_disabled():
+    """add_cell_comments=False leaves open-row cells without a comment."""
+    cfg = ExportConfig(add_cell_comments=False)
+    wb = ExcelLayoutWriter([_open_row_layout("T_A", 800)], cfg).write()
+
+    assert _only_data_cell(wb["T_A"], "800").comment is None
+
+
+def test_data_cell_comments_disabled():
+    """add_cell_comments=False leaves closed-table cells without a comment."""
+    layout = _empty_layout(
+        rows=[_h(1, direction="y", code="0010", label="Row")],
+        columns=[_h(10, direction="x", code="0010", label="Col")],
+        cells={
+            (1, 10, None): CellData(
+                row_header_id=1,
+                col_header_id=10,
+                sheet_header_id=None,
+                variable_vid=800,
+                variable_id=800,
+                data_type_code="m",
+            ),
+        },
+    )
+    cfg = ExportConfig(add_cell_comments=False)
+    wb = ExcelLayoutWriter([layout], cfg).write()
+
+    assert _only_data_cell(wb["T"], "800").comment is None
+
+
+def test_sheet_renderings_falls_back_when_no_z_header_matches():
+    """Cells keyed by an unknown sheet still get a single grid."""
+    layout = _empty_layout(
+        rows=[_h(1, direction="y", code="0010")],
+        columns=[_h(10, direction="x", code="0010")],
+        sheets=[_h(20, direction="z", code="0010")],
+        cells={
+            (1, 10, 99): CellData(
+                row_header_id=1,
+                col_header_id=10,
+                sheet_header_id=99,
+                variable_vid=800,
+            ),
+        },
+    )
+    renderings = ew._sheet_renderings(layout)
+
+    assert renderings == [(layout.sheets, 99, None)]
+
+
+def test_worksheet_title_disambiguates_repeated_collisions():
+    """A third colliding title keeps counting up."""
+    used: set[str] = set()
+    sheet = _h(1, direction="z", code="0010")
+    titles = [ew._worksheet_title("T" * 40, sheet, used) for _ in range(3)]
+
+    assert len(set(titles)) == 3
+    assert titles[2].endswith("~3")
+
+
+def test_cell_location_without_row_column_or_sheet():
+    """Only the parts that exist appear in a location."""
+    assert ew._cell_location("T_A", "", "", "") == "T_A"
+
+
+def test_cell_tooltip_caps_the_identity_list():
+    """Very shared datapoints list a capped number of locations."""
+    identities = [f"T_{i} r0010 c0010" for i in range(20)]
+    cell_data = CellData(
+        row_header_id=1,
+        col_header_id=10,
+        sheet_header_id=None,
+        variable_vid=800,
+        variable_id=800,
+    )
+    text = ew._cell_tooltip(cell_data, identities)
+
+    assert "T_0 r0010 c0010" in text
+    assert "T_19 r0010 c0010" not in text
+    assert "... and 5 more" in text
+
+
+def _void_cell(**kw):
+    return CellData(
+        row_header_id=kw.get("row_header_id"),
+        col_header_id=10,
+        sheet_header_id=None,
+        variable_vid=None,
+        is_excluded=True,
+        is_void=True,
+    )
+
+
+def _data_cell_of_row(ws, row_label):
+    """The first data cell of the row whose label is ``row_label``."""
+    row = next(
+        c.row for rows in ws.iter_rows() for c in rows if c.value == row_label
+    )
+    # Column A holds the "Rows" band, B the labels and C the codes.
+    return ws.cell(row=row, column=4)
+
+
+def test_void_cell_is_darker_than_an_excluded_cell():
+    """Void cells are excluded too, so they need their own shade."""
+    layout = _empty_layout(
+        rows=[
+            _h(1, direction="y", code="0010", label="Void"),
+            _h(2, direction="y", code="0020", label="Excluded"),
+        ],
+        columns=[_h(10, direction="x", code="0010", label="Col")],
+        cells={
+            (1, 10, None): _void_cell(row_header_id=1),
+            (2, 10, None): CellData(
+                row_header_id=2,
+                col_header_id=10,
+                sheet_header_id=None,
+                variable_vid=None,
+                is_excluded=True,
+            ),
+        },
+    )
+    ws = ExcelLayoutWriter([layout], ExportConfig()).write()["T"]
+
+    assert _data_cell_of_row(ws, "Void").fill.start_color.rgb == "00595959"
+    assert _data_cell_of_row(ws, "Excluded").fill.start_color.rgb == "00999999"
+
+
+def test_open_row_void_cell_is_darker():
+    """The open-row grid marks void cells the same way."""
+    layout = TableLayout(
+        table_vid=1,
+        table_code="T",
+        table_name="T",
+        columns=[_h(10, direction="x", code="0010", label="Col")],
+        cells={(None, 10, None): _void_cell()},
+        is_open_row=True,
+    )
+    ws = ExcelLayoutWriter([layout], ExportConfig()).write()["T"]
+
+    cell = _data_cell_of_row(ws, "Open Rows")
+    assert cell.fill.start_color.rgb == "00595959"


### PR DESCRIPTION
## Summary

Three defects in the annotated table layout export, covering five reported issues.

**Z-axis tables lost every cell** (DRR-1946, DRR-1947, DRR-1949). Data cells were
looked up with a sheet id that was only computed `if not layout.sheets`, so for a
table that *does* have Z sheets every lookup missed and the cell was drawn with the
excluded fill — a fully grey grid with no variable ids. 103 tables in 4.2.1 and 6 in
TCB_CORE 4.3 (`E_05.01.a/b`, `E_05.02.a/b`, `E_06.01/02`) were affected. Such a table
is now rendered as one worksheet per Z sheet, named `<table code> (<sheet code>)` and
listed individually in the Index; tables whose cells carry no sheet keep a single
worksheet, with every Z header annotated on its own row instead of overwriting the
previous one (`H_03.01` used to lose one).

**Signs the database does not hold** (DRR-1967, DRR-1970). The writer invented
`positive` for NULL-sign monetary cells whenever the column held any signed cell, or
the row label started with "Closing balance". `K_15.00.c` row 0140 has `Sign = NULL`
("No Sign" in DPM Studio) and reported `positive`. Only the sign stored on the cell
is rendered now.

**Identities were never implemented** (DRR-1947, DRR-1949). Cells whose data point is
reported by another cell of the workbook are highlighted in yellow, and their comment
lists the other locations (`T_B r0020 c0030`, capped at 15). Cell comments now always
carry `VariableID` and `VariableVID` — previously a comment only appeared when the
cell had dimensional categorisations.

Also, on request: void cells — which are always excluded too, so they were
indistinguishable — get a darker grey (`595959` against the excluded `999999`).

Verified against the real databases: TCB_CORE/TCB_HU 4.3, `K_15.00.c` and `C_16.01.a`
4.4, and `Y_01.01` / `C_21.00` / `C_07.00.a` 4.2.1.

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`) — 2229 passed, 284 skipped; `dpmcore.services.layout_exporter` at 100% branch coverage. See Notes on the repo-wide gate.
- [x] Documentation updated (if applicable) — `docs/cli.rst` output-format section, `specification/03-services.md` §8 (new §8.3 Z-axis sheets, §8.4 Greyed cells, §8.5 Signs and identities)

## Impact / Risk

- **Breaking changes?** No public API, CLI, REST or Django model change: same
  `LayoutExporterService` methods, same `ExportConfig`, same CLI flags. The *workbook
  shape* changes, which is the point of the fix: a Z-axis table now yields several
  worksheets, so anything addressing an exported worksheet by bare table code must
  handle `<table code> (<sheet code>)`. The Index gained a "Sheet" column (only when
  some table was split) and now uses proper quoted internal hyperlinks instead of
  `#Sheet!A1` targets. `ExcelLayoutWriter._write_table` / `_write_open_row_data` took
  new parameters — both private.
- **Database schema or migration concerns?** None. Read-only; no schema, query or ORM
  change (`queries.py` and `processing.py` untouched).
- **Notes for release/changelog?** Yes, user-visible: Z-axis tables export one
  worksheet per sheet; signs now mirror DPM Studio exactly (cells previously shown as
  `positive` may now show no sign); shared data points are highlighted in yellow;
  void cells use a darker grey.

## Notes

- Three existing tests encoded the sign heuristic (`col_positive_only`,
  "Closing balance") and were rewritten to assert faithful signs; 15 tests were added
  for the Z-axis split, the Index, worksheet-title truncation, identities in both the
  closed and open-row grids, the tooltip cap and the void shade.
- The repo-wide `coverage report --fail-under=100` gate fails at 70.8%, which is the
  pre-existing baseline on `master` and unchanged by this branch — 284 tests are
  skipped in a local run. The touched package is at 100%.
- Identity scope is the workbook, i.e. the module for `export_module`. With
  `export_tables` only identities among the exported tables are flagged, which is the
  best available reading of "the same module".
- Void cells are a strict subset of excluded cells in every release checked (7 cells
  in 4.2.1, 8 in 4.4), so the darker shade also guards against a future DB where the
  two flags diverge.
- `595959` for void is a one-line change if it reads too dark in Excel; `666666` or
  `7F7F7F` are the alternatives.
