### PR TITLE
Add `OutputVariableID` to `OperationVersion`, remove unused `VariableCalculation`

### DIFF
--- a/specification/01-orm-layer.md
+++ b/specification/01-orm-layer.md
@@ -80,7 +80,7 @@ functional components plus infrastructure and packaging:
 |--------|---------------|--------|
 | `orm/glossary.py` | Glossary | Category, Item, SubCategory, SubCategoryVersion, SubCategoryItem, Property, PropertyCategory, Context, ContextComposition, CompoundItemContext, SuperCategory |
 | `orm/rendering.py` | Rendering | Table, TableVersion, Header, HeaderVersion, Cell, TableVersionCell, TableVersionHeader, TableGroup, TableGroupComposition, TableAssociation |
-| `orm/variables.py` | Variables | Variable, VariableVersion, VariableCalculation, VariableGeneration, Dimension (logical concept via Property+SubCategory) |
+| `orm/variables.py` | Variables | Variable, VariableVersion, VariableGeneration, Dimension (logical concept via Property+SubCategory) |
 | `orm/operations.py` | Operations | Operation, OperationVersion, OperationVersionData, OperationNode, OperationScope, OperationScopeComposition, Operator, OperatorArgument, OperandReference, OperandReferenceLocation |
 | `orm/packaging.py` | Packaging | Framework, Module, ModuleVersion, ModuleVersionComposition, ModuleParameters, Release |
 | `orm/infrastructure.py` | Infrastructure | Organisation, Language, User, Role, UserRole, DataType, DpmClass, DpmAttribute, Concept, ConceptRelation, Document, DocumentVersion, Subdivision, SubdivisionType, Translation, Changelog |
@@ -550,8 +550,8 @@ Variable
 ├── concept_guid: str (FK → Concept)
 │
 ├── variable_versions → VariableVersion[] (1:N)
-├── variable_calculations → VariableCalculation[] (1:N)
 ├── operand_references → OperandReference[] (1:N)
+├── output_operation_versions → OperationVersion[] (1:N)
 └── concept → Concept
 ```
 
@@ -587,23 +587,7 @@ VariableVersion
 └── end_release → Release (optional)
 ```
 
-### 7.3 VariableCalculation
-
-Links a Variable to an Operation within a Module.
-
-```
-VariableCalculation
-├── (module_id, variable_id, operation_vid): composite PK
-├── from_reference_date: date (optional)
-├── to_reference_date: date (optional)
-├── concept_guid: str
-│
-├── module → Module
-├── variable → Variable
-└── operation_version → OperationVersion
-```
-
-### 7.4 VariableGeneration
+### 7.3 VariableGeneration
 
 Tracks batch variable generation jobs.
 
@@ -619,7 +603,7 @@ VariableGeneration
 └── release → Release
 ```
 
-### 7.5 CompoundKey & KeyComposition
+### 7.4 CompoundKey & KeyComposition
 
 Multi-variable key definitions.
 
@@ -678,6 +662,7 @@ OperationVersion
 ├── description: str (optional)
 ├── endorsement: str (optional)
 ├── is_variant_approved: bool
+├── output_variable_id: int (FK → Variable, optional)
 ├── concept_guid: str (FK → Concept)
 │
 ├── operation → Operation
@@ -686,7 +671,7 @@ OperationVersion
 ├── operation_nodes → OperationNode[] (1:N)
 ├── operation_scopes → OperationScope[] (1:N)
 ├── operation_version_data → OperationVersionData (1:1)
-├── variable_calculations → VariableCalculation[] (1:N)
+├── output_variable → Variable (optional)
 ├── start_release → Release
 └── end_release → Release (optional)
 ```
@@ -846,7 +831,6 @@ Module
 │
 ├── framework → Framework
 ├── module_versions → ModuleVersion[] (1:N)
-├── variable_calculations → VariableCalculation[] (1:N)
 └── concept → Concept
 
 ModuleVersion

--- a/specification/06-api-messages.md
+++ b/specification/06-api-messages.md
@@ -80,7 +80,6 @@ returned inline within their parent or via sub-resource URLs:
 | ModuleVersionComposition | ModuleVersion | Inline |
 | ModuleParameters | ModuleVersion | Inline |
 | VariableVersion | Variable | Via `{version}` path segment |
-| VariableCalculation | Variable | Inline |
 | CompoundKey | *(shared)* | Inline wherever referenced |
 | KeyComposition | CompoundKey | Inline |
 | ItemCategory | Category / Item | Inline (release-versioned join) |

--- a/src/dpmcore/django/admin.py
+++ b/src/dpmcore/django/admin.py
@@ -90,7 +90,6 @@ from dpmcore.django.models.variables import (
     CompoundKey,
     KeyComposition,
     Variable,
-    VariableCalculation,
     VariableVersion,
 )
 
@@ -643,17 +642,6 @@ class VariableVersionAdmin(DpmModelAdmin):
     search_fields = ("code", "name")
 
 
-@admin.register(VariableCalculation)
-class VariableCalculationAdmin(DpmModelAdmin):
-    list_display = (
-        "module",
-        "variable",
-        "operation_version",
-        "from_reference_date",
-        "to_reference_date",
-    )
-
-
 @admin.register(CompoundKey)
 class CompoundKeyAdmin(DpmModelAdmin):
     list_display = ("key_id", "signature")
@@ -688,6 +676,7 @@ class OperationVersionAdmin(DpmModelAdmin):
         "endorsement",
         "start_release",
         "end_release",
+        "output_variable",
     )
     search_fields = ("description", "expression")
     list_filter = ("endorsement", "is_variant_approved")

--- a/src/dpmcore/django/models/__init__.py
+++ b/src/dpmcore/django/models/__init__.py
@@ -79,7 +79,6 @@ from dpmcore.django.models.variables import (
     CompoundKey,
     KeyComposition,
     Variable,
-    VariableCalculation,
     VariableVersion,
 )
 
@@ -157,6 +156,5 @@ __all__ = [
     "CompoundKey",
     "KeyComposition",
     "Variable",
-    "VariableCalculation",
     "VariableVersion",
 ]

--- a/src/dpmcore/django/models/operations.py
+++ b/src/dpmcore/django/models/operations.py
@@ -134,6 +134,14 @@ class OperationVersion(models.Model):
         null=True,
         blank=True,
     )
+    output_variable = models.ForeignKey(
+        "Variable",
+        on_delete=models.DO_NOTHING,
+        db_column="OutputVariableID",
+        related_name="output_operation_versions",
+        null=True,
+        blank=True,
+    )
 
     class Meta:
         managed = False

--- a/src/dpmcore/django/models/variables.py
+++ b/src/dpmcore/django/models/variables.py
@@ -129,49 +129,6 @@ class VariableVersion(models.Model):
         app_label = "dpmcore_django"
 
 
-class VariableCalculation(models.Model):
-    """Link between a Module, Variable, and OperationVersion."""
-
-    module = models.ForeignKey(
-        "Module",
-        on_delete=models.DO_NOTHING,
-        db_column="ModuleID",
-        primary_key=True,
-    )
-    variable = models.ForeignKey(
-        "Variable",
-        on_delete=models.DO_NOTHING,
-        db_column="VariableID",
-    )
-    operation_version = models.ForeignKey(
-        "OperationVersion",
-        on_delete=models.DO_NOTHING,
-        db_column="OperationVID",
-    )
-    from_reference_date = models.DateField(
-        db_column="FromReferenceDate",
-        null=True,
-        blank=True,
-    )
-    to_reference_date = models.DateField(
-        db_column="ToReferenceDate",
-        null=True,
-        blank=True,
-    )
-    row_guid = models.CharField(
-        db_column="RowGUID",
-        max_length=36,
-        null=True,
-        blank=True,
-    )
-
-    class Meta:
-        managed = False
-        db_table = "VariableCalculation"
-        app_label = "dpmcore_django"
-        unique_together = (("module", "variable", "operation_version"),)
-
-
 class CompoundKey(models.Model):
     """Composite key definition for Variables."""
 

--- a/src/dpmcore/dpm_xl/ast/ml_generation.py
+++ b/src/dpmcore/dpm_xl/ast/ml_generation.py
@@ -48,6 +48,7 @@ from dpmcore.dpm_xl.model_queries import (
     ItemCategoryQuery,
     OperatorQuery,
     VariableVersionQuery,
+    ViewDatapointsQuery,
 )
 from dpmcore.dpm_xl.utils import tokens
 from dpmcore.dpm_xl.utils.data_handlers import filter_all_data, generate_xyz
@@ -294,20 +295,24 @@ class MLGeneration(ASTTemplate):
         table = gather_element(target, "table")
         if table is None:
             return None
+        # The target is never visited during semantic analysis, so it's
+        # never in self.data. Resolve it straight from the DB instead
+        cell_data = ViewDatapointsQuery.get_table_data(
+            self.session,
+            table,
+            gather_element(target, "rows"),
+            gather_element(target, "cols"),
+            gather_element(target, "sheets"),
+            self.release_id,
+        )
         # >1 result never happens in practice; left unresolved, not guessed.
-        # Missing self.data also means unresolved, not a crash
-        try:
-            data_xyz = self.extract_operand_data(
-                table,
-                gather_element(target, "rows"),
-                gather_element(target, "cols"),
-                gather_element(target, "sheets"),
-            )
-        except RuntimeError:
+        if len(cell_data) != 1:
             return None
-        if len(data_xyz) == 1:
-            return data_xyz[0]["variable_id"]
-        return None
+        variable_id = cell_data.iloc[0]["variable_id"]
+        # Grey cells come back as NaN, upcasting the column to float64
+        if pd.isna(variable_id):
+            return None
+        return int(variable_id)
 
     def visit_TemporaryAssignment(self, node: TemporaryAssignment) -> None:
         self.visit(node.right)

--- a/src/dpmcore/dpm_xl/ast/ml_generation.py
+++ b/src/dpmcore/dpm_xl/ast/ml_generation.py
@@ -272,8 +272,11 @@ class MLGeneration(ASTTemplate):
         self._set_output_variable(node.left)
 
     def _set_output_variable(self, target: Any) -> None:
+        # Scripting mode must not dirty a real OperationVersion row
+        if self.is_scripting or self.op_version_id is None:
+            return
         variable_id = self._resolve_output_variable_id(target)
-        if variable_id is None or self.op_version_id is None:
+        if variable_id is None:
             return
         operation_version = self.session.get(
             OperationVersion, self.op_version_id
@@ -292,12 +295,16 @@ class MLGeneration(ASTTemplate):
         if table is None:
             return None
         # >1 result never happens in practice; left unresolved, not guessed.
-        data_xyz = self.extract_operand_data(
-            table,
-            gather_element(target, "rows"),
-            gather_element(target, "cols"),
-            gather_element(target, "sheets"),
-        )
+        # Missing self.data also means unresolved, not a crash
+        try:
+            data_xyz = self.extract_operand_data(
+                table,
+                gather_element(target, "rows"),
+                gather_element(target, "cols"),
+                gather_element(target, "sheets"),
+            )
+        except RuntimeError:
+            return None
         if len(data_xyz) == 1:
             return data_xyz[0]["variable_id"]
         return None

--- a/src/dpmcore/dpm_xl/ast/ml_generation.py
+++ b/src/dpmcore/dpm_xl/ast/ml_generation.py
@@ -57,6 +57,7 @@ from dpmcore.orm.operations import (
     OperandReference,
     OperandReferenceLocation,
     OperationNode,
+    OperationVersion,
 )
 
 
@@ -267,6 +268,39 @@ class MLGeneration(ASTTemplate):
         node.right.parent = operation_node
 
         self.visit(node.right)
+
+        self._set_output_variable(node.left)
+
+    def _set_output_variable(self, target: Any) -> None:
+        variable_id = self._resolve_output_variable_id(target)
+        if variable_id is None or self.op_version_id is None:
+            return
+        operation_version = self.session.get(
+            OperationVersion, self.op_version_id
+        )
+        if operation_version is not None:
+            operation_version.output_variable_id = variable_id
+
+    def _resolve_output_variable_id(self, target: Any) -> int | None:
+        variable_code = gather_element(target, "variable")
+        if variable_code is not None:
+            variable_id_result = VariableVersionQuery.get_variable_id(
+                self.session, variable_code, self.release_id
+            )
+            return variable_id_result[0] if variable_id_result else None
+        table = gather_element(target, "table")
+        if table is None:
+            return None
+        # >1 result never happens in practice; left unresolved, not guessed.
+        data_xyz = self.extract_operand_data(
+            table,
+            gather_element(target, "rows"),
+            gather_element(target, "cols"),
+            gather_element(target, "sheets"),
+        )
+        if len(data_xyz) == 1:
+            return data_xyz[0]["variable_id"]
+        return None
 
     def visit_TemporaryAssignment(self, node: TemporaryAssignment) -> None:
         self.visit(node.right)

--- a/src/dpmcore/orm/operations.py
+++ b/src/dpmcore/orm/operations.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
     )
     from dpmcore.orm.packaging import ModuleVersion
     from dpmcore.orm.rendering import Cell
-    from dpmcore.orm.variables import Variable, VariableCalculation
+    from dpmcore.orm.variables import Variable
 
 
 # ------------------------------------------------------------------
@@ -169,6 +169,11 @@ class OperationVersion(Base):
     is_variant_approved: Mapped[Optional[bool]] = mapped_column(
         "IsVariantApproved", Boolean
     )
+    output_variable_id: Mapped[Optional[int]] = mapped_column(
+        "OutputVariableID",
+        Integer,
+        ForeignKey("Variable.VariableID"),
+    )
 
     operation: Mapped[Optional["Operation"]] = relationship(
         "Operation", back_populates="operation_versions"
@@ -225,9 +230,10 @@ class OperationVersion(Base):
             uselist=False,
         )
     )
-    variable_calculations: Mapped[List["VariableCalculation"]] = relationship(
-        "VariableCalculation",
-        back_populates="operation_version",
+    output_variable: Mapped[Optional["Variable"]] = relationship(
+        "Variable",
+        foreign_keys=[output_variable_id],
+        back_populates="output_operation_versions",
     )
 
 

--- a/src/dpmcore/orm/packaging.py
+++ b/src/dpmcore/orm/packaging.py
@@ -30,7 +30,6 @@ if TYPE_CHECKING:
     from dpmcore.orm.rendering import Table, TableVersion
     from dpmcore.orm.variables import (
         CompoundKey,
-        VariableCalculation,
         VariableVersion,
     )
 
@@ -139,10 +138,6 @@ class Module(Base):
     )
     module_versions: Mapped[List["ModuleVersion"]] = relationship(
         "ModuleVersion",
-        back_populates="module",
-    )
-    variable_calculations: Mapped[List["VariableCalculation"]] = relationship(
-        "VariableCalculation",
         back_populates="module",
     )
 

--- a/src/dpmcore/orm/variables.py
+++ b/src/dpmcore/orm/variables.py
@@ -1,17 +1,15 @@
 """ORM models for DPM Variables domain.
 
-This module defines Variable, VariableVersion, VariableCalculation,
-CompoundKey, and KeyComposition models.
+This module defines Variable, VariableVersion, CompoundKey, and
+KeyComposition models.
 """
 
 from __future__ import annotations
 
-from datetime import date
 from typing import TYPE_CHECKING, List, Optional
 
 from sqlalchemy import (
     Boolean,
-    Date,
     ForeignKey,
     Integer,
     String,
@@ -30,7 +28,7 @@ if TYPE_CHECKING:
         SubCategoryVersion,
     )
     from dpmcore.orm.operations import OperandReference, OperationVersion
-    from dpmcore.orm.packaging import Module, ModuleParameters, ModuleVersion
+    from dpmcore.orm.packaging import ModuleParameters, ModuleVersion
     from dpmcore.orm.rendering import (
         HeaderVersion,
         TableVersion,
@@ -79,13 +77,14 @@ class Variable(Base):
         "VariableVersion",
         back_populates="variable",
     )
-    variable_calculations: Mapped[List["VariableCalculation"]] = relationship(
-        "VariableCalculation",
-        back_populates="variable",
-    )
     operand_references: Mapped[List["OperandReference"]] = relationship(
         "OperandReference",
         back_populates="variable",
+    )
+    output_operation_versions: Mapped[List["OperationVersion"]] = relationship(
+        "OperationVersion",
+        foreign_keys="[OperationVersion.output_variable_id]",
+        back_populates="output_variable",
     )
 
 
@@ -203,62 +202,6 @@ class VariableVersion(Base):
     header_versions: Mapped[List["HeaderVersion"]] = relationship(
         "HeaderVersion",
         back_populates="key_variable_version",
-    )
-
-
-# ------------------------------------------------------------------
-# VariableCalculation
-# ------------------------------------------------------------------
-
-
-class VariableCalculation(Base):
-    """Link between a Module, Variable, and OperationVersion.
-
-    Attributes:
-        module_id: FK to Module (composite PK).
-        variable_id: FK to Variable (composite PK).
-        operation_vid: FK to OperationVersion (composite PK).
-        from_reference_date: Start of reference period.
-        to_reference_date: End of reference period.
-        row_guid: Row GUID.
-    """
-
-    __tablename__ = "VariableCalculation"
-
-    module_id: Mapped[int] = mapped_column(
-        "ModuleID",
-        Integer,
-        ForeignKey("Module.ModuleID"),
-        primary_key=True,
-    )
-    variable_id: Mapped[int] = mapped_column(
-        "VariableID",
-        Integer,
-        ForeignKey("Variable.VariableID"),
-        primary_key=True,
-    )
-    operation_vid: Mapped[int] = mapped_column(
-        "OperationVID",
-        Integer,
-        ForeignKey("OperationVersion.OperationVID"),
-        primary_key=True,
-    )
-    from_reference_date: Mapped[Optional[date]] = mapped_column(
-        "FromReferenceDate", Date
-    )
-    to_reference_date: Mapped[Optional[date]] = mapped_column(
-        "ToReferenceDate", Date
-    )
-    row_guid: Mapped[Optional[str]] = mapped_column("RowGUID", String(38))
-
-    module: Mapped["Module"] = relationship(
-        "Module", back_populates="variable_calculations"
-    )
-    variable: Mapped["Variable"] = relationship(
-        "Variable", back_populates="variable_calculations"
-    )
-    operation_version: Mapped["OperationVersion"] = relationship(
-        "OperationVersion", back_populates="variable_calculations"
     )
 
 

--- a/tests/unit/ast/test_ml_generation_persistent_assignment.py
+++ b/tests/unit/ast/test_ml_generation_persistent_assignment.py
@@ -8,8 +8,9 @@ from unittest.mock import MagicMock
 import pytest
 
 from dpmcore.dpm_xl.ast.ml_generation import MLGeneration
-from dpmcore.dpm_xl.ast.nodes import PersistentAssignment, VarID
-from dpmcore.orm.operations import OperationNode
+from dpmcore.dpm_xl.ast.nodes import PersistentAssignment, VarID, VarRef
+from dpmcore.dpm_xl.model_queries import VariableVersionQuery
+from dpmcore.orm.operations import OperationNode, OperationVersion
 
 
 @pytest.fixture
@@ -19,6 +20,7 @@ def ml_generation():
     ml.op_version_id = 99
     ml.is_scripting = False
     ml.data = None
+    ml.release_id = None
     ml.create_operation_node = MagicMock(
         side_effect=lambda n, is_leaf=False: OperationNode()
     )
@@ -70,9 +72,8 @@ def test_left_hand_side_never_becomes_a_leaf_even_when_it_resolves(
     # create_operation_node: once for the assignment itself, once for the
     # right-hand formula. Never for the left-hand target cell.
     assert ml_generation.create_operation_node.call_count == 2
-    ml_generation.extract_operand_data.assert_called_once()
-    right_call_table = ml_generation.extract_operand_data.call_args[0][0]
-    assert right_call_table == "tFND"
+    # Once for the RHS formula, once to resolve the LHS target's variable_id.
+    assert ml_generation.extract_operand_data.call_count == 2
 
 
 def test_left_hand_side_never_becomes_a_leaf_when_it_does_not_resolve(
@@ -94,3 +95,57 @@ def test_right_hand_side_is_still_visited_and_linked(ml_generation):
 
     assert node.right.argument == "right"
     assert node.right.parent is not None
+
+
+# ---------------------------------------------------------------------------
+# Resolving OperationVersion.output_variable_id from the left-hand target
+# ---------------------------------------------------------------------------
+
+
+def test_var_ref_left_hand_side_sets_output_variable_id(
+    ml_generation, monkeypatch
+):
+    monkeypatch.setattr(
+        VariableVersionQuery,
+        "get_variable_id",
+        lambda session, value, release_id: [42] if value == "t1" else None,
+    )
+    ml_generation.extract_operand_data = MagicMock(return_value=[])
+    node = PersistentAssignment(
+        left=VarRef(variable="t1"),
+        op=":=",
+        right=_persistent_assignment().right,
+    )
+
+    ml_generation.visit_PersistentAssignment(node)
+
+    ml_generation.session.get.assert_called_once_with(OperationVersion, 99)
+    assert ml_generation.session.get.return_value.output_variable_id == 42
+
+
+def test_var_id_left_hand_side_sets_output_variable_id(ml_generation):
+    node = _persistent_assignment()  # left is {tFND, r0010, c0010}
+
+    def extract_operand_data(table, rows, cols, sheets):
+        if rows == ["r0010"]:
+            return [{"variable_id": 7, "cell_id": 1}]
+        return []
+
+    ml_generation.extract_operand_data = MagicMock(
+        side_effect=extract_operand_data
+    )
+
+    ml_generation.visit_PersistentAssignment(node)
+
+    ml_generation.session.get.assert_called_once_with(OperationVersion, 99)
+    assert ml_generation.session.get.return_value.output_variable_id == 7
+
+
+def test_var_id_left_hand_side_that_does_not_resolve_leaves_output_variable_untouched(
+    ml_generation,
+):
+    ml_generation.extract_operand_data = MagicMock(return_value=[])
+
+    ml_generation.visit_PersistentAssignment(_persistent_assignment())
+
+    ml_generation.session.get.assert_not_called()

--- a/tests/unit/ast/test_ml_generation_persistent_assignment.py
+++ b/tests/unit/ast/test_ml_generation_persistent_assignment.py
@@ -149,3 +149,33 @@ def test_var_id_left_hand_side_that_does_not_resolve_leaves_output_variable_unto
     ml_generation.visit_PersistentAssignment(_persistent_assignment())
 
     ml_generation.session.get.assert_not_called()
+
+
+def test_scripting_mode_never_touches_output_variable(ml_generation):
+    # Scripting mode must not dirty a real OperationVersion row
+    ml_generation.is_scripting = True
+    ml_generation.extract_operand_data = MagicMock(return_value=[])
+
+    ml_generation.visit_PersistentAssignment(_persistent_assignment())
+
+    # Only the right-hand formula call; the left-hand resolution is skipped
+    assert ml_generation.extract_operand_data.call_count == 1
+    ml_generation.session.get.assert_not_called()
+
+
+def test_var_id_left_hand_side_without_data_degrades_to_unresolved(
+    ml_generation,
+):
+    # A RuntimeError from extract_operand_data must not propagate
+    def extract_operand_data(table, rows, cols, sheets):
+        if rows == ["r0010"]:  # the left-hand target
+            raise RuntimeError("extract_operand_data requires data")
+        return []
+
+    ml_generation.extract_operand_data = MagicMock(
+        side_effect=extract_operand_data
+    )
+
+    ml_generation.visit_PersistentAssignment(_persistent_assignment())
+
+    ml_generation.session.get.assert_not_called()

--- a/tests/unit/ast/test_ml_generation_persistent_assignment.py
+++ b/tests/unit/ast/test_ml_generation_persistent_assignment.py
@@ -5,11 +5,20 @@ of whether the cell resolves in ``extract_operand_data``.
 
 from unittest.mock import MagicMock
 
+import pandas as pd
 import pytest
 
 from dpmcore.dpm_xl.ast.ml_generation import MLGeneration
-from dpmcore.dpm_xl.ast.nodes import PersistentAssignment, VarID, VarRef
-from dpmcore.dpm_xl.model_queries import VariableVersionQuery
+from dpmcore.dpm_xl.ast.nodes import (
+    Constant,
+    PersistentAssignment,
+    VarID,
+    VarRef,
+)
+from dpmcore.dpm_xl.model_queries import (
+    VariableVersionQuery,
+    ViewDatapointsQuery,
+)
 from dpmcore.orm.operations import OperationNode, OperationVersion
 
 
@@ -48,23 +57,15 @@ def _persistent_assignment():
 
 
 def test_left_hand_side_never_becomes_a_leaf_even_when_it_resolves(
-    ml_generation,
+    ml_generation, monkeypatch
 ):
-    # The target cell happens to also resolve in extract_operand_data (e.g.
-    # some other rule in the batch reads it) -- legacy discards it anyway.
-    ml_generation.extract_operand_data = MagicMock(
-        return_value=[
-            {
-                "x": None,
-                "y": None,
-                "z": None,
-                "variable_id": 1,
-                "cell_id": 7,
-                "row_code": "r0010",
-                "column_code": "c0010",
-                "sheet_code": None,
-            },
-        ]
+    # The target cell happens to also resolve in the datapoints table (e.g.
+    # some other rule in the batch persists it) -- legacy discards it anyway.
+    ml_generation.extract_operand_data = MagicMock(return_value=[])
+    monkeypatch.setattr(
+        ViewDatapointsQuery,
+        "get_table_data",
+        MagicMock(return_value=pd.DataFrame([{"variable_id": 1}])),
     )
 
     ml_generation.visit_PersistentAssignment(_persistent_assignment())
@@ -72,19 +73,24 @@ def test_left_hand_side_never_becomes_a_leaf_even_when_it_resolves(
     # create_operation_node: once for the assignment itself, once for the
     # right-hand formula. Never for the left-hand target cell.
     assert ml_generation.create_operation_node.call_count == 2
-    # Once for the RHS formula, once to resolve the LHS target's variable_id.
-    assert ml_generation.extract_operand_data.call_count == 2
+    # The LHS target is resolved straight from the DB, not extract_operand_data.
+    assert ml_generation.extract_operand_data.call_count == 1
 
 
 def test_left_hand_side_never_becomes_a_leaf_when_it_does_not_resolve(
-    ml_generation,
+    ml_generation, monkeypatch
 ):
     ml_generation.extract_operand_data = MagicMock(return_value=[])
+    monkeypatch.setattr(
+        ViewDatapointsQuery,
+        "get_table_data",
+        MagicMock(return_value=pd.DataFrame(columns=["variable_id"])),
+    )
 
     ml_generation.visit_PersistentAssignment(_persistent_assignment())
 
     assert ml_generation.create_operation_node.call_count == 2
-    assert ml_generation.session.add.call_count == 0
+    ml_generation.session.get.assert_not_called()
 
 
 def test_right_hand_side_is_still_visited_and_linked(ml_generation):
@@ -123,32 +129,90 @@ def test_var_ref_left_hand_side_sets_output_variable_id(
     assert ml_generation.session.get.return_value.output_variable_id == 42
 
 
-def test_var_id_left_hand_side_sets_output_variable_id(ml_generation):
+def test_var_id_left_hand_side_sets_output_variable_id(
+    ml_generation, monkeypatch
+):
     node = _persistent_assignment()  # left is {tFND, r0010, c0010}
-
-    def extract_operand_data(table, rows, cols, sheets):
-        if rows == ["r0010"]:
-            return [{"variable_id": 7, "cell_id": 1}]
-        return []
-
-    ml_generation.extract_operand_data = MagicMock(
-        side_effect=extract_operand_data
-    )
+    ml_generation.extract_operand_data = MagicMock(return_value=[])
+    get_table_data = MagicMock(return_value=pd.DataFrame([{"variable_id": 7}]))
+    monkeypatch.setattr(ViewDatapointsQuery, "get_table_data", get_table_data)
 
     ml_generation.visit_PersistentAssignment(node)
 
+    get_table_data.assert_called_once_with(
+        ml_generation.session, "tFND", ["r0010"], ["c0010"], None, None
+    )
     ml_generation.session.get.assert_called_once_with(OperationVersion, 99)
     assert ml_generation.session.get.return_value.output_variable_id == 7
 
 
 def test_var_id_left_hand_side_that_does_not_resolve_leaves_output_variable_untouched(
-    ml_generation,
+    ml_generation, monkeypatch
 ):
     ml_generation.extract_operand_data = MagicMock(return_value=[])
+    monkeypatch.setattr(
+        ViewDatapointsQuery,
+        "get_table_data",
+        MagicMock(return_value=pd.DataFrame(columns=["variable_id"])),
+    )
 
     ml_generation.visit_PersistentAssignment(_persistent_assignment())
 
     ml_generation.session.get.assert_not_called()
+
+
+def test_var_id_left_hand_side_grey_cell_leaves_output_variable_untouched(
+    ml_generation, monkeypatch
+):
+    # A grey target upcasts the variable_id column to float64 and reads back as NaN.
+    ml_generation.extract_operand_data = MagicMock(return_value=[])
+    monkeypatch.setattr(
+        ViewDatapointsQuery,
+        "get_table_data",
+        MagicMock(return_value=pd.DataFrame([{"variable_id": float("nan")}])),
+    )
+
+    ml_generation.visit_PersistentAssignment(_persistent_assignment())
+
+    ml_generation.session.get.assert_not_called()
+
+
+def test_target_without_variable_or_table_leaves_output_variable_untouched(
+    ml_generation,
+):
+    node = PersistentAssignment(
+        left=Constant(
+            type_="Integer", value=1
+        ),  # neither `variable` nor `table`
+        op=":=",
+        right=_persistent_assignment().right,
+    )
+    ml_generation.extract_operand_data = MagicMock(return_value=[])
+
+    ml_generation.visit_PersistentAssignment(node)
+
+    ml_generation.session.get.assert_not_called()
+
+
+def test_missing_operation_version_row_does_not_raise(
+    ml_generation, monkeypatch
+):
+    monkeypatch.setattr(
+        VariableVersionQuery,
+        "get_variable_id",
+        lambda session, value, release_id: [42],
+    )
+    ml_generation.extract_operand_data = MagicMock(return_value=[])
+    ml_generation.session.get = MagicMock(return_value=None)
+    node = PersistentAssignment(
+        left=VarRef(variable="t1"),
+        op=":=",
+        right=_persistent_assignment().right,
+    )
+
+    ml_generation.visit_PersistentAssignment(node)
+
+    ml_generation.session.get.assert_called_once_with(OperationVersion, 99)
 
 
 def test_scripting_mode_never_touches_output_variable(ml_generation):
@@ -160,22 +224,4 @@ def test_scripting_mode_never_touches_output_variable(ml_generation):
 
     # Only the right-hand formula call; the left-hand resolution is skipped
     assert ml_generation.extract_operand_data.call_count == 1
-    ml_generation.session.get.assert_not_called()
-
-
-def test_var_id_left_hand_side_without_data_degrades_to_unresolved(
-    ml_generation,
-):
-    # A RuntimeError from extract_operand_data must not propagate
-    def extract_operand_data(table, rows, cols, sheets):
-        if rows == ["r0010"]:  # the left-hand target
-            raise RuntimeError("extract_operand_data requires data")
-        return []
-
-    ml_generation.extract_operand_data = MagicMock(
-        side_effect=extract_operand_data
-    )
-
-    ml_generation.visit_PersistentAssignment(_persistent_assignment())
-
     ml_generation.session.get.assert_not_called()

--- a/tests/unit/orm/_schema_snapshot.txt
+++ b/tests/unit/orm/_schema_snapshot.txt
@@ -332,6 +332,7 @@ TABLE OperationVersion
   COL IsVariantApproved pg=BOOLEAN mssql=BIT null=True pk=False ai=auto fks=
   COL OperationID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Operation.OperationID
   COL OperationVID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=
+  COL OutputVariableID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=Variable.VariableID
   COL PreconditionOperationVID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=OperationVersion.OperationVID
   COL RowGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=True pk=False ai=auto fks=Concept.ConceptGUID
   COL SeverityOperationVID pg=INTEGER mssql=INTEGER null=True pk=False ai=auto fks=OperationVersion.OperationVID
@@ -568,14 +569,6 @@ TABLE Variable
   COL Type pg=VARCHAR(20) mssql=VARCHAR(20) null=True pk=False ai=auto fks=
   COL VariableID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=
   PK VariableID
-TABLE VariableCalculation
-  COL FromReferenceDate pg=DATE mssql=DATETIME null=True pk=False ai=auto fks=
-  COL ModuleID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=Module.ModuleID
-  COL OperationVID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=OperationVersion.OperationVID
-  COL RowGUID pg=VARCHAR(38) mssql=VARCHAR(38) null=True pk=False ai=auto fks=
-  COL ToReferenceDate pg=DATE mssql=DATETIME null=True pk=False ai=auto fks=
-  COL VariableID pg=INTEGER mssql=INTEGER null=False pk=True ai=auto fks=Variable.VariableID
-  PK ModuleID,VariableID,OperationVID
 TABLE VariableGeneration
   COL EndDate pg=TIMESTAMP WITHOUT TIME ZONE mssql=DATETIME null=True pk=False ai=auto fks=
   COL Error pg=VARCHAR(4000) mssql=VARCHAR(4000) null=True pk=False ai=auto fks=


### PR DESCRIPTION
Closes #342 

## Summary

Replaces the unused `VariableCalculation` table with a nullable `OperationVersion.output_variable_id` FK to `Variable` (mirrored on the Django models, `specification/01-orm-layer.md` and `06-api-messages.md` updated). A single 1:1 FK is enough.

## Checklist

- [X] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [ ] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [X] Documentation updated (if applicable)

## Impact / Risk

Requires a manual DB migration in every client environment before upgrading dpmcore: a new nullable column, `OperationVersion.OutputVariableID`, with a FK to `Variable`. SQLAlchemy selects all mapped columns on `OperationVersion`, so without it any query touching that table breaks once dpmcore is upgraded.

`VariableCalculation` becoming an unused table is optional cleanup but recomended, so leaving it in place does not break anything.

## Notes

<!-- Follow-ups, TODOs, or anything reviewers should know. -->
