### PR TITLE
Feat/layout export mark key columns

### DIFF
--- a/src/dpmcore/services/layout_exporter/excel_writer.py
+++ b/src/dpmcore/services/layout_exporter/excel_writer.py
@@ -540,6 +540,7 @@ class ExcelLayoutWriter:
                 data_start_col,
                 col_positions,
                 row_label_col,
+                row_code_col,
                 cfg,
                 sheet_id,
                 sheet_code,
@@ -667,6 +668,7 @@ class ExcelLayoutWriter:
         data_start_col: int,
         col_positions: dict[int, int],
         row_label_col: int,
+        row_code_col: int,
         cfg: ExportConfig,
         sheet_id: Optional[int],
         sheet_code: str,
@@ -683,6 +685,22 @@ class ExcelLayoutWriter:
             horizontal="left", vertical="center"
         )
         open_rows_cell.font = _HEADER_FONT
+
+        # Open rows have no code, so the row code column would sit there
+        # empty: merge it into the label instead.
+        if row_code_col:
+            ws.merge_cells(
+                start_row=data_start_row,
+                start_column=row_label_col,
+                end_row=data_start_row,
+                end_column=row_code_col,
+            )
+            # Merging resets the covered cell's style, so fill it after
+            # the merge: Excel paints the range from the top-left cell,
+            # but the trailing border has to sit on the last one.
+            code_cell = ws.cell(row=data_start_row, column=row_code_col)
+            code_cell.fill = _GREY_FILL
+            code_cell.border = _BORDER_ALL
 
         for ch in layout.columns:
             if ch.is_abstract:

--- a/src/dpmcore/services/layout_exporter/excel_writer.py
+++ b/src/dpmcore/services/layout_exporter/excel_writer.py
@@ -43,6 +43,11 @@ _VOID_FILL = PatternFill(
 _IDENTITY_FILL = PatternFill(
     start_color="FFFF00", end_color="FFFF00", fill_type="solid"
 )
+# Key cells of open tables: the variables that identify a reported row
+# rather than carrying a reported figure.
+_KEY_FILL = PatternFill(
+    start_color="C4D79B", end_color="C4D79B", fill_type="solid"
+)
 # Excel worksheet titles are limited to 31 characters.
 _MAX_SHEET_TITLE = 31
 # Cap the identity list in a tooltip; a few datapoints are reported in
@@ -690,6 +695,7 @@ class ExcelLayoutWriter:
             cell.border = _BORDER_ALL
 
             if ch.is_key and ch.key_variable_id:
+                cell.fill = _KEY_FILL
                 if ch.key_data_type_code == "e":
                     type_symbol = f"[{ch.key_property_name}]"
                 else:

--- a/tests/integration/services/layout_exporter/test_excel_writer.py
+++ b/tests/integration/services/layout_exporter/test_excel_writer.py
@@ -380,6 +380,26 @@ def test_write_open_row_table_with_key_columns(memory_session, tmp_path):
                 found = True
     assert found
 
+    # The key variable's data cell is filled green; the reported figure
+    # next to it keeps the default (unfilled) background.
+    fills = {
+        cell.value: cell.fill.start_color.rgb
+        for row in ws.iter_rows()
+        for cell in row
+        if isinstance(cell.value, str)
+        and cell.value.startswith(("400\n", "401\n"))
+    }
+    assert fills["400\n[Currency]\n<Currency>"].endswith("C4D79B")
+    assert not fills["401\n€£$\npositive"].endswith("C4D79B")
+    # The headers themselves are untouched.
+    header_fills = {
+        cell.value: cell.fill.start_color.rgb
+        for row in ws.iter_rows()
+        for cell in row
+        if cell.value in ("Currency", "Amount")
+    }
+    assert all(f.endswith("D8D8D8") for f in header_fills.values())
+
 
 def test_write_table_with_sheets_and_subcategory(memory_session, tmp_path):
     seed_releases(memory_session)

--- a/tests/integration/services/layout_exporter/test_excel_writer.py
+++ b/tests/integration/services/layout_exporter/test_excel_writer.py
@@ -391,6 +391,16 @@ def test_write_open_row_table_with_key_columns(memory_session, tmp_path):
     }
     assert fills["400\n[Currency]\n<Currency>"].endswith("C4D79B")
     assert not fills["401\n€£$\npositive"].endswith("C4D79B")
+    # Open rows have no code, so the label spans the row code column.
+    open_rows_cell = next(
+        cell
+        for row in ws.iter_rows()
+        for cell in row
+        if cell.value == "Open Rows"
+    )
+    merged = {str(r) for r in ws.merged_cells.ranges}
+    assert f"{open_rows_cell.coordinate}:C{open_rows_cell.row}" in merged
+
     # The headers themselves are untouched.
     header_fills = {
         cell.value: cell.fill.start_color.rgb


### PR DESCRIPTION
## Summary

In the export to Excel is not easy to find what columns are key.

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [x] Documentation updated (if applicable)

## Impact / Risk

- Breaking changes? (public API / CLI / REST endpoints / Django models) No
- Database schema or migration concerns? No
- Notes for release/changelog? No

## Notes

Minor change
