### PR TITLE
fix: apply the ghost-module-version fallback to table-version resolution

### DIFF
--- a/src/dpmcore/dpm_xl/model_queries.py
+++ b/src/dpmcore/dpm_xl/model_queries.py
@@ -1286,6 +1286,17 @@ def _ghost_module_ids_for_table_vids(
         ``table_vids`` (the table version is then genuinely live at the
         release and needs no substitution). Also ``None`` when no module
         version hosts them at all.
+
+        The decision is all-or-nothing over ``table_vids``: a live host
+        for *any* of them suppresses substitution for the whole set.
+        That only matters when one table code has several versions open
+        at once, which happens at the perpetual release alone (see
+        :meth:`ViewDatapointsQuery._resolve_table_version_scope`), and
+        deciding per version would also have to merge the live module
+        versions into ``_TableVersionScope.fallback_module_vids`` --
+        :meth:`ViewDatapointsQuery._filter_module_versions` replaces the
+        release filter with that list, so a live version left out of it
+        would lose its rows.
     """
     rows = (
         filter_by_release(
@@ -1331,6 +1342,14 @@ def _apply_table_ghost_fallback(
     resolution report the same module version. Without it the cells --
     hence their variables, properties and domains -- come from a version
     that has no reporting period of its own.
+
+    Kept separate from that helper rather than calling it: the caller
+    needs a scope (the effective ``table_vids`` *and* the module
+    versions the ``ModuleVersion`` join must be narrowed to), not the
+    operand rows the helper returns; a ghost with no fallback is kept
+    here instead of dropped, since dropping it would leave ``table``
+    unresolvable rather than merely unscoped; and the decision is made
+    once per table code rather than per module.
 
     Substitution only: when there is nothing to fall back to (no prior
     non-ghost version, or one that does not contain ``table``) the ghost's

--- a/src/dpmcore/dpm_xl/model_queries.py
+++ b/src/dpmcore/dpm_xl/model_queries.py
@@ -15,6 +15,7 @@ from typing import (
     Callable,
     Collection,
     Hashable,
+    NamedTuple,
     Sequence,
 )
 
@@ -1238,6 +1239,149 @@ def _resolve_with_ghost_fallback(
     return pd.concat([non_ghost, fallback_rows], ignore_index=True)
 
 
+class _TableVersionScope(NamedTuple):
+    """The table version(s) of one table code effective at a release.
+
+    Attributes:
+        table_vids: ``TableVersion.table_vid`` values to read cells from.
+        fallback_module_vids: The module versions hosting ``table_vids``
+            when the ghost fallback fired, ``None`` when the plain release
+            window applies. A fallback version's release window ends
+            *before* the target release, so callers must narrow the
+            ``ModuleVersion`` join to these VIDs rather than applying
+            :func:`filter_by_release`, which would drop every row.
+    """
+
+    table_vids: list[int]
+    fallback_module_vids: list[int] | None = None
+
+
+def _is_collapsed_window(from_date: Any, to_date: Any) -> bool:
+    """Whether one version's reference-date window is collapsed (ghost).
+
+    Row-level mirror of :func:`_collapsed_mask`: collapsed only when both
+    reference dates are present and equal; an open-ended window is a
+    genuine range.
+    """
+    return (
+        from_date is not None and to_date is not None and from_date == to_date
+    )
+
+
+def _ghost_module_ids_for_table_vids(
+    session: "Session",
+    table_vids: Sequence[int],
+    release_id: int,
+) -> set[int] | None:
+    """Modules whose ghosts are the only versions hosting ``table_vids``.
+
+    Args:
+        session: SQLAlchemy session.
+        table_vids: Table versions open at ``release_id``.
+        release_id: Target release id.
+
+    Returns:
+        The module ids of those ghosts, or ``None`` as soon as a
+        non-ghost module version covering ``release_id`` hosts one of
+        ``table_vids`` (the table version is then genuinely live at the
+        release and needs no substitution). Also ``None`` when no module
+        version hosts them at all.
+    """
+    rows = (
+        filter_by_release(
+            session.query(
+                ModuleVersion.module_id,
+                ModuleVersion.from_reference_date,
+                ModuleVersion.to_reference_date,
+            )
+            .join(
+                ModuleVersionComposition,
+                ModuleVersion.module_vid
+                == ModuleVersionComposition.module_vid,
+            )
+            .filter(ModuleVersionComposition.table_vid.in_(list(table_vids))),
+            start_col=ModuleVersion.start_release_id,
+            end_col=ModuleVersion.end_release_id,
+            release_id=release_id,
+        )
+        .distinct()
+        .all()
+    )
+    ghost_module_ids: set[int] = set()
+    for module_id, from_date, to_date in rows:
+        if not _is_collapsed_window(from_date, to_date):
+            return None
+        if module_id is not None:
+            ghost_module_ids.add(module_id)
+    return ghost_module_ids or None
+
+
+def _apply_table_ghost_fallback(
+    session: "Session",
+    table: str,
+    table_vids: list[int],
+    release_id: int,
+) -> _TableVersionScope:
+    """Substitute a ghost-only table version with its fallback's (#356).
+
+    The table-version mirror of :func:`_resolve_with_ghost_fallback`: when
+    every module version hosting ``table_vids`` at ``release_id`` is a
+    ghost, the table's cells are read from the latest prior non-ghost
+    version of the same module instead, so datapoint resolution and module
+    resolution report the same module version. Without it the cells --
+    hence their variables, properties and domains -- come from a version
+    that has no reporting period of its own.
+
+    Substitution only: when there is nothing to fall back to (no prior
+    non-ghost version, or one that does not contain ``table``) the ghost's
+    table version is kept, since dropping it would make the table
+    unresolvable at that release.
+
+    Args:
+        session: SQLAlchemy session.
+        table: Table version code being resolved.
+        table_vids: The versions of ``table`` open at ``release_id``.
+        release_id: Target release id.
+
+    Returns:
+        The effective scope, ghost substituted where a fallback exists.
+    """
+    ghost_module_ids = _ghost_module_ids_for_table_vids(
+        session, table_vids, release_id
+    )
+    if ghost_module_ids is None:
+        return _TableVersionScope(table_vids)
+    fallback_vids = _latest_prior_non_collapsed_vids(
+        session, ghost_module_ids, release_id
+    )
+    if not fallback_vids:
+        return _TableVersionScope(table_vids)
+    rows = (
+        session.query(
+            ModuleVersionComposition.module_vid,
+            ModuleVersionComposition.table_vid,
+        )
+        .join(
+            TableVersion,
+            TableVersion.table_vid == ModuleVersionComposition.table_vid,
+        )
+        .filter(
+            ModuleVersionComposition.module_vid.in_(
+                list(fallback_vids.values())
+            ),
+            TableVersion.code == table,
+        )
+        .distinct()
+        .all()
+    )
+    if not rows:
+        return _TableVersionScope(table_vids)
+    return _TableVersionScope(
+        sorted({table_vid for _module_vid, table_vid in rows}),
+        sorted({module_vid for module_vid, _table_vid in rows}),
+    )
+
+
 class ModuleVersionQuery:
     """Query helpers around ModuleVersion."""
 
@@ -1752,25 +1896,32 @@ class ViewDatapointsQuery:
         }
         return query, aliases
 
-    @staticmethod
-    def _resolve_current_table_vids(
-        session: "Session", table: str, release_id: int | None
-    ) -> list[int]:
-        """Resolve the ``TableVersion.table_vid`` value(s) of ``table`` open at ``release_id``.
+    @classmethod
+    def _resolve_table_version_scope(
+        cls, session: "Session", table: str, release_id: int | None
+    ) -> _TableVersionScope:
+        """Resolve the table version(s) of ``table`` effective at ``release_id``.
 
         At the perpetual release, an adopted version and one just started
         there can both compare as "open now". When both are present, only
         the adopted one(s) are kept.
 
+        A version open at ``release_id`` only through a *ghost* module
+        version is then substituted with the one the ghost fallback
+        resolves to (see :func:`_apply_table_ghost_fallback`), so cells
+        resolve through the same module version module resolution reports.
+
         Args:
             session: SQLAlchemy session.
             table: Table version code.
             release_id: Release filter; ``None`` resolves to whichever
-                version(s) are currently open.
+                version(s) are currently open, and applies no ghost
+                fallback -- without a target release there is no "prior"
+                version to fall back to.
 
         Returns:
-            The matching ``table_vid`` values (empty when ``table`` has none
-            open at ``release_id``).
+            The effective scope; its ``table_vids`` are empty when
+            ``table`` has no version open at ``release_id``.
         """
         query = session.query(
             TableVersion.table_vid, TableVersion.start_release_id
@@ -1784,15 +1935,56 @@ class ViewDatapointsQuery:
         )
         rows = query.all()
         if len(rows) <= 1:
-            return [row.table_vid for row in rows]
-        sort_orders = load_release_sort_orders(session)
-        perpetual = compute_sort_order(None, None)
-        adopted = [
-            row.table_vid
-            for row in rows
-            if sort_orders.get(row.start_release_id, perpetual) < perpetual
-        ]
-        return adopted or [row.table_vid for row in rows]
+            table_vids = [row.table_vid for row in rows]
+        else:
+            sort_orders = load_release_sort_orders(session)
+            perpetual = compute_sort_order(None, None)
+            adopted = [
+                row.table_vid
+                for row in rows
+                if sort_orders.get(row.start_release_id, perpetual) < perpetual
+            ]
+            table_vids = adopted or [row.table_vid for row in rows]
+        if not table_vids or release_id is None:
+            return _TableVersionScope(table_vids)
+        return _apply_table_ghost_fallback(
+            session, table, table_vids, release_id
+        )
+
+    @staticmethod
+    def _filter_module_versions(
+        query: "Query[Any]",
+        scope: _TableVersionScope,
+        release_id: int | None,
+    ) -> "Query[Any]":
+        """Narrow the ``ModuleVersion`` join to the versions ``scope`` resolved.
+
+        Normally that is the plain release window. In the ghost-fallback
+        case the effective versions are the fallback's, whose release
+        window ends before ``release_id``, so filtering by release would
+        drop every row; the join is narrowed to their VIDs instead --
+        keeping the module-membership scoping the release filter provides.
+
+        Args:
+            query: Query joining ``ModuleVersion``.
+            scope: Scope from :meth:`_resolve_table_version_scope`.
+            release_id: Release filter; ``None`` leaves ``query`` as is.
+
+        Returns:
+            The narrowed query.
+        """
+        if scope.fallback_module_vids is not None:
+            return query.filter(
+                ModuleVersion.module_vid.in_(scope.fallback_module_vids)
+            )
+        if release_id is None:
+            return query
+        return filter_by_release(
+            query,
+            start_col=ModuleVersion.start_release_id,
+            end_col=ModuleVersion.end_release_id,
+            release_id=release_id,
+        )
 
     @classmethod
     def get_axis_orders(
@@ -1841,19 +2033,10 @@ class ViewDatapointsQuery:
             aliases["tvh_sheet"].order.label("sheet_order"),
         ).distinct()
 
+        scope = cls._resolve_table_version_scope(session, table, release_id)
         query = query.filter(TableVersion.code == table)
-        query = query.filter(
-            TableVersion.table_vid.in_(
-                cls._resolve_current_table_vids(session, table, release_id)
-            )
-        )
-        if release_id is not None:
-            query = filter_by_release(
-                query,
-                start_col=ModuleVersion.start_release_id,
-                end_col=ModuleVersion.end_release_id,
-                release_id=release_id,
-            )
+        query = query.filter(TableVersion.table_vid.in_(scope.table_vids))
+        query = cls._filter_module_versions(query, scope, release_id)
 
         data = read_sql_with_connection(query.statement, session)
 
@@ -1953,12 +2136,9 @@ class ViewDatapointsQuery:
             ModuleVersion.end_release_id.label("end_release_id"),
         )
 
+        scope = cls._resolve_table_version_scope(session, table, release_id)
         query = query.filter(TableVersion.code == table)
-        query = query.filter(
-            TableVersion.table_vid.in_(
-                cls._resolve_current_table_vids(session, table, release_id)
-            )
-        )
+        query = query.filter(TableVersion.table_vid.in_(scope.table_vids))
 
         # Range endpoints are resolved against the stored display order, not
         # the code text; ``get_axis_orders`` supplies the per-axis map (or
@@ -1986,13 +2166,7 @@ class ViewDatapointsQuery:
                 query, aliases["hvs"].code, sheets, axis_orders["sheets"]
             )
 
-        if release_id is not None:
-            query = filter_by_release(
-                query,
-                start_col=ModuleVersion.start_release_id,
-                end_col=ModuleVersion.end_release_id,
-                release_id=release_id,
-            )
+        query = cls._filter_module_versions(query, scope, release_id)
 
         data = read_sql_with_connection(query.statement, session)
 
@@ -2070,17 +2244,11 @@ class ViewDatapointsQuery:
                     query = query.filter(clause)
 
         if release_id:
-            query = filter_by_release(
-                query,
-                start_col=ModuleVersion.start_release_id,
-                end_col=ModuleVersion.end_release_id,
-                release_id=release_id,
+            scope = cls._resolve_table_version_scope(
+                session, table, release_id
             )
-            query = query.filter(
-                TableVersion.table_vid.in_(
-                    cls._resolve_current_table_vids(session, table, release_id)
-                )
-            )
+            query = cls._filter_module_versions(query, scope, release_id)
+            query = query.filter(TableVersion.table_vid.in_(scope.table_vids))
 
         return read_sql_with_connection(query.statement, session)
 

--- a/src/dpmcore/services/hierarchy.py
+++ b/src/dpmcore/services/hierarchy.py
@@ -649,6 +649,35 @@ class HierarchyService:
         match (by date-based sort order of ``start_release_id``)
         when several rows survive the filter.
         """
+        rows = self._table_version_candidates(table_code, release_id, date)
+        if not rows:
+            return None
+        picked = _most_recent_by_release(
+            self.session, rows, lambda row: row[1]
+        )
+        if picked is None:
+            return None
+        return picked[0]
+
+    def _table_version_candidates(
+        self,
+        table_code: str,
+        release_id: Optional[int],
+        date: Optional[str],
+    ) -> List[Any]:
+        """``(TableVersion, module-version start release)`` candidates.
+
+        On the release axis a table version reachable only through a
+        *ghost* module version (collapsed reference-date window) is
+        substituted with the prior non-ghost version's, so a release
+        answers with the same table version its reporting dates do
+        (issue #356). ``ModuleVersionQuery.get_from_table_codes`` is
+        where that rule lives.
+
+        It leaves out a module whose ghost has no prior non-ghost
+        version to fall back to; the raw join stays as the fallback so
+        the table still resolves there, from the ghost.
+        """
         q = (
             self.session.query(TableVersion, ModuleVersion.start_release_id)
             .join(
@@ -662,13 +691,34 @@ class HierarchyService:
             )
             .filter(TableVersion.code == table_code)
         )
-        q = _apply_module_filter(q, release_id, date)
-        rows = q.all()
-        if not rows:
-            return None
-        picked = _most_recent_by_release(
-            self.session, rows, lambda row: row[1]
+        rows: List[Any] = _apply_module_filter(q, release_id, date).all()
+        if release_id is None or not rows:
+            return rows
+
+        from dpmcore.dpm_xl.model_queries import ModuleVersionQuery
+
+        resolved = ModuleVersionQuery.get_from_table_codes(
+            self.session, [table_code], release_id
         )
-        if picked is None:
-            return None
-        return picked[0]
+        if resolved.empty:
+            return rows
+        # One candidate per resolved (table version, module version), as
+        # the raw join produces, so the most-recent tie-break is unchanged.
+        pairs = list(
+            zip(
+                resolved["variable_vid"].tolist(),
+                resolved["StartReleaseID"].tolist(),
+                strict=True,
+            )
+        )
+        table_version_by_vid: Dict[int, TableVersion] = {
+            table_version.table_vid: table_version
+            for table_version in self.session.query(TableVersion).filter(
+                TableVersion.table_vid.in_({vid for vid, _start in pairs})
+            )
+        }
+        return [
+            (table_version_by_vid[vid], start)
+            for vid, start in pairs
+            if vid in table_version_by_vid
+        ]

--- a/tests/integration/queries/test_table_data_perpetual_release.py
+++ b/tests/integration/queries/test_table_data_perpetual_release.py
@@ -273,7 +273,7 @@ def test_none_release_id_also_prefers_the_adopted_version(memory_session):
     assert data.loc[data["row_code"] == "0010", "variable_id"].iloc[0] == 50
 
 
-def test_resolve_current_table_vids_falls_back_when_nothing_is_adopted(
+def test_table_version_scope_falls_back_when_nothing_is_adopted(
     memory_session,
 ):
     """A table that only exists as drafts still resolves to something."""
@@ -312,8 +312,8 @@ def test_resolve_current_table_vids_falls_back_when_nothing_is_adopted(
     )
     session.commit()
 
-    table_vids = ViewDatapointsQuery._resolve_current_table_vids(
+    table_vids = ViewDatapointsQuery._resolve_table_version_scope(
         session, "T_ALLDRAFT", 9001
-    )
+    ).table_vids
 
     assert sorted(table_vids) == [201, 202]

--- a/tests/integration/queries/test_table_version_ghost_fallback.py
+++ b/tests/integration/queries/test_table_version_ghost_fallback.py
@@ -1,0 +1,383 @@
+"""Ghost-module-version fallback on the table-version axis (issue #356).
+
+The fallback added for issues #182/#151/#221 covered *module* resolution
+only: a table version open at a release solely through a ghost module
+version (collapsed reference-date window) was still the one datapoints
+were read from, so the same release answered "FINREP9 3.1.0" for the
+module and "3.2.0's table version" for the cells -- and reported the
+variables, properties and domains the ghost introduced.
+
+These tests pin the substitution rule and its three limits: a live
+module version is never overridden, and a ghost with nothing to fall back
+to (no prior non-ghost version, or one that does not contain the table)
+keeps its own table version rather than making the table disappear.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+from dpmcore.dpm_xl.model_queries import (
+    ModuleVersionQuery,
+    ViewDatapointsQuery,
+)
+from dpmcore.dpm_xl.utils.filters import resolve_release_id
+from dpmcore.orm.infrastructure import Release
+from dpmcore.orm.packaging import (
+    Framework,
+    Module,
+    ModuleVersion,
+    ModuleVersionComposition,
+)
+from dpmcore.orm.rendering import (
+    Cell,
+    Header,
+    HeaderVersion,
+    Table,
+    TableVersion,
+    TableVersionCell,
+)
+from dpmcore.orm.variables import VariableVersion
+from dpmcore.services.semantic import SemanticService
+
+# Releases: the ghost's window is [OLD, NEW); the target sits inside it.
+OLD = 7001
+GHOST_ERA = 7002
+NEW = 7003
+
+
+def _seed_releases(session):
+    session.add_all(
+        [
+            Release(release_id=OLD, code="7.0", date=date(2024, 1, 1)),
+            Release(release_id=GHOST_ERA, code="7.1", date=date(2025, 1, 1)),
+            Release(release_id=NEW, code="7.2", date=date(2026, 1, 1)),
+        ]
+    )
+
+
+def _seed_module_versions(session, *, ghost_only=False):
+    """A module with a live version, then a ghost covering ``GHOST_ERA``.
+
+    Args:
+        session: SQLAlchemy session.
+        ghost_only: When True the live prior version is omitted, so the
+            ghost is the module's only version.
+    """
+    session.add(Framework(framework_id=1, code="FW"))
+    session.add(Module(module_id=1, framework_id=1))
+    if not ghost_only:
+        session.add(
+            ModuleVersion(
+                module_vid=10,
+                module_id=1,
+                code="M",
+                version_number="1.0.0",
+                from_reference_date=date(2023, 12, 31),
+                to_reference_date=date(2027, 12, 31),
+                start_release_id=OLD,
+                end_release_id=GHOST_ERA,
+            )
+        )
+    # Collapsed reference-date window: a ghost.
+    session.add(
+        ModuleVersion(
+            module_vid=11,
+            module_id=1,
+            code="M",
+            version_number="1.1.0",
+            from_reference_date=date(2024, 12, 31),
+            to_reference_date=date(2024, 12, 31),
+            start_release_id=GHOST_ERA,
+            end_release_id=NEW,
+        )
+    )
+
+
+def _seed_table_version(session, *, table_vid, module_vid, start, end, code):
+    """One table version, its single cell and the variable behind it."""
+    session.add(
+        TableVersion(
+            table_vid=table_vid,
+            table_id=1,
+            code=code,
+            start_release_id=start,
+            end_release_id=end,
+        )
+    )
+    session.add(
+        ModuleVersionComposition(
+            module_vid=module_vid, table_vid=table_vid, table_id=1
+        )
+    )
+    # The variable id is what a caller reads back: distinct per version, so
+    # the assertions say which table version answered.
+    session.add(
+        VariableVersion(
+            variable_vid=table_vid * 10,
+            variable_id=table_vid,
+            code=f"V{table_vid}",
+        )
+    )
+    session.add(
+        TableVersionCell(
+            table_vid=table_vid,
+            cell_id=900,
+            cell_code=f"{{{code}, r0010}}",
+            variable_vid=table_vid * 10,
+            is_nullable=True,
+            is_void=False,
+            is_excluded=False,
+        )
+    )
+
+
+def _seed_shared_rendering(session):
+    """The row header and cell both table versions map."""
+    session.add(Table(table_id=1))
+    session.add(Header(header_id=1, direction="Y", is_key=True))
+    session.add(HeaderVersion(header_vid=10, header_id=1, code="0010"))
+    session.add(Cell(cell_id=900, table_id=1, row_id=1))
+
+
+def _seed_ghost_supersedes_live(session, code):
+    """Live version at ``OLD``, ghost carrying its own table version."""
+    _seed_releases(session)
+    _seed_module_versions(session)
+    _seed_shared_rendering(session)
+    _seed_table_version(
+        session,
+        table_vid=101,
+        module_vid=10,
+        start=OLD,
+        end=GHOST_ERA,
+        code=code,
+    )
+    _seed_table_version(
+        session,
+        table_vid=102,
+        module_vid=11,
+        start=GHOST_ERA,
+        end=NEW,
+        code=code,
+    )
+    session.commit()
+
+
+def test_cells_come_from_the_prior_non_ghost_version(memory_session):
+    """The ghost's table version is substituted with the live one's."""
+    session = memory_session
+    _seed_ghost_supersedes_live(session, "T_GHOST_SUB")
+
+    data = ViewDatapointsQuery.get_table_data(
+        session, "T_GHOST_SUB", release_id=GHOST_ERA
+    )
+
+    assert data["table_vid"].unique().tolist() == [101]
+    assert data["variable_id"].tolist() == [101]
+
+
+def test_datapoints_agree_with_module_resolution(memory_session):
+    """The module version behind the cells is the one modules resolve to."""
+    session = memory_session
+    _seed_ghost_supersedes_live(session, "T_GHOST_AGREE")
+
+    scope = ViewDatapointsQuery._resolve_table_version_scope(
+        session, "T_GHOST_AGREE", GHOST_ERA
+    )
+    modules = ModuleVersionQuery.get_from_table_codes(
+        session, ["T_GHOST_AGREE"], GHOST_ERA
+    )
+
+    assert scope.table_vids == [101]
+    # The fallback's release window ends before GHOST_ERA, so the join has
+    # to be narrowed to its VID instead of filtered by release.
+    assert scope.fallback_module_vids == [10]
+    assert sorted(set(modules["ModuleVID"])) == [10]
+
+
+def test_filtered_datapoints_use_the_same_fallback(memory_session):
+    """``get_filtered_datapoints`` resolves through the same scope."""
+    session = memory_session
+    _seed_ghost_supersedes_live(session, "T_GHOST_FILTERED")
+
+    data = ViewDatapointsQuery.get_filtered_datapoints(
+        session,
+        "T_GHOST_FILTERED",
+        {"rows": ["0010"], "cols": None, "sheets": None},
+        release_id=GHOST_ERA,
+    )
+
+    assert data["table_vid"].unique().tolist() == [101]
+    assert data["variable_id"].tolist() == [101]
+
+
+def test_a_live_module_version_is_never_substituted(memory_session):
+    """A ghost alongside a live version leaves resolution untouched."""
+    session = memory_session
+    _seed_releases(session)
+    _seed_module_versions(session)
+    _seed_shared_rendering(session)
+    # The live version runs past the ghost's start, and the table is
+    # unchanged between the two, so both compositions point at the same
+    # table version -- a live version hosts it and nothing is substituted.
+    session.query(ModuleVersion).filter(ModuleVersion.module_vid == 10).update(
+        {ModuleVersion.end_release_id: NEW}
+    )
+    _seed_table_version(
+        session,
+        table_vid=201,
+        module_vid=10,
+        start=OLD,
+        end=NEW,
+        code="T_GHOST_LIVE",
+    )
+    session.add(
+        ModuleVersionComposition(module_vid=11, table_vid=201, table_id=1)
+    )
+    session.commit()
+
+    scope = ViewDatapointsQuery._resolve_table_version_scope(
+        session, "T_GHOST_LIVE", GHOST_ERA
+    )
+
+    assert scope.table_vids == [201]
+    assert scope.fallback_module_vids is None
+
+
+def test_ghost_without_a_prior_version_keeps_its_table_version(
+    memory_session,
+):
+    """Nothing to fall back to: the table still resolves, from the ghost."""
+    session = memory_session
+    _seed_releases(session)
+    _seed_module_versions(session, ghost_only=True)
+    _seed_shared_rendering(session)
+    _seed_table_version(
+        session,
+        table_vid=301,
+        module_vid=11,
+        start=GHOST_ERA,
+        end=NEW,
+        code="T_GHOST_ALONE",
+    )
+    session.commit()
+
+    scope = ViewDatapointsQuery._resolve_table_version_scope(
+        session, "T_GHOST_ALONE", GHOST_ERA
+    )
+    data = ViewDatapointsQuery.get_table_data(
+        session, "T_GHOST_ALONE", release_id=GHOST_ERA
+    )
+
+    assert scope.table_vids == [301]
+    assert scope.fallback_module_vids is None
+    assert data["variable_id"].tolist() == [301]
+
+
+def test_table_introduced_by_the_ghost_keeps_its_table_version(
+    memory_session,
+):
+    """The prior version exists but has no such table: no substitution."""
+    session = memory_session
+    _seed_releases(session)
+    _seed_module_versions(session)
+    _seed_shared_rendering(session)
+    # The live version hosts a different table, so the fallback module
+    # version has nothing to answer with for this code.
+    _seed_table_version(
+        session,
+        table_vid=401,
+        module_vid=10,
+        start=OLD,
+        end=GHOST_ERA,
+        code="T_GHOST_OTHER",
+    )
+    _seed_table_version(
+        session,
+        table_vid=402,
+        module_vid=11,
+        start=GHOST_ERA,
+        end=NEW,
+        code="T_GHOST_NEW",
+    )
+    session.commit()
+
+    scope = ViewDatapointsQuery._resolve_table_version_scope(
+        session, "T_GHOST_NEW", GHOST_ERA
+    )
+
+    assert scope.table_vids == [402]
+    assert scope.fallback_module_vids is None
+
+
+def test_no_release_applies_no_fallback(memory_session):
+    """Without a target release there is no "prior" version to pick."""
+    session = memory_session
+    _seed_ghost_supersedes_live(session, "T_GHOST_NORELEASE")
+
+    scope = ViewDatapointsQuery._resolve_table_version_scope(
+        session, "T_GHOST_NORELEASE", None
+    )
+
+    assert scope.fallback_module_vids is None
+
+
+# ------------------------------------------------------------------ #
+# The reported case, against the real dictionary
+# ------------------------------------------------------------------ #
+
+# F_40.01 belongs to FINREP9, whose 3.2.0 is a ghost spanning 4.0 -> 4.2.
+_GHOST_RELEASES = ("4.0", "4.1")
+_EXPRESSION = "{tF_40.01, c0095} = [eba_CT:x12]"
+
+
+def _module_vid(session, code, version):
+    return (
+        session.query(ModuleVersion.module_vid)
+        .filter(
+            ModuleVersion.code == code,
+            ModuleVersion.version_number == version,
+        )
+        .one()[0]
+    )
+
+
+def test_finrep9_datapoints_resolve_to_the_prior_non_ghost(fixture_session):
+    """F_40.01's cells come from 3.1.0's table version across the ghost."""
+    session = fixture_session
+    prior = _module_vid(session, "FINREP9", "3.1.0")
+    ghost = _module_vid(session, "FINREP9", "3.2.0")
+    release_id = resolve_release_id(session, release_code="4.0")
+
+    scope = ViewDatapointsQuery._resolve_table_version_scope(
+        session, "F_40.01", release_id
+    )
+    hosted_by = {
+        vid
+        for (vid,) in session.query(ModuleVersionComposition.module_vid)
+        .filter(ModuleVersionComposition.table_vid.in_(scope.table_vids))
+        .distinct()
+    }
+
+    assert prior in hosted_by
+    assert ghost not in hosted_by
+    assert scope.fallback_module_vids == [prior]
+
+
+def test_domain_warning_only_fires_where_the_retyping_is_real(
+    fixture_session,
+):
+    """``c0095`` takes CT items until 4.2, qSR items from 4.2 on."""
+    service = SemanticService(fixture_session)
+
+    for release_code in _GHOST_RELEASES:
+        result = service.validate(_EXPRESSION, release_code=release_code)
+        assert result.is_valid, result.error_message
+        assert result.warning is None, (
+            f"{release_code}: the column still takes CT items there"
+        )
+
+    retyped = service.validate(_EXPRESSION, release_code="4.2")
+    assert retyped.warning is not None
+    assert "qSR" in retyped.warning

--- a/tests/integration/services/test_ghost_release_resolution.py
+++ b/tests/integration/services/test_ghost_release_resolution.py
@@ -1,0 +1,96 @@
+"""The release-axis companion of ``test_ghost_date_resolution`` (#356).
+
+``HierarchyService`` resolves a table version through the module-version
+join, so a release whose only covering module version is a ghost used to
+answer with the ghost's table version -- while the very same lookup by
+reference date answered with the prior non-ghost's. The two axes describe
+the same reporting era and must agree.
+
+FINREP9's ghost ``3.2.0`` claims the instant ``2024-12-31`` and spans
+releases 4.0 -> 4.2; the prior non-ghost ``3.1.0`` covers that date, and
+F_40.01 has a different table version in each.
+"""
+
+from __future__ import annotations
+
+from dpmcore.orm.packaging import ModuleVersion, ModuleVersionComposition
+from dpmcore.services.hierarchy import HierarchyService
+
+_GHOST_ERA_DATE = "2024-12-31"
+_GHOST_RELEASES = ("4.0", "4.1")
+_TABLE = "F_40.01"
+# A table the ghost introduced: the prior non-ghost does not contain it,
+# so there is nothing to fall back to.
+_GHOST_ONLY_TABLE = "C_94.02"
+
+
+def _module_vid(session, code, version):
+    """Return the ``ModuleVID`` for a ``(code, version_number)`` pair."""
+    return (
+        session.query(ModuleVersion.module_vid)
+        .filter(
+            ModuleVersion.code == code,
+            ModuleVersion.version_number == version,
+        )
+        .one()[0]
+    )
+
+
+def _hosts_table_vid(session, module_vid, table_vid):
+    """Whether ``module_vid``'s composition contains ``table_vid``."""
+    return (
+        session.query(ModuleVersionComposition)
+        .filter(
+            ModuleVersionComposition.module_vid == module_vid,
+            ModuleVersionComposition.table_vid == table_vid,
+        )
+        .first()
+        is not None
+    )
+
+
+def test_release_lookup_resolves_to_prior_non_ghost(fixture_session):
+    """Across the ghost's releases the table details come from 3.1.0."""
+    session = fixture_session
+    prior = _module_vid(session, "FINREP9", "3.1.0")
+    ghost = _module_vid(session, "FINREP9", "3.2.0")
+    service = HierarchyService(session)
+
+    for release_code in _GHOST_RELEASES:
+        details = service.get_table_details(_TABLE, release_code=release_code)
+        assert details is not None, release_code
+        table_vid = details["table_vid"]
+        assert _hosts_table_vid(session, prior, table_vid), release_code
+        assert not _hosts_table_vid(session, ghost, table_vid), release_code
+
+
+def test_release_and_date_axes_agree(fixture_session):
+    """The ghost era resolves to one table version, whichever axis asks."""
+    service = HierarchyService(fixture_session)
+
+    by_release = service.get_table_details(_TABLE, release_code="4.0")
+    by_date = service.get_table_details(_TABLE, date=_GHOST_ERA_DATE)
+
+    assert by_release["table_vid"] == by_date["table_vid"]
+
+
+def test_release_after_the_ghost_keeps_its_own_version(fixture_session):
+    """From 4.2 the module version is live again and answers for itself."""
+    session = fixture_session
+    current = _module_vid(session, "FINREP9", "3.3.0")
+
+    details = HierarchyService(session).get_table_details(
+        _TABLE, release_code="4.2"
+    )
+
+    assert _hosts_table_vid(session, current, details["table_vid"])
+
+
+def test_table_introduced_by_a_ghost_still_resolves(fixture_session):
+    """With nothing to fall back to the table stays reachable."""
+    details = HierarchyService(fixture_session).get_table_details(
+        _GHOST_ONLY_TABLE, release_code="4.0"
+    )
+
+    assert details is not None
+    assert details["code"] == _GHOST_ONLY_TABLE


### PR DESCRIPTION
## Summary

Closes #356 

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [ ] Documentation updated (if applicable)

## Impact / Risk

- Breaking changes? (public API / CLI / REST endpoints / Django models)
- Database schema or migration concerns?
- Notes for release/changelog?

## Notes

<!-- Follow-ups, TODOs, or anything reviewers should know. -->
