### PR TITLE
feat: add export-script CLI command for auto-discovered validation sc…

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,69 @@ curl -X POST http://localhost:8000/api/v1/scripts \
         }'
 ```
 
+**Auto-discovered script (no expressions file needed):**
+
+`generate-script` requires the caller to already know every validation's
+expression text. `export-script` instead discovers the active validations,
+preconditions and severities for a module version directly from the
+database (`OperationScope` / `OperationScopeComposition` /
+`OperationVersion`):
+
+```python
+from dpmcore import connect
+
+with connect("sqlite:///dpm.db") as db:
+    script = db.services.ast_generator.script_for_module(
+        module_code="COREP_Con",
+        module_version="2.0.1",
+        release="4.2",  # optional; latest available if omitted
+    )
+```
+
+```bash
+dpmcore export-script \
+    --module-code COREP_Con --module-version 2.0.1 \
+    --database sqlite:///dpm.db --output ./script.json
+```
+
+Severities come from `OperationScope.Severity` in the database rather than
+a manual `--severity` override. `--output` is optional for a single target;
+when omitted, the script is written to
+`<module_code>-<module_version>.json` in the current directory.
+
+**Bulk export (`--all-modules`/`--all-versions`):**
+
+Sweep every module and/or every active version of a module.
+`--output` becomes a directory —
+one `<module_code>-<module_version>.json` file is written per discovered
+target (defaults to the current directory when omitted). A target that
+fails to resolve is skipped with a warning instead of aborting the whole
+sweep; the command exits non-zero if any target failed.
+
+```bash
+# Every version of every module
+dpmcore export-script --all-modules --all-versions \
+    --database sqlite:///dpm.db --output ./scripts/
+
+# Every version of one module
+dpmcore export-script --module-code COREP_Con --all-versions \
+    --database sqlite:///dpm.db --output ./scripts/
+
+# Every module, pinned to its version active at one release (no
+# --all-versions: exactly one file per module)
+dpmcore export-script --all-modules --release 4.2 \
+    --database sqlite:///dpm.db --output ./scripts/
+```
+
+`--module-code`/`--all-modules` are mutually exclusive, and one is
+required. `--module-version` cannot be combined with `--all-modules` (a
+version number isn't portable across modules). Exactly one of
+`--module-version`, `--all-versions`, or `--release` is required, and the
+three are pairwise mutually exclusive — a bare `--release` (no
+`--module-version`/`--all-versions`) resolves each selected module to its
+single version active at that release, instead of naming a version
+directly.
+
 **Data dictionary queries:**
 
 Release-aware methods accept `release_id` (integer ID) or
@@ -600,7 +663,7 @@ src/dpmcore/
 │   └── routers/           scope, scripts, structure
 ├── django/                Django integration app (models, admin, views)
 ├── cli/
-│   └── main.py            Click CLI (migrate, export-csv, build-meili-json, update-db, serve, generate-script, export-layout)
+│   └── main.py            Click CLI (migrate, export-csv, build-meili-json, update-db, serve, generate-script, export-script, export-layout)
 └── dpm_xl/                DPM-XL engine internals
     ├── grammar/           ANTLR4 grammar + generated parser
     ├── ast/               AST nodes, visitor, operands

--- a/README.rst
+++ b/README.rst
@@ -464,7 +464,7 @@ Package Layout
    |   +-- meili_json.py      MeiliJsonService (operations JSON generation)
    |   +-- database_update.py DatabaseUpdateService (atomic DB update)
    +-- cli/
-   |   +-- main.py            Click CLI (migrate, export-csv, build-meili-json, update-db, serve, generate-script, export-layout)
+   |   +-- main.py            Click CLI (migrate, export-csv, build-meili-json, update-db, serve, generate-script, export-script, export-layout)
    +-- dpm_xl/                DPM-XL engine internals
    |   +-- grammar/           ANTLR4 grammar + generated parser
    |   +-- ast/               AST nodes, visitor, operands

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -387,6 +387,86 @@ required; ``preconditions`` and ``severities`` are optional.
        --severity warning --release 4.2 \
        --database sqlite:///dpm.db --output ./script.json
 
+``dpmcore export-script``
+-------------------------
+
+Generate engine-ready DPM-XL validations scripts directly from the
+database, with no ``--expressions`` file. Unlike ``generate-script``, the
+active validations, preconditions and severities for each module version
+are discovered from ``OperationScope`` / ``OperationScopeComposition`` /
+``OperationVersion``.
+
+.. code-block:: text
+
+   dpmcore export-script (--module-code <code> | --all-modules)
+                          (--module-version <ver> | --all-versions | --release <code>)
+                          --database <url> [--output <path>]
+
+**Options:**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Option
+     - Description
+   * - ``--module-code TEXT``
+     - Primary module code, e.g. ``COREP_Con``. Required unless
+       ``--all-modules`` is given.
+   * - ``--module-version TEXT``
+     - Primary module version, e.g. ``2.0.1``. Mutually exclusive with
+       ``--all-versions`` and ``--release``; one of the three is required.
+   * - ``--all-modules``
+     - Sweep every module in the database, instead of ``--module-code``.
+   * - ``--all-versions``
+     - Sweep every active version of the selected module(s), instead of
+       ``--module-version``. Mutually exclusive with ``--module-version``
+       and ``--release``.
+   * - ``--release TEXT``
+     - Release code, e.g. ``4.2``. Mutually exclusive with
+       ``--module-version`` and ``--all-versions``: on its own, resolves
+       each selected module to its single version active at this release.
+       One of ``--module-version``, ``--all-versions``, or ``--release``
+       is required.
+   * - ``--database TEXT``
+     - SQLAlchemy database URL. **(Required)**
+   * - ``--output PATH``
+     - Where to write the generated script(s). For a single
+       module/version target, a JSON file path (defaults to
+       ``<module_code>-<module_version>.json`` in the current directory).
+       When sweeping (``--all-modules``/``--all-versions``), a directory
+       to write one ``<module_code>-<version>.json`` file per target into
+       (defaults to the current directory).
+
+**Example — single target:**
+
+.. code-block:: bash
+
+   dpmcore export-script \
+       --module-code COREP_Con --module-version 2.0.1 \
+       --database sqlite:///dpm.db --output ./script.json
+
+**Examples — bulk export:**
+
+.. code-block:: bash
+
+   # Every version of every module
+   dpmcore export-script --all-modules --all-versions \
+       --database sqlite:///dpm.db --output ./scripts/
+
+   # Every version of one module
+   dpmcore export-script --module-code COREP_Con --all-versions \
+       --database sqlite:///dpm.db --output ./scripts/
+
+   # Every module, pinned to its version active at one release (no
+   # --all-versions: exactly one file per module)
+   dpmcore export-script --all-modules --release 4.2 \
+       --database sqlite:///dpm.db --output ./scripts/
+
+A target that fails to resolve is skipped with a warning instead of
+aborting the whole sweep; the command exits non-zero if any target
+failed.
+
 ``dpmcore export-layout``
 -------------------------
 

--- a/docs/guide/quickstart.rst
+++ b/docs/guide/quickstart.rst
@@ -111,6 +111,11 @@ Generate an engine-ready validations script
 The same generation is exposed via ``dpmcore generate-script`` and the
 ``/api/v1/scripts`` REST endpoint.
 
+For a module version's active validations, preconditions and severities
+discovered directly from the database — no ``expressions`` list needed —
+use :meth:`~dpmcore.services.ast_generator.ASTGeneratorService.script_for_module`
+or ``dpmcore export-script``.
+
 Export table layouts to Excel
 -----------------------------
 

--- a/src/dpmcore/cli/main.py
+++ b/src/dpmcore/cli/main.py
@@ -692,9 +692,7 @@ def export_script(
                 console.print(f"[red]{exc}[/red]")
                 sys.exit(1)
             if not targets:
-                console.print(
-                    "[red]No active module versions matched.[/red]"
-                )
+                console.print("[red]No active module versions matched.[/red]")
                 sys.exit(1)
 
             out_dir = Path(output) if output else Path(".")
@@ -813,8 +811,7 @@ def _validate_export_script_args(
 
     if bool(module_code) == bool(all_modules):
         console.print(
-            "[red]Specify exactly one of --module-code or "
-            "--all-modules.[/red]"
+            "[red]Specify exactly one of --module-code or --all-modules.[/red]"
         )
         sys.exit(1)
     _validate_version_selector_args(

--- a/src/dpmcore/cli/main.py
+++ b/src/dpmcore/cli/main.py
@@ -752,6 +752,7 @@ def export_script(
         if output
         else Path(f"{module_code}-{module_version}.json")
     )
+    out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(
         json.dumps(result, indent=2, default=str), encoding="utf-8"
     )

--- a/src/dpmcore/cli/main.py
+++ b/src/dpmcore/cli/main.py
@@ -13,7 +13,7 @@ Usage::
 from __future__ import annotations
 
 import sys
-from typing import Any
+from typing import Any, cast
 
 import click
 
@@ -561,6 +561,298 @@ def generate_script(
         f"[green]Wrote script to[/green] {output} "
         f"({len(items)} expressions, {n_dep} dependency modules)"
     )
+
+
+@main.command("export-script")
+@click.option(
+    "--module-code",
+    default=None,
+    help="Primary module code (e.g. COREP_Con). Required unless "
+    "--all-modules is given.",
+)
+@click.option(
+    "--module-version",
+    default=None,
+    help="Primary module version (e.g. 2.0.1). Mutually exclusive with "
+    "--all-versions and --release; one of the three is required.",
+)
+@click.option(
+    "--all-modules",
+    is_flag=True,
+    default=False,
+    help="Sweep every module in the database, instead of --module-code.",
+)
+@click.option(
+    "--all-versions",
+    is_flag=True,
+    default=False,
+    help="Sweep every active version of the selected module(s), "
+    "instead of --module-version. Mutually exclusive with "
+    "--module-version and --release.",
+)
+@click.option(
+    "--release",
+    default=None,
+    help=(
+        "Release code (e.g. '4.2'). Mutually exclusive with "
+        "--module-version and --all-versions: on its own, resolves each "
+        "selected module to its single version active at this release. "
+        "One of --module-version, --all-versions, or --release is "
+        "required."
+    ),
+)
+@click.option(
+    "--database",
+    required=True,
+    help="SQLAlchemy database URL.",
+)
+@click.option(
+    "--output",
+    default=None,
+    type=click.Path(),
+    help="Where to write the generated script(s). For a single "
+    "module/version target, a JSON file path (defaults to "
+    "'<module_code>-<module_version>.json' in the current directory). "
+    "When sweeping (--all-modules/--all-versions), a directory to write "
+    "one '<module_code>-<version>.json' file per target into (defaults "
+    "to the current directory).",
+)
+def export_script(
+    module_code: str | None,
+    module_version: str | None,
+    all_modules: bool,
+    all_versions: bool,
+    release: str | None,
+    database: str,
+    output: str | None,
+) -> None:
+    """Generate engine-ready DPM-XL validations scripts from the database.
+
+    Unlike ``generate-script``, no ``--expressions`` file is needed: the
+    active validations, preconditions and severities for each module
+    version are discovered directly from the database. Pass
+    ``--module-code``/``--module-version`` for a single target, or
+    ``--all-modules``/``--all-versions`` to sweep many at once.
+    ``--release`` on its own (no ``--module-version``/``--all-versions``)
+    selects each targeted module's version active at that release instead.
+    """
+    import json
+    from pathlib import Path
+
+    try:
+        from rich.console import Console
+    except ImportError:
+        click.echo(
+            "Install 'rich' for pretty output: pip install dpmcore[cli]",
+            err=True,
+        )
+        sys.exit(1)
+
+    from sqlalchemy import create_engine
+    from sqlalchemy.exc import ArgumentError
+    from sqlalchemy.orm import Session
+
+    from dpmcore.services.ast_generator import ASTGeneratorService
+
+    console = Console()
+
+    _validate_export_script_args(
+        console,
+        module_code=module_code,
+        module_version=module_version,
+        all_modules=all_modules,
+        all_versions=all_versions,
+        release=release,
+        output=output,
+    )
+    sweeping = module_version is None
+
+    try:
+        engine = create_engine(database)
+    except ArgumentError:
+        console.print(
+            f"[red]--database is not a valid SQLAlchemy URL:[/red] "
+            f"{database!r}\n"
+            "Pass a URL such as "
+            "[bold]sqlite:////absolute/path/to.sqlite[/bold] or "
+            "[bold]sqlite:///relative/path.sqlite[/bold], not a bare "
+            "filesystem path."
+        )
+        sys.exit(1)
+    with Session(engine) as session:
+        svc = ASTGeneratorService(session)
+
+        if sweeping:
+            try:
+                targets = svc.list_module_versions(
+                    module_code=None if all_modules else module_code,
+                    release=release,
+                )
+            except ValueError as exc:
+                console.print(f"[red]{exc}[/red]")
+                sys.exit(1)
+            if not targets:
+                console.print(
+                    "[red]No active module versions matched.[/red]"
+                )
+                sys.exit(1)
+
+            out_dir = Path(output) if output else Path(".")
+            out_dir.mkdir(parents=True, exist_ok=True)
+
+            succeeded: list[tuple[str, str]] = []
+            failed: list[tuple[str, str]] = []
+            for code, version in targets:
+                result = svc.script_for_module(
+                    module_code=code, module_version=version, release=release
+                )
+                if not result.get("success"):
+                    console.print(
+                        f"[yellow]Skipped {code} {version}:[/yellow] "
+                        f"{result.get('error')}"
+                    )
+                    failed.append((code, version))
+                    continue
+
+                out_path = out_dir / f"{code}-{version}.json"
+                out_path.write_text(
+                    json.dumps(result, indent=2, default=str),
+                    encoding="utf-8",
+                )
+                n_ops, n_dep = _script_result_counts(result)
+                console.print(
+                    f"[green]Wrote[/green] {out_path} "
+                    f"({n_ops} validations discovered, "
+                    f"{n_dep} dependency modules)"
+                )
+                succeeded.append((code, version))
+
+            console.print(
+                f"\n[bold]{len(succeeded)} succeeded, {len(failed)} "
+                f"failed[/bold] out of {len(targets)} module versions"
+            )
+            if failed:
+                sys.exit(1)
+            return
+
+        # _validate_export_script_args guarantees both are set here (the
+        # sweeping branch, which allows either to be None, returned above).
+        result = svc.script_for_module(
+            module_code=cast(str, module_code),
+            module_version=cast(str, module_version),
+            release=release,
+        )
+
+    if not result.get("success"):
+        console.print(
+            f"[red]Script generation failed:[/red] {result.get('error')}"
+        )
+        sys.exit(1)
+
+    out_path = (
+        Path(output)
+        if output
+        else Path(f"{module_code}-{module_version}.json")
+    )
+    out_path.write_text(
+        json.dumps(result, indent=2, default=str), encoding="utf-8"
+    )
+
+    n_ops, n_dep = _script_result_counts(result)
+    console.print(
+        f"[green]Wrote script to[/green] {out_path} "
+        f"({n_ops} validations discovered, {n_dep} dependency modules)"
+    )
+
+
+def _validate_version_selector_args(
+    console: Any,
+    *,
+    module_version: str | None,
+    all_versions: bool,
+    release: str | None,
+) -> None:
+    """Validate the version-selector option combination, exiting on error.
+
+    ``--module-version``, ``--all-versions`` and a bare ``--release`` (no
+    version selector) are pairwise mutually exclusive, and exactly one of
+    the three is required.
+    """
+    if module_version and all_versions:
+        console.print(
+            "[red]--module-version and --all-versions are mutually "
+            "exclusive.[/red]"
+        )
+        sys.exit(1)
+    if release is not None and (module_version or all_versions):
+        console.print(
+            "[red]--release is mutually exclusive with "
+            "--module-version and --all-versions.[/red]"
+        )
+        sys.exit(1)
+    if not module_version and not all_versions and release is None:
+        console.print(
+            "[red]Specify one of --module-version, --all-versions, or "
+            "--release.[/red]"
+        )
+        sys.exit(1)
+
+
+def _validate_export_script_args(
+    console: Any,
+    *,
+    module_code: str | None,
+    module_version: str | None,
+    all_modules: bool,
+    all_versions: bool,
+    release: str | None,
+    output: str | None,
+) -> None:
+    """Validate ``export-script``'s option combination, exiting on error."""
+    from pathlib import Path
+
+    if bool(module_code) == bool(all_modules):
+        console.print(
+            "[red]Specify exactly one of --module-code or "
+            "--all-modules.[/red]"
+        )
+        sys.exit(1)
+    _validate_version_selector_args(
+        console,
+        module_version=module_version,
+        all_versions=all_versions,
+        release=release,
+    )
+    if module_version and all_modules:
+        console.print(
+            "[red]--module-version requires --module-code, not "
+            "--all-modules.[/red]"
+        )
+        sys.exit(1)
+
+    sweeping = module_version is None
+    if sweeping and output and Path(output).is_file():
+        console.print(
+            "[red]--output must be a directory when sweeping "
+            "(--all-modules/--all-versions/--release).[/red]"
+        )
+        sys.exit(1)
+
+
+def _script_result_counts(result: dict[str, Any]) -> tuple[int, int]:
+    """Count validations/dependency modules across a script() result."""
+    enriched = result.get("enriched_ast") or {}
+    n_ops = sum(
+        len((ns_block or {}).get("operations") or {})
+        for ns_block in enriched.values()
+        if isinstance(ns_block, dict)
+    )
+    n_dep = sum(
+        len((ns_block or {}).get("dependency_modules") or {})
+        for ns_block in enriched.values()
+        if isinstance(ns_block, dict)
+    )
+    return n_ops, n_dep
 
 
 @main.command()

--- a/src/dpmcore/services/ast_generator.py
+++ b/src/dpmcore/services/ast_generator.py
@@ -393,6 +393,294 @@ class ASTGeneratorService:
                 "failed_operations": {},
             }
 
+    def script_for_module(
+        self,
+        module_code: str,
+        module_version: str,
+        release: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Auto-discover a module version's active validations and script them.
+
+        No ``expressions``, ``preconditions`` or ``severities`` need to be
+        supplied — they are looked up from ``OperationScope`` /
+        ``OperationScopeComposition`` / ``OperationVersion`` for this module
+        version, then handed to :meth:`script`.
+
+        Args:
+            module_code: Code of the module (e.g. ``"COREP_Con"``).
+            module_version: Version of the module (e.g. ``"2.0.1"``).
+            release: Optional release code; resolved the same way as in
+                :meth:`script`.
+
+        Returns:
+            Same shape as :meth:`script`.
+        """
+        if self.session is None:
+            return {
+                "success": False,
+                "enriched_ast": None,
+                "error": "No database session — cannot generate script.",
+                "failed_operations": {},
+            }
+
+        try:
+            mv, release_row = self._resolve_release(
+                module_code, module_version, release
+            )
+            expressions, preconditions, severities = (
+                self._discover_module_validations(mv, release_row)
+            )
+        except ValueError as exc:
+            return {
+                "success": False,
+                "enriched_ast": None,
+                "error": str(exc),
+                "failed_operations": {},
+            }
+
+        return self.script(
+            expressions=expressions,
+            module_code=module_code,
+            module_version=module_version,
+            preconditions=preconditions or None,
+            severities=severities or None,
+            release=release_row.code,
+        )
+
+    def list_module_versions(
+        self,
+        module_code: Optional[str] = None,
+        release: Optional[str] = None,
+    ) -> List[Tuple[str, str]]:
+        """Enumerate ``(module_code, version_number)`` pairs to sweep.
+
+        Used by the CLI's ``--all-modules``/``--all-versions`` sweep to
+        discover targets for :meth:`script_for_module`.
+
+        Args:
+            module_code: Restrict to this module's versions. ``None``
+                enumerates every module in the database.
+            release: When given, only ``ModuleVersion`` rows whose window
+                contains this release (via :func:`filter_by_release`) are
+                returned.
+
+        Returns:
+            ``(module_code, version_number)`` pairs, ordered by
+            ``(code, start_release_id)``, excluding ghost/phantom
+            ``ModuleVersion`` rows (``from_reference_date ==
+            to_reference_date``, both non-null — the same test
+            :meth:`_walk_ghost_chain` uses).
+
+        Raises:
+            ValueError: If a database session is missing, or ``release``
+                doesn't match any ``Release.code``.
+        """
+        from sqlalchemy import or_
+
+        from dpmcore.dpm_xl.utils.filters import (
+            filter_by_release,
+            resolve_release_id,
+        )
+        from dpmcore.orm.packaging import ModuleVersion
+
+        if self.session is None:
+            raise ValueError("No database session — cannot list modules.")
+        session = self.session
+
+        query = session.query(
+            ModuleVersion.code, ModuleVersion.version_number
+        ).filter(
+            or_(
+                ModuleVersion.from_reference_date.is_(None),
+                ModuleVersion.to_reference_date.is_(None),
+                ModuleVersion.from_reference_date
+                != ModuleVersion.to_reference_date,
+            )
+        )
+        if module_code is not None:
+            query = query.filter(ModuleVersion.code == module_code)
+        if release is not None:
+            release_id = resolve_release_id(session, release_code=release)
+            query = filter_by_release(
+                query,
+                start_col=ModuleVersion.start_release_id,
+                end_col=ModuleVersion.end_release_id,
+                release_id=release_id,
+            )
+        query = query.order_by(
+            ModuleVersion.code, ModuleVersion.start_release_id
+        )
+
+        seen: set[Tuple[str, str]] = set()
+        pairs: List[Tuple[str, str]] = []
+        for code, version_number in query.all():
+            if code is None or version_number is None:
+                continue
+            pair = (code, version_number)
+            if pair not in seen:
+                seen.add(pair)
+                pairs.append(pair)
+        return pairs
+
+    def _discover_module_validations(
+        self,
+        mv: Any,
+        release_row: Any,
+    ) -> Tuple[
+        List[Tuple[str, str]],
+        List[Union[Tuple[str, List[str]], Dict[str, Any]]],
+        Dict[str, str],
+    ]:
+        """Look up the active ``(expression, code)`` pairs for a module.
+
+        Resolves the module version's active operations by joining
+        ``OperationVersion`` to ``OperationScope`` /
+        ``OperationScopeComposition``, filtered to this release using
+        dpmcore's point-release model (:func:`filter_by_release`, a window
+        containment check rather than a raw ``StartReleaseID``/
+        ``EndReleaseID`` overlap). This does not filter out operations
+        scoped exclusively to phantom module versions (see
+        :meth:`list_module_versions`'s docstring for what "phantom" means
+        here) — that guard only matters when sweeping every module in the
+        database, which this single-module lookup never does; revisit
+        alongside a future ``--all-modules`` sweep.
+
+        Returns:
+            ``(expressions, preconditions, severities)`` ready to pass to
+            :meth:`script`.
+        """
+        from sqlalchemy import or_
+
+        from dpmcore.dpm_xl.utils.filters import filter_by_release
+        from dpmcore.orm.operations import (
+            Operation,
+            OperationScope,
+            OperationScopeComposition,
+            OperationVersion,
+        )
+
+        session = self.session
+        if session is None:
+            raise ValueError("No database session — cannot generate script.")
+
+        query = (
+            session.query(
+                OperationVersion.operation_vid,
+                Operation.code,
+                OperationVersion.expression,
+                OperationScope.severity,
+                OperationVersion.precondition_operation_vid,
+            )
+            .join(
+                OperationScope,
+                OperationVersion.operation_vid == OperationScope.operation_vid,
+            )
+            .join(
+                OperationScopeComposition,
+                OperationScope.operation_scope_id
+                == OperationScopeComposition.operation_scope_id,
+            )
+            .join(
+                Operation,
+                OperationVersion.operation_id == Operation.operation_id,
+            )
+            .filter(OperationScopeComposition.module_vid == mv.module_vid)
+            # Access boolean convention: True is stored as -1, not 1.
+            .filter(OperationScope.is_active.in_([-1, 1, True]))
+            .filter(
+                or_(
+                    Operation.code.startswith("v"),
+                    Operation.code.startswith("e"),
+                )
+            )
+        )
+        query = filter_by_release(
+            query,
+            start_col=OperationVersion.start_release_id,
+            end_col=OperationVersion.end_release_id,
+            release_id=release_row.release_id,
+        )
+
+        # A code can match more than one OperationVersion row; keep the
+        # latest (highest OperationVID) per code.
+        _Row = Tuple[int, str, Optional[str], Optional[int]]
+        latest_by_code: Dict[str, _Row] = {}
+        for op_vid, code, expression, severity, prec_vid in query.all():
+            existing = latest_by_code.get(code)
+            if existing is None or op_vid > existing[0]:
+                latest_by_code[code] = (op_vid, expression, severity, prec_vid)
+
+        expressions: List[Tuple[str, str]] = []
+        severities: Dict[str, str] = {}
+        prec_vid_to_codes: Dict[int, List[str]] = {}
+        for code, (_, expression, severity, prec_vid) in sorted(
+            latest_by_code.items()
+        ):
+            expressions.append((expression, code))
+            if severity:
+                severities[code] = severity
+            if prec_vid is not None:
+                prec_vid_to_codes.setdefault(prec_vid, []).append(code)
+
+        preconditions: List[Union[Tuple[str, List[str]], Dict[str, Any]]] = (
+            list(self._resolve_preconditions(prec_vid_to_codes))
+        )
+        return expressions, preconditions, severities
+
+    def _resolve_preconditions(
+        self, prec_vid_to_codes: Dict[int, List[str]]
+    ) -> List[Dict[str, Any]]:
+        """Resolve discovered ``PreconditionOperationVID``s into entries.
+
+        Note: :meth:`_build_preconditions_block` does not build a
+        precondition's AST structurally from the DB's stored
+        ``OperationNode`` graph, so it cannot express arbitrary DPM-XL
+        boolean expressions — it only recognises ``{v_<variable_code>}``
+        markers (or an ``and``-chain of them) in the expression text — see
+        its docstring and ``TestBuildPreconditionsBlock`` in
+        ``tests/unit/services/test_ast_generator.py``. A discovered
+        precondition whose stored ``Expression`` isn't in that form resolves
+        to no variables and is silently dropped, same as pydpm. This is a
+        pre-existing limitation of ``script()``'s precondition support, not
+        specific to auto-discovery.
+        """
+        if not prec_vid_to_codes:
+            return []
+
+        from dpmcore.orm.operations import Operation, OperationVersion
+
+        session = self.session
+        if session is None:
+            raise ValueError("No database session — cannot generate script.")
+
+        rows = (
+            session.query(
+                OperationVersion.operation_vid,
+                Operation.code,
+                OperationVersion.expression,
+            )
+            .join(
+                Operation,
+                OperationVersion.operation_id == Operation.operation_id,
+            )
+            .filter(
+                OperationVersion.operation_vid.in_(prec_vid_to_codes.keys())
+            )
+            .all()
+        )
+
+        preconditions: List[Dict[str, Any]] = []
+        for prec_vid, prec_code, prec_expression in rows:
+            preconditions.append(
+                {
+                    "expression": prec_expression,
+                    "affected_operations": sorted(prec_vid_to_codes[prec_vid]),
+                    "code": prec_code,
+                    "version_id": prec_vid,
+                }
+            )
+        return preconditions
+
     # ------------------------------------------------------------------ #
     # Resolution helpers
     # ------------------------------------------------------------------ #

--- a/tests/integration/services/test_ast_generator_discovery.py
+++ b/tests/integration/services/test_ast_generator_discovery.py
@@ -1,4 +1,3 @@
-
 """Integration tests for ``ASTGeneratorService.script_for_module``.
 
 Verifies the auto-discovery path (issue #625): given only a
@@ -185,7 +184,9 @@ def test_discovers_active_validations(fixture_session):
 
     for code, entry in operations.items():
         candidates = oracle[code]
-        matching = [r for r in candidates if r.Expression == entry["expression"]]
+        matching = [
+            r for r in candidates if r.Expression == entry["expression"]
+        ]
         assert matching, (
             f"discovered expression for {code!r} matches none of the "
             f"active OperationVersion rows for it in the fixture DB"
@@ -223,7 +224,9 @@ def test_discovered_preconditions_reference_affected_operations(
         if code not in operations:
             continue
         entry = operations[code]
-        matching = [r for r in candidates if r.Expression == entry["expression"]]
+        matching = [
+            r for r in candidates if r.Expression == entry["expression"]
+        ]
         if not matching or not matching[0].PreconditionOperationVID:
             continue
         prec_row = _precondition_expression(

--- a/tests/integration/services/test_ast_generator_discovery.py
+++ b/tests/integration/services/test_ast_generator_discovery.py
@@ -1,0 +1,252 @@
+
+"""Integration tests for ``ASTGeneratorService.script_for_module``.
+
+Verifies the auto-discovery path (issue #625): given only a
+``module_code``/``module_version``, the active validations, severities and
+preconditions are looked up from the database instead of being supplied by
+the caller.
+
+Assertions are checked against an independent raw-SQL oracle rather than by
+re-deriving expected values from the code under test. The oracle
+deliberately does not replicate dpmcore's release-window resolution (a code
+can have several historical ``OperationVersion`` rows) — instead, each
+assertion matches the row whose ``Expression`` equals what
+``script_for_module`` actually picked, so it is correct regardless of which
+historical version dpmcore resolves to.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import text
+
+from dpmcore.services.ast_generator import (
+    _VAR_REF_PATTERN,
+    ASTGeneratorService,
+)
+
+# Also exercised by test_ast_generator_condexpr.py — known to have active,
+# type-checking validations in the fixture DB.
+_MODULE_CODE = "REM_DBM"
+_MODULE_VERSION = "2.3.0"
+
+
+def _active_scope_rows(session, module_code, module_version):
+    """Raw-SQL oracle: active OperationScope rows for a module version.
+
+    Deliberately re-implemented with plain SQL (not reusing
+    ``_discover_module_validations``) so it serves as independent ground
+    truth. Returns ``{code: [rows]}`` — a code may have more than one
+    historical ``OperationVersion`` row in scope.
+    """
+    module_vid = session.execute(
+        text(
+            "SELECT ModuleVID FROM ModuleVersion "
+            "WHERE Code = :c AND VersionNumber = :v"
+        ),
+        {"c": module_code, "v": module_version},
+    ).scalar()
+    assert module_vid is not None, (
+        f"{module_code} {module_version} not in fixture DB"
+    )
+
+    rows = session.execute(
+        text(
+            """
+            SELECT o.Code, ov.Expression, os.Severity,
+                   ov.PreconditionOperationVID
+            FROM OperationScopeComposition osc
+            JOIN OperationScope os
+                ON os.OperationScopeID = osc.OperationScopeID
+            JOIN OperationVersion ov ON ov.OperationVID = os.OperationVID
+            JOIN Operation o ON o.OperationID = ov.OperationID
+            WHERE osc.ModuleVID = :mvid
+              AND os.IsActive IN (-1, 1)
+              AND (o.Code LIKE 'v%' OR o.Code LIKE 'e%')
+            """
+        ),
+        {"mvid": module_vid},
+    ).fetchall()
+    by_code: dict[str, list] = {}
+    for row in rows:
+        by_code.setdefault(row.Code, []).append(row)
+    return by_code
+
+
+def _precondition_expression(session, precondition_operation_vid):
+    return session.execute(
+        text(
+            "SELECT o.Code, ov.Expression "
+            "FROM OperationVersion ov "
+            "JOIN Operation o ON o.OperationID = ov.OperationID "
+            "WHERE ov.OperationVID = :vid"
+        ),
+        {"vid": precondition_operation_vid},
+    ).first()
+
+
+def _active_module_versions_oracle(session, module_code):
+    """Raw-SQL oracle: non-phantom ``ModuleVersion`` rows for a module code.
+
+    Phantom rows (``FromReferenceDate == ToReferenceDate``, both non-null)
+    are excluded, mirroring ``list_module_versions``'s own filter.
+    """
+    rows = session.execute(
+        text(
+            "SELECT Code, VersionNumber, FromReferenceDate, ToReferenceDate "
+            "FROM ModuleVersion WHERE Code = :c"
+        ),
+        {"c": module_code},
+    ).fetchall()
+    return {
+        (r.Code, r.VersionNumber)
+        for r in rows
+        if r.FromReferenceDate is None
+        or r.ToReferenceDate is None
+        or r.FromReferenceDate != r.ToReferenceDate
+    }
+
+
+def test_list_module_versions_excludes_phantom_rows(fixture_session):
+    oracle = _active_module_versions_oracle(fixture_session, _MODULE_CODE)
+    assert oracle, "fixture DB has no ModuleVersion rows for this module"
+
+    result = set(
+        ASTGeneratorService(fixture_session).list_module_versions(
+            module_code=_MODULE_CODE
+        )
+    )
+
+    assert result == oracle
+
+
+def test_list_module_versions_all_modules_is_a_superset(fixture_session):
+    single = set(
+        ASTGeneratorService(fixture_session).list_module_versions(
+            module_code=_MODULE_CODE
+        )
+    )
+    assert single, "fixture DB has no non-phantom versions for this module"
+
+    everything = set(
+        ASTGeneratorService(fixture_session).list_module_versions()
+    )
+
+    assert single <= everything
+
+
+def test_list_module_versions_release_filter_stays_within_module(
+    fixture_session,
+):
+    release_code = fixture_session.execute(
+        text("SELECT Code FROM Release ORDER BY ReleaseID LIMIT 1")
+    ).scalar()
+    assert release_code is not None, "fixture DB has no Release rows"
+
+    oracle = _active_module_versions_oracle(fixture_session, _MODULE_CODE)
+
+    result = set(
+        ASTGeneratorService(fixture_session).list_module_versions(
+            module_code=_MODULE_CODE, release=release_code
+        )
+    )
+
+    # A release filter must never surface a phantom row or a version of a
+    # different module; it may only narrow the non-phantom set down.
+    assert result <= oracle
+
+
+def test_list_module_versions_unknown_release_raises(fixture_session):
+    with pytest.raises(ValueError, match="not found"):
+        ASTGeneratorService(fixture_session).list_module_versions(
+            release="not-a-real-release-code-xyz"
+        )
+
+
+def test_discovers_active_validations(fixture_session):
+    oracle = _active_scope_rows(fixture_session, _MODULE_CODE, _MODULE_VERSION)
+    assert oracle, "fixture DB has no active validations for this module"
+
+    result = ASTGeneratorService(fixture_session).script_for_module(
+        module_code=_MODULE_CODE,
+        module_version=_MODULE_VERSION,
+    )
+
+    assert result["success"] is True, result.get("error")
+    assert result["failed_operations"] == {}
+
+    _, ns_block = next(iter(result["enriched_ast"].items()))
+    operations = ns_block["operations"]
+    assert operations, "script_for_module discovered no validations"
+
+    # Every discovered code must be a real, active-scoped operation for this
+    # module version (no bogus/unscoped code leaks through).
+    assert set(operations) <= set(oracle)
+
+    for code, entry in operations.items():
+        candidates = oracle[code]
+        matching = [r for r in candidates if r.Expression == entry["expression"]]
+        assert matching, (
+            f"discovered expression for {code!r} matches none of the "
+            f"active OperationVersion rows for it in the fixture DB"
+        )
+        oracle_row = matching[0]
+        if oracle_row.Severity:
+            assert entry["severity"] == oracle_row.Severity.lower()
+
+
+def test_discovered_preconditions_reference_affected_operations(
+    fixture_session,
+):
+    """Preconditions whose expression uses the ``{v_<code>}`` marker form
+    (the only form ``_build_preconditions_block`` understands — see the
+    note on ``ASTGeneratorService._resolve_preconditions``) must surface in
+    the output with the right ``affected_operations``. Preconditions using
+    any other DPM-XL expression form are expected to resolve to no
+    variables and be silently dropped, same as pydpm — this test only
+    asserts on the former.
+    """
+    oracle = _active_scope_rows(fixture_session, _MODULE_CODE, _MODULE_VERSION)
+
+    result = ASTGeneratorService(fixture_session).script_for_module(
+        module_code=_MODULE_CODE,
+        module_version=_MODULE_VERSION,
+    )
+    assert result["success"] is True, result.get("error")
+
+    _, ns_block = next(iter(result["enriched_ast"].items()))
+    operations = ns_block["operations"]
+    preconditions = ns_block["preconditions"]
+
+    checked_any = False
+    for code, candidates in oracle.items():
+        if code not in operations:
+            continue
+        entry = operations[code]
+        matching = [r for r in candidates if r.Expression == entry["expression"]]
+        if not matching or not matching[0].PreconditionOperationVID:
+            continue
+        prec_row = _precondition_expression(
+            fixture_session, matching[0].PreconditionOperationVID
+        )
+        assert prec_row is not None
+        if not _VAR_REF_PATTERN.search(prec_row.Expression):
+            continue  # not in the form _build_preconditions_block supports
+        checked_any = True
+        matches = [
+            prec
+            for prec in preconditions.values()
+            if code in prec["affected_operations"]
+        ]
+        assert matches, (
+            f"{code} has a precondition in the DB "
+            f"({matching[0].PreconditionOperationVID}) but no matching "
+            f"precondition entry was generated"
+        )
+
+    if not checked_any:
+        pytest.skip(
+            f"No discovered validation in {_MODULE_CODE} {_MODULE_VERSION} "
+            "has a precondition using the {v_<code>} marker form that "
+            "_build_preconditions_block supports."
+        )

--- a/tests/unit/cli/test_cli_export_script.py
+++ b/tests/unit/cli/test_cli_export_script.py
@@ -79,9 +79,7 @@ class TestExportScriptSuccess:
         with patch(
             "dpmcore.services.ast_generator.ASTGeneratorService"
         ) as Svc:
-            Svc.return_value.script_for_module.return_value = (
-                _success_result()
-            )
+            Svc.return_value.script_for_module.return_value = _success_result()
             result = runner.invoke(
                 main,
                 [
@@ -120,9 +118,7 @@ class TestExportScriptSuccess:
         with patch(
             "dpmcore.services.ast_generator.ASTGeneratorService"
         ) as Svc:
-            Svc.return_value.script_for_module.return_value = (
-                _success_result()
-            )
+            Svc.return_value.script_for_module.return_value = _success_result()
             runner.invoke(
                 main,
                 [
@@ -317,9 +313,7 @@ class TestExportScriptSweep:
                 ("MOD_A", "1.0"),
                 ("MOD_B", "2.0"),
             ]
-            Svc.return_value.script_for_module.return_value = (
-                _success_result()
-            )
+            Svc.return_value.script_for_module.return_value = _success_result()
             result = runner.invoke(
                 main,
                 [
@@ -623,9 +617,7 @@ class TestExportScriptReleaseOnlyMode:
             Svc.return_value.list_module_versions.return_value = [
                 ("FINREP_Con", "2.0.1"),
             ]
-            Svc.return_value.script_for_module.return_value = (
-                _success_result()
-            )
+            Svc.return_value.script_for_module.return_value = _success_result()
             result = runner.invoke(
                 main,
                 [
@@ -658,9 +650,7 @@ class TestExportScriptReleaseOnlyMode:
                 ("MOD_A", "1.0"),
                 ("MOD_B", "2.0"),
             ]
-            Svc.return_value.script_for_module.return_value = (
-                _success_result()
-            )
+            Svc.return_value.script_for_module.return_value = _success_result()
             result = runner.invoke(
                 main,
                 [
@@ -692,9 +682,7 @@ class TestExportScriptReleaseOnlyMode:
             Svc.return_value.list_module_versions.return_value = [
                 ("FINREP_Con", "2.0.1"),
             ]
-            Svc.return_value.script_for_module.return_value = (
-                _success_result()
-            )
+            Svc.return_value.script_for_module.return_value = _success_result()
             runner.invoke(
                 main,
                 [

--- a/tests/unit/cli/test_cli_export_script.py
+++ b/tests/unit/cli/test_cli_export_script.py
@@ -1,0 +1,739 @@
+"""Tests for the ``dpmcore export-script`` CLI subcommand."""
+
+import json
+import os
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from dpmcore.cli.main import main
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+_NS_URI = "http://example.org/mod"
+
+
+def _success_result():
+    return {
+        "success": True,
+        "enriched_ast": {
+            _NS_URI: {
+                "module_code": "FINREP_Con",
+                "module_version": "2.0.1",
+                "framework_code": "FINREP",
+                "dpm_release": {
+                    "release": "4.2",
+                    "publication_date": "2025-04-28",
+                },
+                "dates": {"from": "2026-03-31", "to": None},
+                "operations": {
+                    "v0001": {
+                        "version_id": 1234,
+                        "code": "v0001",
+                        "expression": "expr",
+                        "root_operator_id": 24,
+                        "ast": {"class_name": "BinOp"},
+                        "from_submission_date": "2026-03-31",
+                        "severity": "error",
+                    },
+                    "v0002": {
+                        "version_id": 1235,
+                        "code": "v0002",
+                        "expression": "expr2",
+                        "root_operator_id": 24,
+                        "ast": {"class_name": "BinOp"},
+                        "from_submission_date": "2026-03-31",
+                        "severity": "warning",
+                    },
+                },
+                "variables": {},
+                "tables": {},
+                "preconditions": {},
+                "precondition_variables": {},
+                "dependency_information": {
+                    "intra_instance_validations": ["v0001", "v0002"],
+                    "cross_instance_dependencies": [],
+                    "alternative_dependencies": [],
+                },
+                "dependency_modules": {
+                    "http://example.org/m1": {
+                        "tables": {},
+                        "variables": {},
+                    },
+                },
+            }
+        },
+        "error": None,
+        "failed_operations": {},
+    }
+
+
+class TestExportScriptSuccess:
+    def test_writes_output_file(self, runner, tmp_path):
+        out = tmp_path / "script.json"
+        with patch(
+            "dpmcore.services.ast_generator.ASTGeneratorService"
+        ) as Svc:
+            Svc.return_value.script_for_module.return_value = (
+                _success_result()
+            )
+            result = runner.invoke(
+                main,
+                [
+                    "export-script",
+                    "--module-code",
+                    "FINREP_Con",
+                    "--module-version",
+                    "2.0.1",
+                    "--database",
+                    "sqlite:///:memory:",
+                    "--output",
+                    str(out),
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert out.exists()
+        payload = json.loads(out.read_text())
+        assert payload["success"] is True
+        ns = payload["enriched_ast"][_NS_URI]
+        assert "dependency_modules" in ns
+        # Rich wraps long lines according to console width, and the tmp_path
+        # in the printed line varies in length across runs/machines, so the
+        # wrap point can land inside these phrases; normalize whitespace
+        # before matching.
+        normalized_output = " ".join(result.output.split())
+        assert "2 validations discovered" in normalized_output
+        assert "1 dependency modules" in normalized_output
+
+    def test_passes_all_args_to_service(self, runner, tmp_path):
+        # --release is intentionally omitted: it is mutually exclusive
+        # with --module-version (see TestExportScriptSweepValidation).
+        # Release pass-through for a single target is covered by
+        # TestExportScriptReleaseOnlyMode instead.
+        out = tmp_path / "script.json"
+        with patch(
+            "dpmcore.services.ast_generator.ASTGeneratorService"
+        ) as Svc:
+            Svc.return_value.script_for_module.return_value = (
+                _success_result()
+            )
+            runner.invoke(
+                main,
+                [
+                    "export-script",
+                    "--module-code",
+                    "FINREP_Con",
+                    "--module-version",
+                    "2.0.1",
+                    "--database",
+                    "sqlite:///:memory:",
+                    "--output",
+                    str(out),
+                ],
+            )
+
+        kwargs = Svc.return_value.script_for_module.call_args.kwargs
+        assert kwargs["module_code"] == "FINREP_Con"
+        assert kwargs["module_version"] == "2.0.1"
+        assert kwargs["release"] is None
+
+    def test_no_expressions_option_exists(self, runner, tmp_path):
+        out = tmp_path / "script.json"
+        result = runner.invoke(
+            main,
+            [
+                "export-script",
+                "--expressions",
+                "does-not-matter.json",
+                "--module-code",
+                "MOD",
+                "--module-version",
+                "1.0",
+                "--database",
+                "sqlite:///:memory:",
+                "--output",
+                str(out),
+            ],
+        )
+        assert result.exit_code != 0
+        assert "no such option" in result.output.lower()
+
+
+class TestExportScriptFailure:
+    def test_service_failure_exits_1(self, runner, tmp_path):
+        out = tmp_path / "script.json"
+        with patch(
+            "dpmcore.services.ast_generator.ASTGeneratorService"
+        ) as Svc:
+            Svc.return_value.script_for_module.return_value = {
+                "success": False,
+                "enriched_ast": None,
+                "error": "boom",
+                "failed_operations": {},
+            }
+            result = runner.invoke(
+                main,
+                [
+                    "export-script",
+                    "--module-code",
+                    "FINREP_Con",
+                    "--module-version",
+                    "2.0.1",
+                    "--database",
+                    "sqlite:///:memory:",
+                    "--output",
+                    str(out),
+                ],
+            )
+
+        assert result.exit_code == 1
+        assert "boom" in result.output
+        assert not out.exists()
+
+
+class TestExportScriptValidation:
+    def test_missing_required_database(self, runner, tmp_path):
+        out = tmp_path / "script.json"
+        result = runner.invoke(
+            main,
+            [
+                "export-script",
+                "--module-code",
+                "MOD",
+                "--module-version",
+                "1.0",
+                "--output",
+                str(out),
+            ],
+        )
+        assert result.exit_code != 0
+
+    def test_missing_required_module_code(self, runner, tmp_path):
+        out = tmp_path / "script.json"
+        result = runner.invoke(
+            main,
+            [
+                "export-script",
+                "--module-version",
+                "1.0",
+                "--database",
+                "sqlite:///:memory:",
+                "--output",
+                str(out),
+            ],
+        )
+        assert result.exit_code != 0
+
+    def test_missing_required_module_version(self, runner, tmp_path):
+        out = tmp_path / "script.json"
+        result = runner.invoke(
+            main,
+            [
+                "export-script",
+                "--module-code",
+                "MOD",
+                "--database",
+                "sqlite:///:memory:",
+                "--output",
+                str(out),
+            ],
+        )
+        assert result.exit_code != 0
+
+
+class TestExportScriptDatabaseArgument:
+    def test_invalid_database_url_shows_friendly_error(self, runner, tmp_path):
+        result = runner.invoke(
+            main,
+            [
+                "export-script",
+                "--module-code",
+                "MOD",
+                "--module-version",
+                "1.0",
+                "--database",
+                "/not/a/sqlalchemy/url",
+                "--output",
+                str(tmp_path / "out.json"),
+            ],
+        )
+        assert result.exit_code == 1
+        assert "not a valid SQLAlchemy URL" in result.output
+        assert "/not/a/sqlalchemy/url" in result.output
+
+
+class TestExportScriptListModuleVersionsError:
+    def test_value_error_from_list_module_versions_is_reported(
+        self, runner, tmp_path
+    ):
+        out_dir = tmp_path / "out"
+        with patch(
+            "dpmcore.services.ast_generator.ASTGeneratorService"
+        ) as Svc:
+            Svc.return_value.list_module_versions.side_effect = ValueError(
+                "Unknown release code. Possible values: ['4.2', '4.3']"
+            )
+            result = runner.invoke(
+                main,
+                [
+                    "export-script",
+                    "--all-modules",
+                    "--release",
+                    "9.9",
+                    "--database",
+                    "sqlite:///:memory:",
+                    "--output",
+                    str(out_dir),
+                ],
+            )
+
+        assert result.exit_code == 1
+        assert "Unknown release code" in result.output
+        assert not out_dir.exists()
+
+
+class TestHelpExposesCommand:
+    def test_help_lists_export_script(self, runner):
+        result = runner.invoke(main, ["--help"])
+        assert result.exit_code == 0
+        assert "export-script" in result.output
+
+
+class TestExportScriptSweep:
+    def test_all_modules_all_versions_writes_one_file_per_target(
+        self, runner, tmp_path
+    ):
+        out_dir = tmp_path / "out"
+        with patch(
+            "dpmcore.services.ast_generator.ASTGeneratorService"
+        ) as Svc:
+            Svc.return_value.list_module_versions.return_value = [
+                ("MOD_A", "1.0"),
+                ("MOD_B", "2.0"),
+            ]
+            Svc.return_value.script_for_module.return_value = (
+                _success_result()
+            )
+            result = runner.invoke(
+                main,
+                [
+                    "export-script",
+                    "--all-modules",
+                    "--all-versions",
+                    "--database",
+                    "sqlite:///:memory:",
+                    "--output",
+                    str(out_dir),
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert (out_dir / "MOD_A-1.0.json").exists()
+        assert (out_dir / "MOD_B-2.0.json").exists()
+        assert "2 succeeded, 0 failed" in result.output
+
+    def test_failed_target_does_not_abort_sweep(self, runner, tmp_path):
+        out_dir = tmp_path / "out"
+        with patch(
+            "dpmcore.services.ast_generator.ASTGeneratorService"
+        ) as Svc:
+            Svc.return_value.list_module_versions.return_value = [
+                ("MOD_A", "1.0"),
+                ("MOD_B", "2.0"),
+            ]
+            Svc.return_value.script_for_module.side_effect = [
+                {
+                    "success": False,
+                    "enriched_ast": None,
+                    "error": "boom",
+                    "failed_operations": {},
+                },
+                _success_result(),
+            ]
+            result = runner.invoke(
+                main,
+                [
+                    "export-script",
+                    "--module-code",
+                    "FINREP_Con",
+                    "--all-versions",
+                    "--database",
+                    "sqlite:///:memory:",
+                    "--output",
+                    str(out_dir),
+                ],
+            )
+
+        assert result.exit_code == 1
+        assert not (out_dir / "MOD_A-1.0.json").exists()
+        assert (out_dir / "MOD_B-2.0.json").exists()
+        assert "1 succeeded, 1 failed" in result.output
+        assert "boom" in result.output
+
+    def test_no_targets_found_exits_1(self, runner, tmp_path):
+        out_dir = tmp_path / "out"
+        with patch(
+            "dpmcore.services.ast_generator.ASTGeneratorService"
+        ) as Svc:
+            Svc.return_value.list_module_versions.return_value = []
+            result = runner.invoke(
+                main,
+                [
+                    "export-script",
+                    "--all-modules",
+                    "--all-versions",
+                    "--database",
+                    "sqlite:///:memory:",
+                    "--output",
+                    str(out_dir),
+                ],
+            )
+        assert result.exit_code == 1
+
+    def test_sweep_defaults_output_to_current_directory(self, runner):
+        with runner.isolated_filesystem():
+            with patch(
+                "dpmcore.services.ast_generator.ASTGeneratorService"
+            ) as Svc:
+                Svc.return_value.list_module_versions.return_value = [
+                    ("MOD_A", "1.0"),
+                ]
+                Svc.return_value.script_for_module.return_value = (
+                    _success_result()
+                )
+                result = runner.invoke(
+                    main,
+                    [
+                        "export-script",
+                        "--all-modules",
+                        "--all-versions",
+                        "--database",
+                        "sqlite:///:memory:",
+                    ],
+                )
+            assert result.exit_code == 0, result.output
+            assert os.path.exists("MOD_A-1.0.json")
+
+    def test_output_must_be_a_directory_when_sweeping(self, runner, tmp_path):
+        existing_file = tmp_path / "not_a_dir.json"
+        existing_file.write_text("{}")
+        result = runner.invoke(
+            main,
+            [
+                "export-script",
+                "--all-modules",
+                "--all-versions",
+                "--database",
+                "sqlite:///:memory:",
+                "--output",
+                str(existing_file),
+            ],
+        )
+        assert result.exit_code != 0
+        assert "must be a directory" in result.output
+
+
+class TestExportScriptOutputDefaults:
+    def test_single_target_defaults_output_filename(self, runner):
+        with runner.isolated_filesystem():
+            with patch(
+                "dpmcore.services.ast_generator.ASTGeneratorService"
+            ) as Svc:
+                Svc.return_value.script_for_module.return_value = (
+                    _success_result()
+                )
+                result = runner.invoke(
+                    main,
+                    [
+                        "export-script",
+                        "--module-code",
+                        "FINREP_Con",
+                        "--module-version",
+                        "2.0.1",
+                        "--database",
+                        "sqlite:///:memory:",
+                    ],
+                )
+            assert result.exit_code == 0, result.output
+            assert os.path.exists("FINREP_Con-2.0.1.json")
+
+
+class TestExportScriptSweepValidation:
+    def test_module_code_and_all_modules_mutually_exclusive(
+        self, runner, tmp_path
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "export-script",
+                "--module-code",
+                "MOD",
+                "--all-modules",
+                "--all-versions",
+                "--database",
+                "sqlite:///:memory:",
+                "--output",
+                str(tmp_path / "out"),
+            ],
+        )
+        assert result.exit_code != 0
+        assert "exactly one of --module-code" in result.output
+
+    def test_module_version_and_all_versions_mutually_exclusive(
+        self, runner, tmp_path
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "export-script",
+                "--module-code",
+                "MOD",
+                "--module-version",
+                "1.0",
+                "--all-versions",
+                "--database",
+                "sqlite:///:memory:",
+                "--output",
+                str(tmp_path / "out"),
+            ],
+        )
+        assert result.exit_code != 0
+        assert "mutually exclusive" in result.output
+
+    def test_module_version_with_all_modules_rejected(self, runner, tmp_path):
+        result = runner.invoke(
+            main,
+            [
+                "export-script",
+                "--all-modules",
+                "--module-version",
+                "1.0",
+                "--database",
+                "sqlite:///:memory:",
+                "--output",
+                str(tmp_path / "out"),
+            ],
+        )
+        assert result.exit_code != 0
+        assert "requires --module-code" in result.output
+
+    def test_no_version_selector_rejected_with_module_code(
+        self, runner, tmp_path
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "export-script",
+                "--module-code",
+                "MOD",
+                "--database",
+                "sqlite:///:memory:",
+                "--output",
+                str(tmp_path / "out.json"),
+            ],
+        )
+        assert result.exit_code != 0
+        assert (
+            "Specify one of --module-version, --all-versions, or "
+            "--release" in result.output
+        )
+
+    def test_no_version_selector_rejected_with_all_modules(
+        self, runner, tmp_path
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "export-script",
+                "--all-modules",
+                "--database",
+                "sqlite:///:memory:",
+                "--output",
+                str(tmp_path / "out"),
+            ],
+        )
+        assert result.exit_code != 0
+        assert (
+            "Specify one of --module-version, --all-versions, or "
+            "--release" in result.output
+        )
+
+    def test_release_with_module_version_mutually_exclusive(
+        self, runner, tmp_path
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "export-script",
+                "--module-code",
+                "MOD",
+                "--module-version",
+                "1.0",
+                "--release",
+                "4.2",
+                "--database",
+                "sqlite:///:memory:",
+                "--output",
+                str(tmp_path / "out.json"),
+            ],
+        )
+        assert result.exit_code != 0
+        assert "mutually exclusive" in result.output
+
+    def test_release_with_all_versions_mutually_exclusive(
+        self, runner, tmp_path
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "export-script",
+                "--module-code",
+                "MOD",
+                "--all-versions",
+                "--release",
+                "4.2",
+                "--database",
+                "sqlite:///:memory:",
+                "--output",
+                str(tmp_path / "out"),
+            ],
+        )
+        assert result.exit_code != 0
+        assert "mutually exclusive" in result.output
+
+
+class TestExportScriptReleaseOnlyMode:
+    """``--release`` alone (no ``--module-version``/``--all-versions``)
+    resolves each targeted module to its version active at that release.
+    """
+
+    def test_module_code_with_release_only_resolves_single_target(
+        self, runner, tmp_path
+    ):
+        out_dir = tmp_path / "out"
+        with patch(
+            "dpmcore.services.ast_generator.ASTGeneratorService"
+        ) as Svc:
+            Svc.return_value.list_module_versions.return_value = [
+                ("FINREP_Con", "2.0.1"),
+            ]
+            Svc.return_value.script_for_module.return_value = (
+                _success_result()
+            )
+            result = runner.invoke(
+                main,
+                [
+                    "export-script",
+                    "--module-code",
+                    "FINREP_Con",
+                    "--release",
+                    "4.2",
+                    "--database",
+                    "sqlite:///:memory:",
+                    "--output",
+                    str(out_dir),
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert (out_dir / "FINREP_Con-2.0.1.json").exists()
+        list_kwargs = Svc.return_value.list_module_versions.call_args.kwargs
+        assert list_kwargs["module_code"] == "FINREP_Con"
+        assert list_kwargs["release"] == "4.2"
+
+    def test_all_modules_with_release_only_sweeps_every_module(
+        self, runner, tmp_path
+    ):
+        out_dir = tmp_path / "out"
+        with patch(
+            "dpmcore.services.ast_generator.ASTGeneratorService"
+        ) as Svc:
+            Svc.return_value.list_module_versions.return_value = [
+                ("MOD_A", "1.0"),
+                ("MOD_B", "2.0"),
+            ]
+            Svc.return_value.script_for_module.return_value = (
+                _success_result()
+            )
+            result = runner.invoke(
+                main,
+                [
+                    "export-script",
+                    "--all-modules",
+                    "--release",
+                    "4.2",
+                    "--database",
+                    "sqlite:///:memory:",
+                    "--output",
+                    str(out_dir),
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert (out_dir / "MOD_A-1.0.json").exists()
+        assert (out_dir / "MOD_B-2.0.json").exists()
+        list_kwargs = Svc.return_value.list_module_versions.call_args.kwargs
+        assert list_kwargs["module_code"] is None
+        assert list_kwargs["release"] == "4.2"
+
+    def test_release_only_passes_release_through_to_script_for_module(
+        self, runner, tmp_path
+    ):
+        out_dir = tmp_path / "out"
+        with patch(
+            "dpmcore.services.ast_generator.ASTGeneratorService"
+        ) as Svc:
+            Svc.return_value.list_module_versions.return_value = [
+                ("FINREP_Con", "2.0.1"),
+            ]
+            Svc.return_value.script_for_module.return_value = (
+                _success_result()
+            )
+            runner.invoke(
+                main,
+                [
+                    "export-script",
+                    "--module-code",
+                    "FINREP_Con",
+                    "--release",
+                    "4.2",
+                    "--database",
+                    "sqlite:///:memory:",
+                    "--output",
+                    str(out_dir),
+                ],
+            )
+
+        kwargs = Svc.return_value.script_for_module.call_args.kwargs
+        assert kwargs["module_code"] == "FINREP_Con"
+        assert kwargs["module_version"] == "2.0.1"
+        assert kwargs["release"] == "4.2"
+
+    def test_no_targets_at_release_exits_1(self, runner, tmp_path):
+        out_dir = tmp_path / "out"
+        with patch(
+            "dpmcore.services.ast_generator.ASTGeneratorService"
+        ) as Svc:
+            Svc.return_value.list_module_versions.return_value = []
+            result = runner.invoke(
+                main,
+                [
+                    "export-script",
+                    "--module-code",
+                    "FINREP_Con",
+                    "--release",
+                    "4.2",
+                    "--database",
+                    "sqlite:///:memory:",
+                    "--output",
+                    str(out_dir),
+                ],
+            )
+        assert result.exit_code == 1
+        assert "No active module versions matched" in result.output


### PR DESCRIPTION
…ripts

Adds ASTGeneratorService.script_for_module/list_module_versions plus the dpmcore export-script CLI command, which discovers active validations, preconditions and severities directly from the database instead of requiring a caller-supplied --expressions file. Supports five flag combinations mirroring a familiar module/version/release selection model: --module-code + --module-version, --module-code + --all-versions, --module-code + --release, --all-modules + --all-versions, and --all-modules + --release, all pairwise mutually exclusive per version selector.

## Summary

<!-- Short description of the change and why it's needed. -->

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [x] Documentation updated (if applicable)

## Impact / Risk

- Breaking changes? (public API / CLI / REST endpoints / Django models)
- Database schema or migration concerns?
- Notes for release/changelog?

## Notes

<!-- Follow-ups, TODOs, or anything reviewers should know. -->
