### PR TITLE
fix: serialize year/month/day on DateConstructorOp

### DIFF
--- a/src/dpmcore/dpm_xl/utils/serialization.py
+++ b/src/dpmcore/dpm_xl/utils/serialization.py
@@ -713,6 +713,21 @@ class ASTToJSONVisitor(NodeVisitor):
             "reference_period": node.component,
         }
 
+    def visit_DateConstructorOp(self, node: Any) -> NodeDict:
+        """Visit DateConstructorOp nodes.
+
+        ``year``/``month``/``day`` are full Nodes (§10.3.5 admits a
+        Recordset in any of the three positions), so each is serialized
+        recursively rather than copied as a raw value.
+        """
+        return {
+            "class_name": "DateConstructorOp",
+            "op": node.op,
+            "year": self.visit(node.year),
+            "month": self.visit(node.month),
+            "day": self.visit(node.day),
+        }
+
     def visit_AnnualiseOp(self, node: Any) -> NodeDict:
         """Visit AnnualiseOp nodes."""
         return {

--- a/tests/unit/ast/test_date_constructor_expression.py
+++ b/tests/unit/ast/test_date_constructor_expression.py
@@ -13,6 +13,7 @@ from dpmcore.dpm_xl.symbols import (
     Structure,
 )
 from dpmcore.dpm_xl.types.scalar import Date, Integer, Mixed, Number, String
+from dpmcore.dpm_xl.utils.serialization import ASTToJSONVisitor
 from dpmcore.dpm_xl.utils.tokens import STANDARD
 from dpmcore.errors import SemanticError
 from dpmcore.services.syntax import SyntaxService
@@ -67,6 +68,20 @@ def test_constructor_tojson_serializable():
     assert "day" in result
 
 
+def test_serializer_produces_date_constructor_dict():
+    """The live serialization path (``serialize_ast`` / ``ASTToJSONVisitor``),
+    not just the unused ``toJSON()`` method, must carry ``year``/``month``/
+    ``day`` — this is what a Producer actually emits.
+    """
+    ast = SyntaxService().parse("date(2025, 12, 31)")
+    result = ASTToJSONVisitor().visit(ast)
+    node = result["children"][0]
+    assert node["class_name"] == "DateConstructorOp"
+    assert "year" in node
+    assert "month" in node
+    assert "day" in node
+
+
 def test_constructor_node_op_is_date():
     """``op`` is set at construction (like ``UnaryOp``) so raw-AST
     consumers — e.g. ``_resolve_root_operator_id`` — see the operator symbol
@@ -76,7 +91,8 @@ def test_constructor_node_op_is_date():
     node = ast.children[0]
     assert isinstance(node, DateConstructorOp)
     assert node.op == "date"
-    assert node.toJSON()["op"] == "date"
+    result = ASTToJSONVisitor().visit(ast)
+    assert result["children"][0]["op"] == "date"
 
 
 # Operator validation: any combination of Scalar and Recordset operands is allowed


### PR DESCRIPTION
Closes #350 

## Summary

`date(year, month, day)` silently lost `year`/`month`/`day` when serialized through the real path (`serialize_ast` / `ASTToJSONVisitor`), because `DateConstructorOp` had no dedicated `visit_DateConstructorOp` and fell back to the generic `generic_visit`, which doesn't cover those fields. The only existing test missed it because it called `node.toJSON()`.

This PR adds the missing `visit_DateConstructorOp` (serializing `year`/`month`/`day` the same way `visit_AnnualiseOp`/`visit_SubstrOp` do) plus a test against the real path that fails without the fix.

## Checklist

- [X] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [ ] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [ ] Documentation updated (if applicable)

## Impact / Risk

- Breaking changes? (public API / CLI / REST endpoints / Django models)
- Database schema or migration concerns?
- Notes for release/changelog?

## Notes

<!-- Follow-ups, TODOs, or anything reviewers should know. -->
