### PR TITLE
fix: expand super-categories when resolving domains and enumerations

### DIFF
--- a/src/dpmcore/dpm_xl/ast/domain_membership.py
+++ b/src/dpmcore/dpm_xl/ast/domain_membership.py
@@ -21,11 +21,19 @@ plus the categories composing that one when it is a *super-category*: EBA's
 rest of its value set from those four, which ``ItemCategory`` files under the
 member domains (#359). ``Category.IsEnumerated`` is the gate: a property in a
 non-enumerated category (dates, identifiers, free text, "not applicable")
-describes no value set, so nothing is claimed about it. The dictionary offers
-nothing finer: the subcategory link on variable versions is unpopulated, so
-the check is domain membership and nothing more -- a super-category component
-accepts every item of every member domain, not only the ones the column's
-subcategory actually lists.
+describes no value set, so nothing is claimed about it.
+
+Widening a super-category to its members costs precision -- ``qTU`` goes from
+1 item to 927 -- so where the dictionary can say which of them a *column*
+actually offers, it is asked. A cell selection whose table header names a
+``SubCategoryVersion`` for the same property is judged against that list
+instead (``{tC_14.00, c0160}``: 18 items, not 927), with the super-category's
+own items still accepted, since a subcategory never lists the domain's
+"not applicable / all" default. This refinement needs a header subcategory for
+every data point in the selection; anything less falls back to the widened
+domain, which is a superset and so can only be more permissive. Open keys and
+``sub`` targets have no header, so they stay at domain granularity, as does
+the ``SubCategoryVID`` column on variable versions, which is unpopulated.
 
 The pass runs after semantic analysis has succeeded, so a genuine type error
 is reported on its own rather than alongside this warning.
@@ -33,7 +41,10 @@ is reported on its own rather than alongside this warning.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Iterable
+
+import pandas as pd
 
 from dpmcore.dpm_xl.ast.nodes import (
     AST,
@@ -57,6 +68,8 @@ from dpmcore.dpm_xl.ast.template import ASTTemplate
 from dpmcore.dpm_xl.model_queries import (
     ItemCategoryQuery,
     PropertyCategoryQuery,
+    PropertyDomains,
+    SubCategoryQuery,
     ViewOpenKeysQuery,
 )
 from dpmcore.dpm_xl.utils import tokens
@@ -111,6 +124,27 @@ def _join(domains: Iterable[str]) -> str:
     return ", ".join(sorted(domains))
 
 
+@dataclass(frozen=True)
+class _Component:
+    """One side of a comparison, and the values it can take.
+
+    ``own``/``members`` mirror :class:`PropertyDomains`. ``offered`` is
+    the exact set of item signatures a header subcategory pins the
+    component down to; ``None`` means no such list is known and the
+    domains are all there is to go on.
+    """
+
+    reference: str
+    own: frozenset[str]
+    members: frozenset[str]
+    offered: frozenset[str] | None = None
+
+    @property
+    def domains(self) -> frozenset[str]:
+        """Every category the component may take items from."""
+        return self.own | self.members
+
+
 class DomainMembershipChecker(ASTTemplate):
     """Warns on comparisons an item's domain makes impossible.
 
@@ -132,9 +166,13 @@ class DomainMembershipChecker(ASTTemplate):
         # last, so a condition on the Fact Component ("f") resolves against
         # the recordset the clause filters.
         self._clause_operands: list[AST] = []
-        self._property_domains: dict[int, set[str]] = {}
+        self._property_domains: dict[int, PropertyDomains | None] = {}
         self._item_domains: dict[str, set[str]] = {}
         self._sub_property_ids: dict[str, int | None] = {}
+        # (table_vid, cell_id, property_id) -> subcategory, ``None`` once
+        # the dictionary has been asked and named none.
+        self._cell_subcategories: dict[tuple[int, int, int], int | None] = {}
+        self._subcategory_signatures: dict[int, frozenset[str]] = {}
         self.visit(ast)
 
     # -- traversal ------------------------------------------------- #
@@ -194,11 +232,10 @@ class DomainMembershipChecker(ASTTemplate):
 
     def _report(
         self,
-        component: tuple[str, set[str]],
+        component: _Component,
         literals: Iterable[str],
         effect: str,
     ) -> None:
-        reference, domains = component
         # A set literal may repeat a member. The mismatch is one fact about
         # the item, so it is reported once however often it is written.
         signatures = list(dict.fromkeys(literals))
@@ -208,18 +245,47 @@ class DomainMembershipChecker(ASTTemplate):
             # An item with no domain open at this release is reported as
             # not-found (1-1) before this pass runs; a set member the
             # dictionary places in no enumerated category says nothing.
-            if not found or found & domains:
+            if not found:
                 continue
-            add_semantic_warning(
+            warning = self._mismatch(component, signature, found, effect)
+            if warning is not None:
+                add_semantic_warning(warning)
+
+    def _mismatch(
+        self,
+        component: _Component,
+        signature: str,
+        found: set[str],
+        effect: str,
+    ) -> str | None:
+        """The warning *signature* earns against *component*, if any."""
+        if found & component.own:
+            # In the category the component is typed on: always a value it
+            # can take, whatever a subcategory narrows the members to.
+            return None
+        if not found & component.members:
+            return (
                 f"Item [{signature}] belongs to domain {_join(found)}, "
-                f"but {reference} takes items from domain "
-                f"{_join(domains)}: {effect}."
+                f"but {component.reference} takes items from domain "
+                f"{_join(component.domains)}: {effect}."
             )
+        if component.offered is None or signature in component.offered:
+            return None
+        # The item is in the super-category's overall value set, but the
+        # header says which of those items this column actually offers.
+        count = len(component.offered)
+        return (
+            f"Item [{signature}] belongs to domain {_join(found)}, which "
+            f"composes {_join(component.own)}, but the "
+            f"{count} item{'' if count == 1 else 's'} "
+            f"{component.reference} enumerates there do not include it: "
+            f"{effect}."
+        )
 
     # -- domain resolution ----------------------------------------- #
 
-    def _component_domains(self, node: AST) -> tuple[str, set[str]] | None:
-        """Return ``(component reference, domains)`` for *node*.
+    def _component_domains(self, node: AST) -> _Component | None:
+        """Return the values *node* can take, or ``None``.
 
         ``None`` whenever the domain cannot be pinned down -- an expression
         that is not a component reference, a selection spanning a property
@@ -240,8 +306,8 @@ class DomainMembershipChecker(ASTTemplate):
             return self._component_domains(node.selection)
         return None
 
-    def _selection_domains(self, node: VarID) -> tuple[str, set[str]] | None:
-        """Domains of the Fact Component of a cell selection.
+    def _selection_domains(self, node: VarID) -> _Component | None:
+        """Values the Fact Component of a cell selection can take.
 
         A selection can span several data points, each with its own variable
         and so its own domain. The result is their union: an item is only
@@ -258,17 +324,91 @@ class DomainMembershipChecker(ASTTemplate):
             return None
         property_ids = {int(value) for value in properties.unique()}
         resolved = self._domains_of_properties(property_ids)
-        domains: set[str] = set()
+        own: set[str] = set()
+        members: set[str] = set()
         for property_id in property_ids:
             found = resolved.get(property_id)
-            if not found:
+            if found is None:
                 return None
-            domains |= found
-        return generate_operand_expression(node), domains
+            own |= found.own
+            members |= found.members
+        return _Component(
+            reference=generate_operand_expression(node),
+            own=frozenset(own),
+            members=frozenset(members),
+            # Only a widened domain has precision to recover; asking about
+            # a plain category would buy nothing and cost two queries.
+            offered=self._offered_signatures(data) if members else None,
+        )
 
-    def _dimension_domains(
-        self, node: Dimension
-    ) -> tuple[str, set[str]] | None:
+    def _offered_signatures(
+        self, data: "pd.DataFrame"
+    ) -> frozenset[str] | None:
+        """Item signatures the selection's headers pin the columns to.
+
+        ``None`` unless every data point in the selection has a header
+        subcategory for its own property: the fallback (the whole widened
+        domain) is a superset, so a partial answer would have to widen back
+        to it anyway.
+        """
+        if not {"table_vid", "cell_id"} <= set(data.columns):
+            return None
+        keys: list[tuple[int, int, int]] = []
+        for table_vid, cell_id, property_id in zip(
+            data["table_vid"],
+            data["cell_id"],
+            data["property_id"],
+            strict=True,
+        ):
+            if pd.isna(table_vid) or pd.isna(cell_id):
+                return None
+            keys.append((int(table_vid), int(cell_id), int(property_id)))
+        subcategories = self._subcategories_of_cells(keys)
+        vids: set[int] = set()
+        for key in keys:
+            vid = subcategories.get(key)
+            if vid is None:
+                return None
+            vids.add(vid)
+        signatures = self._signatures_of_subcategories(vids)
+        offered: set[str] = set()
+        for vid in vids:
+            offered |= signatures[vid]
+        return frozenset(offered)
+
+    def _subcategories_of_cells(
+        self, keys: Iterable[tuple[int, int, int]]
+    ) -> dict[tuple[int, int, int], int | None]:
+        """Resolve, and remember, the header subcategory of each cell."""
+        missing = [key for key in keys if key not in self._cell_subcategories]
+        if missing:
+            found = SubCategoryQuery.get_cell_subcategory_vids(
+                self.session,
+                [(table_vid, cell_id) for table_vid, cell_id, _p in missing],
+                self.release_id,
+            )
+            for key in missing:
+                self._cell_subcategories[key] = found.get(key)
+        return self._cell_subcategories
+
+    def _signatures_of_subcategories(
+        self, vids: Iterable[int]
+    ) -> dict[int, frozenset[str]]:
+        """Resolve, and remember, the items each subcategory lists."""
+        missing = [
+            vid for vid in vids if vid not in self._subcategory_signatures
+        ]
+        if missing:
+            found = SubCategoryQuery.get_subcategory_signatures(
+                self.session, missing, self.release_id
+            )
+            for vid in missing:
+                self._subcategory_signatures[vid] = frozenset(
+                    found.get(vid, set())
+                )
+        return self._subcategory_signatures
+
+    def _dimension_domains(self, node: Dimension) -> _Component | None:
         """Domains of an open key, or of the Fact Component for ``f``."""
         if node.dimension_code == tokens.FACT:
             if not self._clause_operands:
@@ -278,18 +418,22 @@ class DomainMembershipChecker(ASTTemplate):
 
     def _property_component(
         self, code: str, property_id: int | None
-    ) -> tuple[str, set[str]] | None:
+    ) -> _Component | None:
         """Domains of the component built on property *property_id*.
 
         Implicit open keys (``refPeriod``, ``entityID``, ``baseCurrency``)
-        carry the sentinel ``-1`` and belong to no category.
+        carry the sentinel ``-1`` and belong to no category. An open key or
+        a ``sub`` target names no table cell, so there is no header
+        subcategory to narrow it with.
         """
         if property_id is None or property_id < 0:
             return None
         domains = self._domains_of_properties([property_id]).get(property_id)
-        if not domains:
+        if domains is None:
             return None
-        return code, domains
+        return _Component(
+            reference=code, own=domains.own, members=domains.members
+        )
 
     def _sub_property_id(self, code: str) -> int | None:
         """Resolve a ``sub`` clause target property code to its ID."""
@@ -307,7 +451,7 @@ class DomainMembershipChecker(ASTTemplate):
 
     def _domains_of_properties(
         self, property_ids: Iterable[int]
-    ) -> dict[int, set[str]]:
+    ) -> dict[int, PropertyDomains | None]:
         missing = [
             property_id
             for property_id in property_ids
@@ -318,9 +462,7 @@ class DomainMembershipChecker(ASTTemplate):
                 self.session, missing, self.release_id
             )
             for property_id in missing:
-                self._property_domains[property_id] = found.get(
-                    property_id, set()
-                )
+                self._property_domains[property_id] = found.get(property_id)
         return self._property_domains
 
     def _domains_of_items(

--- a/src/dpmcore/dpm_xl/ast/domain_membership.py
+++ b/src/dpmcore/dpm_xl/ast/domain_membership.py
@@ -1,7 +1,8 @@
 """Domain-membership check for comparisons against item literals.
 
-An enumerated component takes its values from exactly one *domain* (a
-``Category``). Comparing it with an item that belongs to a different domain is
+An enumerated component takes its values from one *domain* (a ``Category``)
+-- or, when that category is a super-category, from the domains composing it.
+Comparing it with an item that belongs to a different domain is
 accepted by every other check -- the item exists (1-1) and ``Item`` is
 type-compatible with ``Item`` -- yet the comparison can never hold: ``=`` and
 ``in`` are always false, ``!=`` is always true, and a ``sub`` clause on an
@@ -14,12 +15,17 @@ legacy signatures behind in expressions that still validate clean), and those
 must keep validating.
 
 Domain resolution is the same for every component kind -- the component's
-property, then the category that property is typed on at the script's release.
-``Category.IsEnumerated`` is the gate: a property in a non-enumerated category
-(dates, identifiers, free text, "not applicable") describes no value set, so
-nothing is claimed about it. The dictionary offers nothing finer: the
-subcategory link on variable versions is unpopulated, so the check is domain
-membership and nothing more.
+property, then the category that property is typed on at the script's release,
+plus the categories composing that one when it is a *super-category*: EBA's
+``qTU`` ("qAI, qFI, qSR & qTA") holds a single item of its own and draws the
+rest of its value set from those four, which ``ItemCategory`` files under the
+member domains (#359). ``Category.IsEnumerated`` is the gate: a property in a
+non-enumerated category (dates, identifiers, free text, "not applicable")
+describes no value set, so nothing is claimed about it. The dictionary offers
+nothing finer: the subcategory link on variable versions is unpopulated, so
+the check is domain membership and nothing more -- a super-category component
+accepts every item of every member domain, not only the ones the column's
+subcategory actually lists.
 
 The pass runs after semantic analysis has succeeded, so a genuine type error
 is reported on its own rather than alongside this warning.

--- a/src/dpmcore/dpm_xl/model_queries.py
+++ b/src/dpmcore/dpm_xl/model_queries.py
@@ -9,6 +9,7 @@ legacy ``session.query()`` API for compatibility.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -22,7 +23,10 @@ import pandas as pd
 from sqlalchemy import and_, func, or_
 from sqlalchemy.orm import aliased
 
-from dpmcore.dpm_xl.utils.filters import filter_by_release
+from dpmcore.dpm_xl.utils.filters import (
+    filter_by_release,
+    release_window_conditions,
+)
 from dpmcore.dpm_xl.utils.range_resolution import (
     build_axis_order_map,
     build_axis_value_map,
@@ -34,6 +38,7 @@ from dpmcore.orm.glossary import (
     ItemCategory,
     Property,
     PropertyCategory,
+    SubCategoryItem,
     SupercategoryComposition,
 )
 from dpmcore.orm.infrastructure import (
@@ -69,6 +74,7 @@ from dpmcore.orm.rendering import (
     TableVersionCell,
     TableVersionHeader,
 )
+from dpmcore.orm.supercategories import load_supercategory_member_codes
 from dpmcore.orm.variables import (
     KeyComposition,
     Variable,
@@ -206,13 +212,40 @@ def _filter_elements(
 # ------------------------------------------------------------------ #
 
 
+@dataclass(frozen=True)
+class PropertyDomains:
+    """The categories a component built on a property takes items from.
+
+    ``own`` is the category the property is typed on (a set, because the
+    link is release-versioned). ``members`` is what a *super-category*
+    among them adds: the categories composing it, which is where
+    ``ItemCategory`` actually files most of its value set.
+
+    The two are kept apart rather than unioned because they carry
+    different confidence. An item in ``own`` is unconditionally a value
+    the component can take; an item in ``members`` is only known to be in
+    the super-category's *overall* value set, and a header subcategory
+    may narrow which of them a given column actually offers.
+    """
+
+    own: frozenset[str]
+    members: frozenset[str]
+
+    @property
+    def codes(self) -> frozenset[str]:
+        """Every category the component may take items from."""
+        return self.own | self.members
+
+
 def _enumerated_domains(
     session: "Session",
     model: Any,
     key_col: Any,
     keys: Sequence[Any],
     release_id: int | None,
-) -> dict[Any, set[str]]:
+    *,
+    with_members: bool = False,
+) -> tuple[dict[Any, set[str]], dict[Any, set[str]]]:
     """Map the keys of a category link table to enumerated category codes.
 
     ``ItemCategory`` and ``PropertyCategory`` are the same shape: a
@@ -227,92 +260,99 @@ def _enumerated_domains(
         key_col: Column of *model* the result is keyed on.
         keys: Values of *key_col* to resolve.
         release_id: Release the link is resolved at.
+        with_members: Also resolve, in the same statement, the categories
+            composing each linked category when it is a *super-category*.
+            An outer join, so a key whose category composes nothing is
+            still returned; the window on the composition lives in the
+            ``ON`` clause, where it cannot narrow that outer join back to
+            an inner one.
 
     Returns:
-        ``{key: {category_code, ...}}``, omitting keys with no enumerated
-        category open at ``release_id``.
+        ``({key: {category_code, ...}}, {key: {member_code, ...}})``,
+        each omitting keys with nothing to report. The second mapping is
+        always empty unless *with_members*, and covers one level of
+        composition -- :func:`load_supercategory_member_codes` completes
+        the closure for the rare nested case.
     """
+    # Both windows come from one release load: the link's own, and --
+    # when members are wanted -- the composition's, which has to sit in
+    # the join's ON clause so the outer join stays outer.
+    windows = [(model.start_release_id, model.end_release_id)]
+    if with_members:
+        windows.append(
+            (
+                SupercategoryComposition.start_release_id,
+                SupercategoryComposition.end_release_id,
+            )
+        )
+    conditions = release_window_conditions(session, windows, release_id)
+
     query = (
         session.query(
             key_col.label("DomainKey"),
             Category.code.label("CategoryCode"),
         )
         .join(Category, Category.category_id == model.category_id)
-        .filter(key_col.in_(list(keys)))
         .filter(Category.is_enumerated == True)  # noqa: E712
         .filter(Category.code.isnot(None))
+        .filter(conditions[0])
     )
-    query = filter_by_release(
-        query,
-        start_col=model.start_release_id,
-        end_col=model.end_release_id,
-        release_id=release_id,
-        active_only_fallback=True,
-    )
+    if with_members:
+        query = _add_member_columns(query, conditions[1])
     domains: dict[Any, set[str]] = {}
-    for row in query.distinct().all():
+    members: dict[Any, set[str]] = {}
+    for row in chunked_in(query, key_col, keys):
         domains.setdefault(row.DomainKey, set()).add(row.CategoryCode)
-    return domains
+        if with_members and row.MemberCode is not None:
+            members.setdefault(row.DomainKey, set()).add(row.MemberCode)
+    return domains, members
 
 
-def _supercategory_members(
+def _add_member_columns(
+    query: "Query[Any]",
+    composition_window: Any,
+) -> "Query[Any]":
+    """Outer-join the composing categories of a super-category domain."""
+    member = aliased(Category)
+    return (
+        query.outerjoin(
+            SupercategoryComposition,
+            and_(
+                SupercategoryComposition.supercategory_id
+                == Category.category_id,
+                composition_window,
+            ),
+        )
+        .outerjoin(
+            member,
+            and_(
+                member.category_id == SupercategoryComposition.category_id,
+                member.is_enumerated == True,  # noqa: E712
+                member.code.isnot(None),
+            ),
+        )
+        .add_columns(member.code.label("MemberCode"))
+    )
+
+
+def _nested_members(
     session: "Session",
-    codes: Collection[str],
+    members: dict[Any, set[str]],
     release_id: int | None,
 ) -> dict[str, set[str]]:
-    """Map super-category codes to the codes of the categories in them.
+    """Expand members that are themselves super-categories.
 
-    A super-category (``SuperCategoryComposition``) is a domain whose
-    value set is the union of the value sets of the categories composing
-    it: EBA's ``qTU`` ("qAI, qFI, qSR & qTA") holds one item of its own
-    and draws the rest from those four. ``ItemCategory`` records the item
-    only under the category that owns it, so a component typed on the
-    super-category has to be judged against the members as well.
-
-    Args:
-        session: SQLAlchemy session.
-        codes: Category codes to expand; non-super-categories yield no
-            entry.
-        release_id: Release the composition is resolved at.
-
-    Returns:
-        ``{supercategory_code: {member_code, ...}}``, omitting codes that
-        compose nothing at ``release_id``.
+    The single-statement join in :func:`_enumerated_domains` reaches one
+    level. This completes the closure -- and issues no query at all when
+    nothing composed anything, which is every property typed on an
+    ordinary category.
     """
+    codes = {code for values in members.values() for code in values}
     if not codes:
         return {}
-    supercategory = aliased(Category)
-    member = aliased(Category)
-    query = (
-        session.query(
-            supercategory.code.label("SupercategoryCode"),
-            member.code.label("MemberCode"),
-        )
-        .select_from(SupercategoryComposition)
-        .join(
-            supercategory,
-            supercategory.category_id
-            == SupercategoryComposition.supercategory_id,
-        )
-        .join(
-            member,
-            member.category_id == SupercategoryComposition.category_id,
-        )
-        .filter(supercategory.code.in_(list(codes)))
-        .filter(member.is_enumerated == True)  # noqa: E712
-        .filter(member.code.isnot(None))
+    return load_supercategory_member_codes(
+        session, codes, release_id=release_id
     )
-    query = filter_by_release(
-        query,
-        start_col=SupercategoryComposition.start_release_id,
-        end_col=SupercategoryComposition.end_release_id,
-        release_id=release_id,
-        active_only_fallback=True,
-    )
-    members: dict[str, set[str]] = {}
-    for row in query.distinct().all():
-        members.setdefault(row.SupercategoryCode, set()).add(row.MemberCode)
-    return members
 
 
 # ------------------------------------------------------------------ #
@@ -456,13 +496,14 @@ class ItemCategoryQuery:
         """
         if not items:
             return {}
-        return _enumerated_domains(
+        domains, _members = _enumerated_domains(
             session,
             ItemCategory,
             ItemCategory.signature,
             items,
             release_id,
         )
+        return domains
 
 
 # ------------------------------------------------------------------ #
@@ -478,8 +519,8 @@ class PropertyCategoryQuery:
         session: "Session",
         property_ids: Sequence[int],
         release_id: int | None = None,
-    ) -> dict[int, set[str]]:
-        """Map properties to the code(s) of the categories they are typed on.
+    ) -> dict[int, PropertyDomains]:
+        """Map properties to the categories they are typed on.
 
         A property's category is the domain of every component built on it:
         the items that component may take. Only enumerated categories are
@@ -487,11 +528,17 @@ class PropertyCategoryQuery:
         resolves to no domain at all. Like ``ItemCategory``, the link is
         release-versioned, hence the set-valued result.
 
-        A category that is a *super-category* is returned together with the
-        categories composing it: the component takes items from any of them,
-        while ``ItemCategory`` files each item under the one category that
-        owns it. The dictionary nests super-categories no deeper than one
-        level, so the members are not expanded again.
+        A category that is a *super-category* also contributes the
+        categories composing it: the component takes items from any of
+        them, while ``ItemCategory`` files each item under the one
+        category that owns it. Both halves are reported separately --
+        see :class:`PropertyDomains` -- because a caller that can pin the
+        component's value set down more precisely needs to know which of
+        the two it is looking at.
+
+        The composition is resolved in the same statement as the domain,
+        so a property on an ordinary category costs no extra query; only
+        the rare nested super-category needs a second round trip.
 
         Args:
             session: SQLAlchemy session.
@@ -499,29 +546,162 @@ class PropertyCategoryQuery:
             release_id: Release the link is resolved at.
 
         Returns:
-            ``{property_id: {category_code, ...}}``, omitting properties with
+            ``{property_id: PropertyDomains}``, omitting properties with
             no category open at ``release_id``.
         """
         if not property_ids:
             return {}
-        domains = _enumerated_domains(
+        own, members = _enumerated_domains(
             session,
             PropertyCategory,
             PropertyCategory.property_id,
             property_ids,
             release_id,
+            with_members=True,
         )
-        members = _supercategory_members(
-            session,
-            {code for codes in domains.values() for code in codes},
-            release_id,
-        )
+        nested = _nested_members(session, members, release_id)
         return {
-            int(key): codes.union(
-                *(members.get(code, set()) for code in codes)
+            int(key): PropertyDomains(
+                own=frozenset(codes),
+                members=frozenset(
+                    members.get(key, set()).union(
+                        *(
+                            nested.get(code, set())
+                            for code in members.get(key, set())
+                        )
+                    )
+                    if members.get(key)
+                    else ()
+                ),
             )
-            for key, codes in domains.items()
+            for key, codes in own.items()
         }
+
+
+# ------------------------------------------------------------------ #
+# SubCategory queries
+# ------------------------------------------------------------------ #
+
+
+class SubCategoryQuery:
+    """Query helpers around the header subcategory of a data point.
+
+    A ``Category`` is the widest thing a component may take values from.
+    Where a table header names a ``SubCategoryVersion``, the dictionary
+    says exactly which of those items *that column* offers -- 18 of
+    ``qTU``'s 927, say. Only about 4% of header versions carry one, so
+    this is a refinement, never the primary resolution.
+    """
+
+    @staticmethod
+    def get_cell_subcategory_vids(
+        session: "Session",
+        cells: Sequence[tuple[int, int]],
+        release_id: int | None = None,
+    ) -> dict[tuple[int, int, int], int]:
+        """Map cells to the subcategory their own header pins down.
+
+        Only a header whose ``property_id`` is the one the caller is
+        asking about counts: a cell is bounded by up to three headers,
+        and a subcategory on the row says nothing about the value set of
+        a column's property.
+
+        Args:
+            session: SQLAlchemy session.
+            cells: ``(table_vid, cell_id)`` pairs to resolve.
+            release_id: Release the header version is resolved at.
+
+        Returns:
+            ``{(table_vid, cell_id, property_id): subcategory_vid}``,
+            omitting cells whose headers name no subcategory.
+        """
+        if not cells:
+            return {}
+        query = (
+            session.query(
+                TableVersionCell.table_vid.label("TableVid"),
+                TableVersionCell.cell_id.label("CellId"),
+                HeaderVersion.property_id.label("PropertyId"),
+                HeaderVersion.subcategory_vid.label("SubcategoryVid"),
+            )
+            .join(Cell, Cell.cell_id == TableVersionCell.cell_id)
+            .join(
+                TableVersionHeader,
+                and_(
+                    TableVersionHeader.table_vid == TableVersionCell.table_vid,
+                    or_(
+                        TableVersionHeader.header_id == Cell.column_id,
+                        TableVersionHeader.header_id == Cell.row_id,
+                        TableVersionHeader.header_id == Cell.sheet_id,
+                    ),
+                ),
+            )
+            .join(
+                HeaderVersion,
+                HeaderVersion.header_vid == TableVersionHeader.header_vid,
+            )
+            .filter(HeaderVersion.subcategory_vid.isnot(None))
+            .filter(HeaderVersion.property_id.isnot(None))
+        )
+        table_vids = {table_vid for table_vid, _cell_id in cells}
+        query = query.filter(TableVersionCell.table_vid.in_(table_vids))
+        wanted = set(cells)
+        found: dict[tuple[int, int, int], int] = {}
+        for row in chunked_in(
+            query,
+            TableVersionCell.cell_id,
+            {cell_id for _table_vid, cell_id in cells},
+        ):
+            if (row.TableVid, row.CellId) not in wanted:
+                continue
+            found[(row.TableVid, row.CellId, row.PropertyId)] = (
+                row.SubcategoryVid
+            )
+        return found
+
+    @staticmethod
+    def get_subcategory_signatures(
+        session: "Session",
+        subcategory_vids: Sequence[int],
+        release_id: int | None = None,
+    ) -> dict[int, set[str]]:
+        """Map subcategory versions to the item signatures they list.
+
+        Args:
+            session: SQLAlchemy session.
+            subcategory_vids: SubCategoryVersion IDs to resolve.
+            release_id: Release the item codes are resolved at -- an
+                item with no ``ItemCategory`` row open there has no
+                signature at that release and is left out.
+
+        Returns:
+            ``{subcategory_vid: {signature, ...}}``.
+        """
+        if not subcategory_vids:
+            return {}
+        query = (
+            session.query(
+                SubCategoryItem.subcategory_vid.label("SubcategoryVid"),
+                ItemCategory.signature.label("Signature"),
+            )
+            .join(
+                ItemCategory, ItemCategory.item_id == SubCategoryItem.item_id
+            )
+            .filter(ItemCategory.signature.isnot(None))
+        )
+        query = filter_by_release(
+            query,
+            start_col=ItemCategory.start_release_id,
+            end_col=ItemCategory.end_release_id,
+            release_id=release_id,
+            active_only_fallback=True,
+        )
+        signatures: dict[int, set[str]] = {}
+        for row in chunked_in(
+            query, SubCategoryItem.subcategory_vid, subcategory_vids
+        ):
+            signatures.setdefault(row.SubcategoryVid, set()).add(row.Signature)
+        return signatures
 
 
 # ------------------------------------------------------------------ #

--- a/src/dpmcore/dpm_xl/model_queries.py
+++ b/src/dpmcore/dpm_xl/model_queries.py
@@ -34,6 +34,7 @@ from dpmcore.orm.glossary import (
     ItemCategory,
     Property,
     PropertyCategory,
+    SupercategoryComposition,
 )
 from dpmcore.orm.infrastructure import (
     DataType,
@@ -254,6 +255,66 @@ def _enumerated_domains(
     return domains
 
 
+def _supercategory_members(
+    session: "Session",
+    codes: Collection[str],
+    release_id: int | None,
+) -> dict[str, set[str]]:
+    """Map super-category codes to the codes of the categories in them.
+
+    A super-category (``SuperCategoryComposition``) is a domain whose
+    value set is the union of the value sets of the categories composing
+    it: EBA's ``qTU`` ("qAI, qFI, qSR & qTA") holds one item of its own
+    and draws the rest from those four. ``ItemCategory`` records the item
+    only under the category that owns it, so a component typed on the
+    super-category has to be judged against the members as well.
+
+    Args:
+        session: SQLAlchemy session.
+        codes: Category codes to expand; non-super-categories yield no
+            entry.
+        release_id: Release the composition is resolved at.
+
+    Returns:
+        ``{supercategory_code: {member_code, ...}}``, omitting codes that
+        compose nothing at ``release_id``.
+    """
+    if not codes:
+        return {}
+    supercategory = aliased(Category)
+    member = aliased(Category)
+    query = (
+        session.query(
+            supercategory.code.label("SupercategoryCode"),
+            member.code.label("MemberCode"),
+        )
+        .select_from(SupercategoryComposition)
+        .join(
+            supercategory,
+            supercategory.category_id
+            == SupercategoryComposition.supercategory_id,
+        )
+        .join(
+            member,
+            member.category_id == SupercategoryComposition.category_id,
+        )
+        .filter(supercategory.code.in_(list(codes)))
+        .filter(member.is_enumerated == True)  # noqa: E712
+        .filter(member.code.isnot(None))
+    )
+    query = filter_by_release(
+        query,
+        start_col=SupercategoryComposition.start_release_id,
+        end_col=SupercategoryComposition.end_release_id,
+        release_id=release_id,
+        active_only_fallback=True,
+    )
+    members: dict[str, set[str]] = {}
+    for row in query.distinct().all():
+        members.setdefault(row.SupercategoryCode, set()).add(row.MemberCode)
+    return members
+
+
 # ------------------------------------------------------------------ #
 # ItemCategory queries
 # ------------------------------------------------------------------ #
@@ -426,6 +487,12 @@ class PropertyCategoryQuery:
         resolves to no domain at all. Like ``ItemCategory``, the link is
         release-versioned, hence the set-valued result.
 
+        A category that is a *super-category* is returned together with the
+        categories composing it: the component takes items from any of them,
+        while ``ItemCategory`` files each item under the one category that
+        owns it. The dictionary nests super-categories no deeper than one
+        level, so the members are not expanded again.
+
         Args:
             session: SQLAlchemy session.
             property_ids: Property IDs to resolve.
@@ -444,7 +511,17 @@ class PropertyCategoryQuery:
             property_ids,
             release_id,
         )
-        return {int(key): codes for key, codes in domains.items()}
+        members = _supercategory_members(
+            session,
+            {code for codes in domains.values() for code in codes},
+            release_id,
+        )
+        return {
+            int(key): codes.union(
+                *(members.get(code, set()) for code in codes)
+            )
+            for key, codes in domains.items()
+        }
 
 
 # ------------------------------------------------------------------ #

--- a/src/dpmcore/dpm_xl/utils/filters.py
+++ b/src/dpmcore/dpm_xl/utils/filters.py
@@ -13,7 +13,7 @@ non-versioned working releases — without parsing the code.
 """
 
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple
 
 from sqlalchemy import Date, and_, cast, or_
 
@@ -21,7 +21,7 @@ from dpmcore.orm.release_sort_order import (
     compute_sort_order,
     load_release_sort_orders,
     release_ids_for_sort_order,
-    resolve_sort_order,
+    sort_order_from,
 )
 
 if TYPE_CHECKING:
@@ -184,19 +184,97 @@ def filter_by_release(
     if release_id is None:
         return filter_active_only(query, end_col)
 
-    # Order releases by date. resolve_sort_order already handles
-    # non-chronological types like "Playground". This block only compares
-    # the sort order it returns. An unknown release_id raises.
-    target_sort_order = resolve_sort_order(session, release_id)
+    return query.filter(
+        release_window_condition(
+            session,
+            start_col=start_col,
+            end_col=end_col,
+            release_id=release_id,
+        )
+    )
+
+
+def release_window_condition(
+    session: "Session",
+    start_col: Any,
+    end_col: Any,
+    release_id: Optional[int] = None,
+) -> Any:
+    """Return the release-window predicate as a standalone expression.
+
+    Same rule as :func:`filter_by_release`, handed back as a boolean
+    expression instead of being applied to a query, so it can go into
+    a join's ``ON`` clause — where a ``WHERE`` predicate would silently
+    turn an outer join into an inner one.
+
+    Args:
+        session: Open SQLAlchemy session (needed to load the release
+            dates the ordering is derived from).
+        start_col: Column for start release ID (FK to ``Release``).
+        end_col: Column for end release ID (FK to ``Release``).
+        release_id: Release ID to filter for. ``None`` yields the
+            "currently active" predicate :func:`filter_active_only`
+            applies.
+
+    Returns:
+        SQLAlchemy boolean expression.
+
+    Raises:
+        ValueError: If ``release_id`` does not correspond to a known
+            ``Release`` row.
+    """
+    (condition,) = release_window_conditions(
+        session, [(start_col, end_col)], release_id
+    )
+    return condition
+
+
+def release_window_conditions(
+    session: "Session",
+    windows: Sequence[Tuple[Any, Any]],
+    release_id: Optional[int] = None,
+) -> List[Any]:
+    """One predicate per ``(start_col, end_col)``, from one release load.
+
+    A statement that windows several tables at once — a domain link and
+    the composition of the category it points at, say — would otherwise
+    reload the release ordering for each. The ordering is the same for
+    all of them, so it is loaded once and every predicate is built from
+    it.
+
+    Args:
+        session: Open SQLAlchemy session.
+        windows: The ``(start_col, end_col)`` pairs to build predicates
+            for, in order.
+        release_id: Release ID to filter for; ``None`` yields the
+            "currently active" predicate for each window.
+
+    Returns:
+        One SQLAlchemy boolean expression per entry of *windows*.
+
+    Raises:
+        ValueError: If ``release_id`` does not correspond to a known
+            ``Release`` row.
+    """
     sort_orders = load_release_sort_orders(session)
-    start_ids = release_ids_for_sort_order(sort_orders, le=target_sort_order)
-    end_ids = release_ids_for_sort_order(sort_orders, gt=target_sort_order)
     # A row ending at an "always latest" release (undated or
     # non-chronological) is still open even when queried at that release.
     perpetual_ids = release_ids_for_sort_order(
         sort_orders, ge=compute_sort_order(None, None)
     )
-    return query.filter(
+    if release_id is None:
+        return [
+            or_(end_col.is_(None), end_col.in_(perpetual_ids))
+            for _start_col, end_col in windows
+        ]
+
+    # Order releases by date. compute_sort_order already handles
+    # non-chronological types like "Playground"; this only compares the
+    # order it produced. An unknown release_id raises.
+    target_sort_order = sort_order_from(sort_orders, release_id)
+    start_ids = release_ids_for_sort_order(sort_orders, le=target_sort_order)
+    end_ids = release_ids_for_sort_order(sort_orders, gt=target_sort_order)
+    return [
         and_(
             start_col.in_(start_ids),
             or_(
@@ -205,7 +283,8 @@ def filter_by_release(
                 end_col.in_(perpetual_ids),
             ),
         )
-    )
+        for start_col, end_col in windows
+    ]
 
 
 def filter_active_only(query: Any, end_col: Any) -> Any:

--- a/src/dpmcore/orm/release_sort_order.py
+++ b/src/dpmcore/orm/release_sort_order.py
@@ -96,6 +96,33 @@ def load_release_sort_orders(
     return {rid: compute_sort_order(d, t) for rid, d, t in rows}
 
 
+def sort_order_from(
+    sort_orders: Dict[int, int], release_id: int, *, role: str = "release"
+) -> int:
+    """Return ``release_id``'s sort order from a preloaded mapping.
+
+    The mapping form of :func:`resolve_sort_order`, for callers that
+    have already loaded it and would otherwise pay a second query to
+    resolve one release they know is in there.
+
+    Args:
+        sort_orders: Mapping from :func:`load_release_sort_orders`.
+        release_id: Numeric FK of the release to look up.
+        role: Short label identifying the release's role in the error
+            message, as in :func:`resolve_sort_order`.
+
+    Raises:
+        ValueError: If ``release_id`` is absent from the mapping.
+    """
+    sort_order = sort_orders.get(release_id)
+    if sort_order is None:
+        raise ValueError(
+            f"{role} {release_id} has no sort_order — "
+            "no Release row matches that ID."
+        )
+    return sort_order
+
+
 def resolve_sort_order(
     session: "Session", release_id: int, *, role: str = "release"
 ) -> int:

--- a/src/dpmcore/orm/supercategories.py
+++ b/src/dpmcore/orm/supercategories.py
@@ -109,6 +109,12 @@ def load_supercategory_compositions(
     window instead, so the composition opening or closing shows up as a
     version boundary like any other change.
 
+    Nesting is followed like it is by :func:`load_supercategory_members`,
+    but the windows are *not* collapsed: the result is the composition
+    graph reachable from *category_ids*, keyed by super-category, so a
+    nested member that is only reachable while both links are open is
+    the caller's own intersection to make, release by release.
+
     Members are filtered the same way as everywhere else: an
     enumerated category carrying a code.
 
@@ -117,11 +123,30 @@ def load_supercategory_compositions(
         category_ids: Super-category IDs to load compositions for.
 
     Returns:
-        ``{supercategory_id: [SupercategoryComposition, ...]}``, omitting
+        ``{supercategory_id: [SupercategoryComposition, ...]}`` for every
+        super-category reachable from *category_ids*, omitting
         categories that compose nothing at any release.
     """
-    if not category_ids:
-        return {}
+    compositions: Dict[int, List[SupercategoryComposition]] = {}
+    pending = set(category_ids)
+    asked: Set[int] = set()
+    while pending:
+        asked |= pending
+        next_level: Set[int] = set()
+        for row in _composition_rows(session, pending):
+            compositions.setdefault(row.supercategory_id, []).append(row)
+            next_level.add(row.category_id)
+        # A member reached twice is queried once, so a cycle in the
+        # data terminates instead of looping.
+        pending = next_level - asked
+    return compositions
+
+
+def _composition_rows(
+    session: "Session",
+    supercategory_ids: Collection[int],
+) -> List[SupercategoryComposition]:
+    """Composition rows of *supercategory_ids*, one level, all windows."""
     member = aliased(Category)
     query = (
         session.query(SupercategoryComposition)
@@ -132,13 +157,9 @@ def load_supercategory_compositions(
         .filter(member.is_enumerated == True)  # noqa: E712
         .filter(member.code.isnot(None))
     )
-    rows = chunked_in(
-        query, SupercategoryComposition.supercategory_id, category_ids
+    return chunked_in(
+        query, SupercategoryComposition.supercategory_id, supercategory_ids
     )
-    compositions: Dict[int, List[SupercategoryComposition]] = {}
-    for row in rows:
-        compositions.setdefault(row.supercategory_id, []).append(row)
-    return compositions
 
 
 def domain_search_order(

--- a/src/dpmcore/orm/supercategories.py
+++ b/src/dpmcore/orm/supercategories.py
@@ -1,0 +1,273 @@
+"""Super-category expansion, shared by every domain-resolving path.
+
+A *super-category* is a ``Category`` whose value set is the union of its
+own items and the value sets of the categories composing it
+(``SuperCategoryComposition``). EBA's ``qTU`` ("qAI, qFI, qSR & qTA")
+holds a single item of its own and draws the other 926 from those four.
+``ItemCategory`` files each item under the one category that owns it, so
+any code that answers "which items does this domain hold?" by reading
+``ItemCategory`` alone sees only that single item (#359).
+
+Every such caller — the DPM-XL domain-membership check, the structure
+service's category/property/table enumerations, the layout exporter —
+needs the same expansion, so it lives here once rather than being
+reimplemented per call site with subtly different filters.
+
+Members are restricted to *enumerated* categories carrying a code: a
+non-enumerated category (dates, identifiers, free text) is not a value
+set, so it contributes no items to the domain.
+
+The composition is release-versioned and is resolved transitively: the
+EBA dictionary does not nest super-categories today (0 of 102
+composition rows names a member that is itself a super-category), but
+nothing in the schema forbids it, and a silently missing second level
+would drop items from enumerations and manufacture false domain
+warnings. The closure walk costs one extra query only when a member
+turns out to be a super-category, so honouring the general case is
+effectively free.
+"""
+
+from __future__ import annotations
+
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Collection,
+    Dict,
+    List,
+    Optional,
+    Set,
+    Tuple,
+)
+
+from sqlalchemy.orm import aliased
+
+from dpmcore.orm.glossary import Category, SupercategoryComposition
+from dpmcore.orm.query_utils import chunked_in
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+
+def load_supercategory_members(
+    session: "Session",
+    category_ids: Collection[int],
+    *,
+    release_id: Optional[int],
+) -> Dict[int, Set[int]]:
+    """Map super-category IDs to the IDs of the categories in them.
+
+    Args:
+        session: SQLAlchemy session.
+        category_ids: Category IDs to expand. One that composes nothing
+            at *release_id* gets no entry, so the result is also the
+            answer to "which of these are super-categories?".
+        release_id: Release the composition is resolved at; ``None``
+            resolves against the currently-open compositions.
+
+    Returns:
+        ``{supercategory_id: {member_category_id, ...}}``, transitively
+        expanded.
+    """
+    return _closure(session, category_ids, release_id, by_code=False)
+
+
+def load_supercategory_member_codes(
+    session: "Session",
+    codes: Collection[str],
+    *,
+    release_id: Optional[int],
+) -> Dict[str, Set[str]]:
+    """Map super-category codes to the codes of the categories in them.
+
+    Code-keyed twin of :func:`load_supercategory_members`, for callers
+    that resolve domains by ``Category.code`` rather than by ID.
+
+    Args:
+        session: SQLAlchemy session.
+        codes: Category codes to expand; a code that composes nothing at
+            *release_id* gets no entry.
+        release_id: Release the composition is resolved at.
+
+    Returns:
+        ``{supercategory_code: {member_code, ...}}``, transitively
+        expanded.
+    """
+    return _closure(session, codes, release_id, by_code=True)
+
+
+def load_supercategory_compositions(
+    session: "Session",
+    category_ids: Collection[int],
+) -> Dict[int, List[SupercategoryComposition]]:
+    """Composition rows for *category_ids*, every release window kept.
+
+    :func:`load_supercategory_members` answers "what composes this
+    domain *at one release*". A caller that walks releases in Python --
+    the structure service's virtual category versions, which emit a new
+    version whenever the item set changes -- needs each row's own
+    window instead, so the composition opening or closing shows up as a
+    version boundary like any other change.
+
+    Members are filtered the same way as everywhere else: an
+    enumerated category carrying a code.
+
+    Args:
+        session: SQLAlchemy session.
+        category_ids: Super-category IDs to load compositions for.
+
+    Returns:
+        ``{supercategory_id: [SupercategoryComposition, ...]}``, omitting
+        categories that compose nothing at any release.
+    """
+    if not category_ids:
+        return {}
+    member = aliased(Category)
+    query = (
+        session.query(SupercategoryComposition)
+        .join(
+            member,
+            member.category_id == SupercategoryComposition.category_id,
+        )
+        .filter(member.is_enumerated == True)  # noqa: E712
+        .filter(member.code.isnot(None))
+    )
+    rows = chunked_in(
+        query, SupercategoryComposition.supercategory_id, category_ids
+    )
+    compositions: Dict[int, List[SupercategoryComposition]] = {}
+    for row in rows:
+        compositions.setdefault(row.supercategory_id, []).append(row)
+    return compositions
+
+
+def domain_search_order(
+    category_id: int,
+    members: Dict[int, Set[int]],
+) -> List[int]:
+    """Categories to look an item up in for a domain, best first.
+
+    The domain's own category comes first — an item filed there is the
+    domain's own item and names itself with the domain's code — then the
+    categories composing it, ascending by ID. Thirteen (super-category,
+    item) pairs in DPM 4.2.1 have the item filed in two members at once,
+    so a fixed order is what makes their code and signature
+    reproducible. Ordering by ID alone would not do: EBA's ``qTU``
+    (1111) outranks every category composing it (1007..1037), so the
+    domain's own item would lose to a member's.
+
+    Args:
+        category_id: The domain.
+        members: ``{supercategory_id: {member_id, ...}}``, as returned
+            by :func:`load_supercategory_members`.
+
+    Returns:
+        The category IDs to search, in order.
+    """
+    return [category_id, *sorted(members.get(category_id, set()))]
+
+
+def _closure(
+    session: "Session",
+    keys: Collection[Any],
+    release_id: Optional[int],
+    *,
+    by_code: bool,
+) -> Dict[Any, Set[Any]]:
+    """Transitively expand *keys* over the composition graph.
+
+    Walks level by level, querying only the keys not yet resolved, then
+    flattens each requested key's reachable set. A key reached twice is
+    queried once, so a cycle in the data terminates instead of looping.
+    """
+    edges: Dict[Any, Set[Any]] = {}
+    pending = set(keys)
+    while pending:
+        found = _direct_members(session, pending, release_id, by_code=by_code)
+        # Record every key asked about, so one that composes nothing is
+        # not asked about again on a later level.
+        for key in pending:
+            edges[key] = found.get(key, set())
+        next_level: Set[Any] = set()
+        for members in found.values():
+            next_level |= members
+        pending = next_level - set(edges)
+    expanded: Dict[Any, Set[Any]] = {}
+    for key in keys:
+        reachable = _reachable(edges, key)
+        if reachable:
+            expanded[key] = reachable
+    return expanded
+
+
+def _reachable(edges: Dict[Any, Set[Any]], key: Any) -> Set[Any]:
+    """Every key reachable from *key*, excluding *key* itself."""
+    seen: Set[Any] = set()
+    frontier = set(edges.get(key, set()))
+    while frontier:
+        member = frontier.pop()
+        if member in seen:
+            continue
+        seen.add(member)
+        frontier |= edges.get(member, set()) - seen
+    seen.discard(key)
+    return seen
+
+
+def _direct_members(
+    session: "Session",
+    keys: Collection[Any],
+    release_id: Optional[int],
+    *,
+    by_code: bool,
+) -> Dict[Any, Set[Any]]:
+    """One level of composition for *keys*, keyed by code or by ID."""
+    if not keys:
+        return {}
+
+    from dpmcore.dpm_xl.utils.filters import filter_by_release
+
+    supercategory = aliased(Category)
+    member = aliased(Category)
+    key_col, member_col = _key_columns(supercategory, member, by_code=by_code)
+    query = (
+        session.query(
+            key_col.label("SuperKey"),
+            member_col.label("MemberKey"),
+        )
+        .select_from(SupercategoryComposition)
+        .join(
+            supercategory,
+            supercategory.category_id
+            == SupercategoryComposition.supercategory_id,
+        )
+        .join(
+            member,
+            member.category_id == SupercategoryComposition.category_id,
+        )
+        .filter(member.is_enumerated == True)  # noqa: E712
+        .filter(member.code.isnot(None))
+    )
+    query = filter_by_release(
+        query,
+        start_col=SupercategoryComposition.start_release_id,
+        end_col=SupercategoryComposition.end_release_id,
+        release_id=release_id,
+        active_only_fallback=True,
+    )
+    members: Dict[Any, Set[Any]] = {}
+    for row in chunked_in(query, key_col, keys):
+        members.setdefault(row.SuperKey, set()).add(row.MemberKey)
+    return members
+
+
+def _key_columns(
+    supercategory: Any, member: Any, *, by_code: bool
+) -> Tuple[Any, Any]:
+    """The (super-category, member) columns the result is keyed on."""
+    if by_code:
+        return supercategory.code, member.code
+    return (
+        SupercategoryComposition.supercategory_id,
+        SupercategoryComposition.category_id,
+    )

--- a/src/dpmcore/services/layout_exporter/queries.py
+++ b/src/dpmcore/services/layout_exporter/queries.py
@@ -196,24 +196,48 @@ def _load_member_codes(
     session: Session,
     item_ids: set[int],
     domain_category_ids: set[int],
-) -> dict[int, str]:
-    """Load MemberCode for member items.
+) -> dict[tuple[int, int], str]:
+    """Load MemberCode for member items, per domain.
 
-    MemberCode = ItemCategory.Code where CategoryID matches the domain.
+    MemberCode = ItemCategory.Code where CategoryID matches the domain
+    the dimension is typed on — or, when that domain is a
+    *super-category*, one of the categories composing it, which is
+    where ``ItemCategory`` actually files the member (#359).
 
-    Returns {item_id: member_code}.
+    Keyed by ``(item_id, domain_category_id)`` rather than by item
+    alone: the export spans many domains at once, and the same item can
+    be filed in two of them, so a per-item key silently hands one
+    domain's code to another domain's member.
+
+    Returns {(item_id, domain_category_id): member_code}.
     """
     if not item_ids or not domain_category_ids:
         return {}
 
     from dpmcore.orm.glossary import ItemCategory
+    from dpmcore.orm.supercategories import (
+        domain_search_order,
+        load_supercategory_members,
+    )
 
-    # Match the domain in Python rather than via a second ``IN (...)`` so
-    # the chunked statement binds only the item-id batch (plus the
-    # release filter) and never approaches SQL Server's 2,100-parameter
-    # cap, however many domains the export spans. ``category_id`` is
-    # already selected, so this is the same predicate moved off SQL.
-    domain = set(domain_category_ids)
+    members_by_domain = load_supercategory_members(
+        session, domain_category_ids, release_id=None
+    )
+    # Which domains a filing category can answer for: itself, plus every
+    # super-category that composes it.
+    domains_by_filing: dict[int, set[int]] = {
+        domain: {domain} for domain in domain_category_ids
+    }
+    for domain, members in members_by_domain.items():
+        for member in members:
+            domains_by_filing.setdefault(member, set()).add(domain)
+
+    # Match the filing category in Python rather than via a second
+    # ``IN (...)`` so the chunked statement binds only the item-id batch
+    # (plus the release filter) and never approaches SQL Server's
+    # 2,100-parameter cap, however many domains the export spans.
+    # ``category_id`` is already selected, so this is the same predicate
+    # moved off SQL.
     base = (
         session.query(
             ItemCategory.item_id,
@@ -221,18 +245,34 @@ def _load_member_codes(
             ItemCategory.category_id,
         )
         .filter(ItemCategory.end_release_id.is_(None))
-        # When an item has several in-domain rows the dict's last write
-        # wins, so order to make that winner deterministic (highest
-        # ``(category_id, code)``). This holds under chunking because
-        # each item_id is queried in exactly one batch (the chunk column
-        # is item_id): all of an item's rows land in that one batch's
-        # ordered result, so the ORDER BY puts the item's highest row
-        # last. Cross-batch order is irrelevant since no item spans
-        # batches.
+        # Two open rows for one item in the same category (successive
+        # start releases) resolve to the lowest code, deterministically.
+        # This holds under chunking because each item_id is queried in
+        # exactly one batch (the chunk column is item_id), so all of an
+        # item's rows land in that one ordered result.
         .order_by(ItemCategory.category_id, ItemCategory.code)
     )
-    rows = chunked_in(base, ItemCategory.item_id, item_ids)
-    return {r[0]: r[1] for r in rows if r[1] and r[2] in domain}
+    filed_by_item: dict[int, dict[int, str]] = {}
+    for item_id, code, category_id in chunked_in(
+        base, ItemCategory.item_id, item_ids
+    ):
+        if code:
+            filed_by_item.setdefault(item_id, {}).setdefault(category_id, code)
+
+    codes: dict[tuple[int, int], str] = {}
+    for item_id, filed in filed_by_item.items():
+        candidates = {
+            domain
+            for category_id in filed
+            for domain in domains_by_filing.get(category_id, ())
+        }
+        for domain in candidates:
+            for category_id in domain_search_order(domain, members_by_domain):
+                code = filed.get(category_id)
+                if code is not None:
+                    codes[(item_id, domain)] = code
+                    break
+    return codes
 
 
 # ------------------------------------------------------------------ #
@@ -323,7 +363,11 @@ def load_categorisations(
             dimension_code=dim_codes.get(row[1], ""),
             domain_code=row[5] or "",
             member_label=row[4] or "",
-            member_code=member_codes.get(row[3], "") if row[3] else "",
+            member_code=(
+                member_codes.get((row[3], row[7]), "")
+                if row[3] and row[7]
+                else ""
+            ),
             data_type_code=row[6] or "",
         )
         result.setdefault(ctx_id, []).append(dm)
@@ -477,7 +521,11 @@ def load_dp_categorisations(
             dimension_code=dim_codes.get(row[1], ""),
             domain_code=row[5] or "",
             member_label=row[3] or "" if not row[4] else row[4],
-            member_code=member_codes.get(row[3], "") if row[3] else "",
+            member_code=(
+                member_codes.get((row[3], row[7]), "")
+                if row[3] and row[7]
+                else ""
+            ),
             data_type_code=row[6] or "",
         )
         result.setdefault(vvid, []).append(dm)

--- a/src/dpmcore/services/structure.py
+++ b/src/dpmcore/services/structure.py
@@ -415,10 +415,16 @@ class StructureService:
         changes the item set exactly like an ItemCategory row does
         (#359).
 
+        The compositions come back as the whole reachable graph, so a
+        super-category composing another one contributes that one's
+        members too; which links are open is decided per release by
+        :meth:`_alive_composed_members`.
+
         Returns:
             (ics_by_cat, items_by_id, compositions_by_cat) —
             ItemCategory rows grouped by category_id, Item rows keyed by
-            item_id, and each super-category's composition rows.
+            item_id, and the composition rows of every super-category
+            reached.
         """
         compositions_by_cat = load_supercategory_compositions(
             self.session, cat_ids
@@ -451,27 +457,52 @@ class StructureService:
 
         return dict(ics_by_cat), items_by_id, compositions_by_cat
 
+    def _alive_composed_members(
+        self,
+        compositions_by_cat: Dict[int, List[SupercategoryComposition]],
+        category_id: int,
+        release_id: int,
+    ) -> set[int]:
+        """Categories whose items belong to *category_id* at a release.
+
+        Walks the composition graph, so a super-category composing
+        another one also draws that one's members. Every link on the
+        way has to be open at *release_id*: a closed composition cuts
+        off everything behind it. A category already reached is not
+        walked twice, so a cycle in the data terminates.
+        """
+        reached: set[int] = {category_id}
+        frontier = [category_id]
+        while frontier:
+            for c in compositions_by_cat.get(frontier.pop(), []):
+                if c.category_id in reached:
+                    continue
+                if not self._window_alive(
+                    c.start_release_id, c.end_release_id, release_id
+                ):
+                    continue
+                reached.add(c.category_id)
+                frontier.append(c.category_id)
+        return reached - {category_id}
+
     def _alive_item_categories(
         self,
         ics_by_cat: Dict[int, List[ItemCategory]],
         category_id: int,
-        compositions: List[SupercategoryComposition],
+        compositions_by_cat: Dict[int, List[SupercategoryComposition]],
         release_id: int,
     ) -> List[ItemCategory]:
         """ItemCategory rows making up a domain's value set at a release.
 
         The category's own rows, then those of every category composing
-        it whose composition is open at *release_id*. An item filed in
-        two of them is named by the first — see
+        it — directly or through another super-category — whose
+        compositions are open at *release_id*. An item filed in two of
+        them is named by the first — see
         :func:`~dpmcore.orm.supercategories.domain_search_order`.
         """
-        alive_members = {
-            c.category_id
-            for c in compositions
-            if self._window_alive(
-                c.start_release_id, c.end_release_id, release_id
-            )
-        }
+        alive_members = self._alive_composed_members(
+            compositions_by_cat, category_id, release_id
+        )
         seen: set[int] = set()
         alive: List[ItemCategory] = []
         for cat_id in domain_search_order(
@@ -493,7 +524,7 @@ class StructureService:
         category: Category,
         releases: List[Release],
         ics_by_cat: Dict[int, List[ItemCategory]],
-        compositions: List[SupercategoryComposition],
+        compositions_by_cat: Dict[int, List[SupercategoryComposition]],
         items_by_id: Dict[int, Item],
         detail: str,
         owner_acronym: Optional[str],
@@ -525,7 +556,7 @@ class StructureService:
             alive_ics = self._alive_item_categories(
                 ics_by_cat,
                 category.category_id,
-                compositions,
+                compositions_by_cat,
                 rel.release_id,
             )
 
@@ -611,7 +642,7 @@ class StructureService:
                 cat,
                 releases,
                 ics_by_cat,
-                compositions_by_cat.get(cat.category_id, []),
+                compositions_by_cat,
                 items_by_id,
                 detail,
                 owner_acronym,

--- a/src/dpmcore/services/structure.py
+++ b/src/dpmcore/services/structure.py
@@ -28,6 +28,7 @@ from dpmcore.orm.glossary import (
     SubCategory,
     SubCategoryItem,
     SubCategoryVersion,
+    SupercategoryComposition,
 )
 from dpmcore.orm.infrastructure import (
     Concept,
@@ -990,6 +991,41 @@ class StructureService:
         rows = chunked_in(base, Item.item_id, property_ids)
         return {r[0]: r[1] for r in rows}
 
+    def _load_supercategory_members(
+        self,
+        category_ids: set[int],
+        *,
+        release_id: Optional[int],
+    ) -> Dict[int, set[int]]:
+        """Return ``{supercategory_id: {member_category_id, ...}}``.
+
+        A super-category is a domain whose value set is the union of the
+        value sets of the categories composing it (EBA's ``qTU``, "qAI,
+        qFI, qSR & qTA", holds one item of its own and draws the rest
+        from those four). ``category_ids`` that compose nothing at
+        *release_id* get no entry. The dictionary nests super-categories
+        no deeper than one level, so members are not expanded again.
+        """
+        if not category_ids:
+            return {}
+
+        from dpmcore.dpm_xl.utils.filters import filter_by_release
+
+        base = filter_by_release(
+            self.session.query(SupercategoryComposition),
+            start_col=SupercategoryComposition.start_release_id,
+            end_col=SupercategoryComposition.end_release_id,
+            release_id=release_id,
+            active_only_fallback=True,
+        )
+        rows = chunked_in(
+            base, SupercategoryComposition.supercategory_id, category_ids
+        )
+        members: Dict[int, set[int]] = defaultdict(set)
+        for row in rows:
+            members[row.supercategory_id].add(row.category_id)
+        return dict(members)
+
     def _load_subcategory_enumerations(
         self,
         subcategory_vids: set[int],
@@ -1005,6 +1041,11 @@ class StructureService:
         ``code``/``signature`` from the :class:`ItemCategory` rows
         valid at *release_id*. Items lacking an ItemCategory entry at
         the release are dropped (they have no code at that release).
+
+        When the parent Category is a *super-category* its items are
+        filed under the categories composing it, not under the
+        super-category itself, so those are searched too — the parent
+        first, then its members in ``category_id`` order.
         """
         if not subcategory_vids:
             return {}
@@ -1046,12 +1087,20 @@ class StructureService:
             items_by_subcat[si.subcategory_vid].append((si, item))
 
         # ItemCategory at release window — gives code/signature per
-        # (item_id, parent_category_id).
+        # (item_id, category_id). A super-category parent contributes
+        # the categories composing it as well, since that is where its
+        # items are actually filed.
         parent_cat_ids = {
             cat.category_id for (_sv, _sc, cat) in subcat_info.values()
         }
+        members_by_parent = self._load_supercategory_members(
+            parent_cat_ids, release_id=release_id
+        )
+        lookup_cat_ids = set(parent_cat_ids)
+        for member_ids in members_by_parent.values():
+            lookup_cat_ids.update(member_ids)
         item_codes: Dict[Tuple[int, int], ItemCategory] = {}
-        if parent_cat_ids:
+        if lookup_cat_ids:
             ic_q = self.session.query(ItemCategory)
             ic_q = filter_by_release(
                 ic_q,
@@ -1061,18 +1110,27 @@ class StructureService:
                 active_only_fallback=True,
             )
             for ic in chunked_in(
-                ic_q, ItemCategory.category_id, parent_cat_ids
+                ic_q, ItemCategory.category_id, lookup_cat_ids
             ):
                 item_codes[(ic.item_id, ic.category_id)] = ic
 
         result: Dict[int, Dict[str, Any]] = {}
         for svid, (_sv, sc, cat) in subcat_info.items():
             items_payload: List[Dict[str, Any]] = []
+            # Parent first, then its members in a fixed order, so an item
+            # filed in more than one of them resolves the same way twice.
+            search_cat_ids = [
+                cat.category_id,
+                *sorted(members_by_parent.get(cat.category_id, set())),
+            ]
             for si, item in items_by_subcat.get(svid, []):
-                ic = item_codes.get((item.item_id, cat.category_id))
+                ic = _first_item_category(
+                    item_codes, item.item_id, search_cat_ids
+                )
                 if ic is None:
                     # Item has no ItemCategory in the parent category
-                    # at this release — skip; no code to surface.
+                    # (nor, for a super-category, in its members) at
+                    # this release — skip; no code to surface.
                     continue
                 items_payload.append(
                     {
@@ -3139,6 +3197,23 @@ def _collect_subcategory_vids_per_variable(
                 out[tvc.variable_vid].add(matched.subcategory_vid)
 
     return out
+
+
+def _first_item_category(
+    item_codes: Dict[Tuple[int, int], ItemCategory],
+    item_id: int,
+    category_ids: List[int],
+) -> Optional[ItemCategory]:
+    """Return the item's ItemCategory row in the first category holding it.
+
+    ``category_ids`` is searched in order, so the caller decides which
+    category names the item when several do.
+    """
+    for category_id in category_ids:
+        found = item_codes.get((item_id, category_id))
+        if found is not None:
+            return found
+    return None
 
 
 def _table_stub_to_dict(

--- a/src/dpmcore/services/structure.py
+++ b/src/dpmcore/services/structure.py
@@ -65,6 +65,11 @@ from dpmcore.orm.rendering import (
     TableVersionCell,
     TableVersionHeader,
 )
+from dpmcore.orm.supercategories import (
+    domain_search_order,
+    load_supercategory_compositions,
+    load_supercategory_members,
+)
 from dpmcore.orm.variables import CompoundKey, Variable, VariableVersion
 from dpmcore.server.params import StructureParams
 
@@ -215,7 +220,7 @@ class StructureService:
 
     def _window_alive(
         self,
-        start_release_id: int,
+        start_release_id: Optional[int],
         end_release_id: Optional[int],
         target_release_id: int,
     ) -> bool:
@@ -225,14 +230,18 @@ class StructureService:
         opaque ``release_id`` FK. The end bound is **inclusive** — the
         convention the category/context virtual-versioning walks have
         always used (this intentionally differs from
-        ``filter_by_release``'s exclusive end). Returns ``False`` only
-        for a release_id absent from the release set (orphan FK); an
-        undated release ranks as the latest.
+        ``filter_by_release``'s exclusive end). A missing start bound
+        means the row has always been open, mirroring the missing end
+        bound. Returns ``False`` only for a release_id absent from the
+        release set (orphan FK); an undated release ranks as the latest.
         """
         target_so = self._sort_order(target_release_id)
-        start_so = self._sort_order(start_release_id)
-        if target_so is None or start_so is None or start_so > target_so:
+        if target_so is None:
             return False
+        if start_release_id is not None:
+            start_so = self._sort_order(start_release_id)
+            if start_so is None or start_so > target_so:
+                return False
         if end_release_id is None:
             return True
         end_so = self._sort_order(end_release_id)
@@ -395,17 +404,32 @@ class StructureService:
     ) -> Tuple[
         Dict[int, List[ItemCategory]],
         Dict[int, Item],
+        Dict[int, List[SupercategoryComposition]],
     ]:
         """Bulk-load ItemCategory and Item rows for given categories.
 
+        A *super-category* files its value set under the categories
+        composing it, so those are loaded too and the compositions are
+        returned with their own release windows: versions are computed
+        per release in Python, and a composition opening or closing
+        changes the item set exactly like an ItemCategory row does
+        (#359).
+
         Returns:
-            (ics_by_cat, items_by_id) — ItemCategory rows grouped by
-            category_id and Item rows keyed by item_id.
+            (ics_by_cat, items_by_id, compositions_by_cat) —
+            ItemCategory rows grouped by category_id, Item rows keyed by
+            item_id, and each super-category's composition rows.
         """
+        compositions_by_cat = load_supercategory_compositions(
+            self.session, cat_ids
+        )
+        lookup_cat_ids = set(cat_ids)
+        for compositions in compositions_by_cat.values():
+            lookup_cat_ids.update(c.category_id for c in compositions)
         ics = chunked_in(
             self.session.query(ItemCategory),
             ItemCategory.category_id,
-            cat_ids,
+            lookup_cat_ids,
         )
 
         ics_by_cat: Dict[int, List[ItemCategory]] = defaultdict(
@@ -425,13 +449,51 @@ class StructureService:
             )
             items_by_id = {i.item_id: i for i in items}
 
-        return dict(ics_by_cat), items_by_id
+        return dict(ics_by_cat), items_by_id, compositions_by_cat
+
+    def _alive_item_categories(
+        self,
+        ics_by_cat: Dict[int, List[ItemCategory]],
+        category_id: int,
+        compositions: List[SupercategoryComposition],
+        release_id: int,
+    ) -> List[ItemCategory]:
+        """ItemCategory rows making up a domain's value set at a release.
+
+        The category's own rows, then those of every category composing
+        it whose composition is open at *release_id*. An item filed in
+        two of them is named by the first — see
+        :func:`~dpmcore.orm.supercategories.domain_search_order`.
+        """
+        alive_members = {
+            c.category_id
+            for c in compositions
+            if self._window_alive(
+                c.start_release_id, c.end_release_id, release_id
+            )
+        }
+        seen: set[int] = set()
+        alive: List[ItemCategory] = []
+        for cat_id in domain_search_order(
+            category_id, {category_id: alive_members}
+        ):
+            for ic in ics_by_cat.get(cat_id, []):
+                if ic.item_id in seen:
+                    continue
+                if not self._window_alive(
+                    ic.start_release_id, ic.end_release_id, release_id
+                ):
+                    continue
+                seen.add(ic.item_id)
+                alive.append(ic)
+        return alive
 
     def _compute_category_versions(
         self,
         category: Category,
         releases: List[Release],
-        ics: List[ItemCategory],
+        ics_by_cat: Dict[int, List[ItemCategory]],
+        compositions: List[SupercategoryComposition],
         items_by_id: Dict[int, Item],
         detail: str,
         owner_acronym: Optional[str],
@@ -439,7 +501,9 @@ class StructureService:
         """Compute virtual versions for a single category.
 
         A new version is emitted only when the set of alive items
-        (fingerprint) changes between consecutive releases.
+        (fingerprint) changes between consecutive releases — including
+        when that set changes because a super-category's composition
+        opened or closed.
 
         Returns:
             List of (release, category_dict) tuples — one per version.
@@ -458,13 +522,12 @@ class StructureService:
             ):
                 continue
 
-            alive_ics = [
-                ic
-                for ic in ics
-                if self._window_alive(
-                    ic.start_release_id, ic.end_release_id, rel.release_id
-                )
-            ]
+            alive_ics = self._alive_item_categories(
+                ics_by_cat,
+                category.category_id,
+                compositions,
+                rel.release_id,
+            )
 
             fingerprint = frozenset(
                 (
@@ -532,6 +595,7 @@ class StructureService:
         cats: List[Category],
         releases: List[Release],
         ics_by_cat: Dict[int, List[ItemCategory]],
+        compositions_by_cat: Dict[int, List[SupercategoryComposition]],
         items_by_id: Dict[int, Item],
         detail: str,
         params: StructureParams,
@@ -543,11 +607,11 @@ class StructureService:
             owner_acronym = self._get_owner_acronym(
                 cat.owner_id,
             )
-            cat_ics = ics_by_cat.get(cat.category_id, [])
             versions = self._compute_category_versions(
                 cat,
                 releases,
-                cat_ics,
+                ics_by_cat,
+                compositions_by_cat.get(cat.category_id, []),
                 items_by_id,
                 detail,
                 owner_acronym,
@@ -623,8 +687,8 @@ class StructureService:
 
         # Bulk load ItemCategory + Item data
         cat_ids = [c.category_id for c in cats]
-        ics_by_cat, items_by_id = self._bulk_load_category_data(
-            cat_ids,
+        ics_by_cat, items_by_id, compositions_by_cat = (
+            self._bulk_load_category_data(cat_ids)
         )
 
         # Compute virtual versions for each category
@@ -632,6 +696,7 @@ class StructureService:
             cats,
             releases,
             ics_by_cat,
+            compositions_by_cat,
             items_by_id,
             detail,
             params,
@@ -991,40 +1056,51 @@ class StructureService:
         rows = chunked_in(base, Item.item_id, property_ids)
         return {r[0]: r[1] for r in rows}
 
-    def _load_supercategory_members(
+    def _load_item_categories(
         self,
+        item_ids: set[int],
         category_ids: set[int],
         *,
         release_id: Optional[int],
-    ) -> Dict[int, set[int]]:
-        """Return ``{supercategory_id: {member_category_id, ...}}``.
+    ) -> Dict[Tuple[int, int], ItemCategory]:
+        """Load ``{(item_id, category_id): ItemCategory}`` at a release.
 
-        A super-category is a domain whose value set is the union of the
-        value sets of the categories composing it (EBA's ``qTU``, "qAI,
-        qFI, qSR & qTA", holds one item of its own and draws the rest
-        from those four). ``category_ids`` that compose nothing at
-        *release_id* get no entry. The dictionary nests super-categories
-        no deeper than one level, so members are not expanded again.
+        Chunked on ``item_id`` and filtered on the category in Python:
+        the caller already knows exactly which items it needs, while a
+        super-category's member domains hold hundreds it does not, so
+        binding the categories instead would load — and throw away —
+        the whole of each member domain.
         """
-        if not category_ids:
+        if not item_ids or not category_ids:
             return {}
 
         from dpmcore.dpm_xl.utils.filters import filter_by_release
 
-        base = filter_by_release(
-            self.session.query(SupercategoryComposition),
-            start_col=SupercategoryComposition.start_release_id,
-            end_col=SupercategoryComposition.end_release_id,
+        ic_q = filter_by_release(
+            self.session.query(ItemCategory),
+            start_col=ItemCategory.start_release_id,
+            end_col=ItemCategory.end_release_id,
             release_id=release_id,
             active_only_fallback=True,
         )
+        return {
+            (ic.item_id, ic.category_id): ic
+            for ic in chunked_in(ic_q, ItemCategory.item_id, item_ids)
+            if ic.category_id in category_ids
+        }
+
+    def _load_category_codes(
+        self, category_ids: set[int]
+    ) -> Dict[int, Optional[str]]:
+        """Resolve ``{category_id: Category.code}``."""
+        if not category_ids:
+            return {}
         rows = chunked_in(
-            base, SupercategoryComposition.supercategory_id, category_ids
+            self.session.query(Category.category_id, Category.code),
+            Category.category_id,
+            category_ids,
         )
-        members: Dict[int, set[int]] = defaultdict(set)
-        for row in rows:
-            members[row.supercategory_id].add(row.category_id)
-        return dict(members)
+        return {r[0]: r[1] for r in rows}
 
     def _load_subcategory_enumerations(
         self,
@@ -1044,13 +1120,12 @@ class StructureService:
 
         When the parent Category is a *super-category* its items are
         filed under the categories composing it, not under the
-        super-category itself, so those are searched too — the parent
-        first, then its members in ``category_id`` order.
+        super-category itself, so those are searched too — see
+        :func:`_first_item_category` for which one names the item when
+        more than one holds it.
         """
         if not subcategory_vids:
             return {}
-
-        from dpmcore.dpm_xl.utils.filters import filter_by_release
 
         # SubCategoryVersion → SubCategory → parent Category.
         info_base = (
@@ -1093,36 +1168,34 @@ class StructureService:
         parent_cat_ids = {
             cat.category_id for (_sv, _sc, cat) in subcat_info.values()
         }
-        members_by_parent = self._load_supercategory_members(
-            parent_cat_ids, release_id=release_id
+        members_by_parent = load_supercategory_members(
+            self.session, parent_cat_ids, release_id=release_id
         )
         lookup_cat_ids = set(parent_cat_ids)
         for member_ids in members_by_parent.values():
             lookup_cat_ids.update(member_ids)
-        item_codes: Dict[Tuple[int, int], ItemCategory] = {}
-        if lookup_cat_ids:
-            ic_q = self.session.query(ItemCategory)
-            ic_q = filter_by_release(
-                ic_q,
-                start_col=ItemCategory.start_release_id,
-                end_col=ItemCategory.end_release_id,
-                release_id=release_id,
-                active_only_fallback=True,
-            )
-            for ic in chunked_in(
-                ic_q, ItemCategory.category_id, lookup_cat_ids
-            ):
-                item_codes[(ic.item_id, ic.category_id)] = ic
+        wanted_item_ids = {
+            item.item_id
+            for rows in items_by_subcat.values()
+            for _si, item in rows
+        }
+        item_codes = self._load_item_categories(
+            wanted_item_ids, lookup_cat_ids, release_id=release_id
+        )
+        category_codes = {
+            cat.category_id: cat.code
+            for (_sv, _sc, cat) in subcat_info.values()
+        }
+        category_codes.update(
+            self._load_category_codes(lookup_cat_ids - set(category_codes))
+        )
 
         result: Dict[int, Dict[str, Any]] = {}
         for svid, (_sv, sc, cat) in subcat_info.items():
             items_payload: List[Dict[str, Any]] = []
-            # Parent first, then its members in a fixed order, so an item
-            # filed in more than one of them resolves the same way twice.
-            search_cat_ids = [
-                cat.category_id,
-                *sorted(members_by_parent.get(cat.category_id, set())),
-            ]
+            search_cat_ids = domain_search_order(
+                cat.category_id, members_by_parent
+            )
             for si, item in items_by_subcat.get(svid, []):
                 ic = _first_item_category(
                     item_codes, item.item_id, search_cat_ids
@@ -1139,6 +1212,15 @@ class StructureService:
                         "code": ic.code,
                         "signature": ic.signature,
                         "isDefaultItem": ic.is_default_item,
+                        # Which category files the item — the parent for
+                        # an ordinary domain, one of the composing
+                        # categories for a super-category, so a consumer
+                        # never has to guess the signature's prefix from
+                        # the enumeration's own ``categoryCode``.
+                        "categoryId": ic.category_id,
+                        "categoryCode": _category_code(
+                            category_codes, ic.category_id
+                        ),
                         "subcategoryLabel": si.label,
                         "order": si.order,
                     }
@@ -2639,7 +2721,12 @@ class StructureService:
         The enumeration members are that Category's
         :class:`ItemCategory` rows valid at the same release. Each
         member carries ``code`` + ``signature`` from its
-        ItemCategory entry.
+        ItemCategory entry, plus the category that files it.
+
+        A *super-category* files almost none of its value set under
+        itself — EBA's ``qTU`` holds 1 of its 927 items and the rest sit
+        under ``qAI``, ``qFI``, ``qSR`` and ``qTA`` — so the categories
+        composing it are enumerated too (#359).
         """
         if not property_ids:
             return {}
@@ -2676,6 +2763,12 @@ class StructureService:
         category_ids = {
             cat.category_id for cat in enum_category_by_property.values()
         }
+        members_by_parent = load_supercategory_members(
+            self.session, category_ids, release_id=release_id
+        )
+        lookup_cat_ids = set(category_ids)
+        for member_ids in members_by_parent.values():
+            lookup_cat_ids.update(member_ids)
         ic_q = self.session.query(ItemCategory, Item).join(
             Item, Item.item_id == ItemCategory.item_id
         )
@@ -2690,9 +2783,16 @@ class StructureService:
             defaultdict(list)
         )
         for ic, item in chunked_in(
-            ic_q, ItemCategory.category_id, category_ids
+            ic_q, ItemCategory.category_id, lookup_cat_ids
         ):
             items_by_category[ic.category_id].append((ic, item))
+        category_codes = {
+            cat.category_id: cat.code
+            for cat in enum_category_by_property.values()
+        }
+        category_codes.update(
+            self._load_category_codes(lookup_cat_ids - set(category_codes))
+        )
 
         result: Dict[int, Dict[str, Any]] = {}
         for property_id, cat in enum_category_by_property.items():
@@ -2707,8 +2807,17 @@ class StructureService:
                         "code": ic.code,
                         "signature": ic.signature,
                         "isDefaultItem": ic.is_default_item,
+                        "categoryId": ic.category_id,
+                        "categoryCode": _category_code(
+                            category_codes, ic.category_id
+                        ),
                     }
-                    for ic, item in items_by_category.get(cat.category_id, [])
+                    for ic, item in _domain_items(
+                        items_by_category,
+                        domain_search_order(
+                            cat.category_id, members_by_parent
+                        ),
+                    )
                 ],
             }
         return result
@@ -3199,6 +3308,37 @@ def _collect_subcategory_vids_per_variable(
     return out
 
 
+def _category_code(
+    category_codes: Dict[int, Optional[str]],
+    category_id: Optional[int],
+) -> Optional[str]:
+    """Code of the category filing an item, if it has one."""
+    if category_id is None:
+        return None
+    return category_codes.get(category_id)
+
+
+def _domain_items(
+    items_by_category: Dict[int, List[Tuple[ItemCategory, Item]]],
+    category_ids: List[int],
+) -> List[Tuple[ItemCategory, Item]]:
+    """Every item of a domain, own category first then its members.
+
+    An item filed in more than one of them appears once, named by the
+    first category in *category_ids* that holds it — the same rule
+    :func:`_first_item_category` applies.
+    """
+    seen: set[int] = set()
+    items: List[Tuple[ItemCategory, Item]] = []
+    for category_id in category_ids:
+        for ic, item in items_by_category.get(category_id, []):
+            if ic.item_id in seen:
+                continue
+            seen.add(ic.item_id)
+            items.append((ic, item))
+    return items
+
+
 def _first_item_category(
     item_codes: Dict[Tuple[int, int], ItemCategory],
     item_id: int,
@@ -3206,8 +3346,9 @@ def _first_item_category(
 ) -> Optional[ItemCategory]:
     """Return the item's ItemCategory row in the first category holding it.
 
-    ``category_ids`` is searched in order, so the caller decides which
-    category names the item when several do.
+    ``category_ids`` is searched in order — see
+    :func:`domain_search_order` — so an item several categories hold
+    resolves the same way every time.
     """
     for category_id in category_ids:
         found = item_codes.get((item_id, category_id))

--- a/tests/integration/services/layout_exporter/test_queries.py
+++ b/tests/integration/services/layout_exporter/test_queries.py
@@ -158,7 +158,7 @@ def test_load_member_codes_populated(memory_session):
     )
     memory_session.commit()
     out = queries._load_member_codes(memory_session, {500}, {20})
-    assert out == {500: "m1"}
+    assert out == {(500, 20): "m1"}
 
 
 def test_load_member_codes_out_of_domain_filtered(memory_session):
@@ -181,19 +181,19 @@ def test_load_member_codes_out_of_domain_filtered(memory_session):
     memory_session.commit()
     # 99 is not in the requested domain set, so 501 is filtered in Python.
     out = queries._load_member_codes(memory_session, {500, 501}, {20})
-    assert out == {500: "keep"}
+    assert out == {(500, 20): "keep"}
 
 
-def test_load_member_codes_multiple_domains_deterministic(memory_session):
-    """An item in several in-domain categories resolves deterministically.
+def test_load_member_codes_are_per_domain(memory_session):
+    """An item filed in two of the export's domains answers for each.
 
-    The highest ``(category_id, code)`` wins last-write-wins, regardless
-    of the backend's physical row order.
+    A per-item key would hand one domain the other's code; the result is
+    keyed by ``(item_id, domain_category_id)`` so each dimension gets
+    the code its own domain files (#359).
     """
     from dpmcore.orm.glossary import ItemCategory
 
     seed_releases(memory_session)
-    # One item categorised under two domains the export spans.
     make_member(
         memory_session,
         item_id=500,
@@ -212,7 +212,77 @@ def test_load_member_codes_multiple_domains_deterministic(memory_session):
     )
     memory_session.commit()
     out = queries._load_member_codes(memory_session, {500}, {20, 21})
-    assert out == {500: "bbb"}
+    assert out == {(500, 20): "aaa", (500, 21): "bbb"}
+
+
+def test_load_member_codes_reach_a_super_categorys_members(memory_session):
+    """A super-category files its value set under what composes it."""
+    from dpmcore.orm.glossary import Category, SupercategoryComposition
+
+    seed_releases(memory_session)
+    seed_domain_category(memory_session, 20, "SUPER")
+    # Only an enumerated member is a value set, so say so explicitly —
+    # seed_domain_category leaves the flag unset.
+    memory_session.add(
+        Category(
+            category_id=21, code="MEMBER", name="MEMBER", is_enumerated=True
+        )
+    )
+    make_member(
+        memory_session,
+        item_id=500,
+        name="FiledInTheMember",
+        domain_category_id=21,
+        code="m1",
+    )
+    memory_session.add(
+        SupercategoryComposition(supercategory_id=20, category_id=21)
+    )
+    memory_session.commit()
+
+    out = queries._load_member_codes(memory_session, {500}, {20})
+
+    assert out == {(500, 20): "m1"}
+
+
+def test_load_member_codes_prefer_the_domains_own_category(memory_session):
+    """Filed in both the super-category and a member: the domain wins."""
+    from dpmcore.orm.glossary import (
+        Category,
+        ItemCategory,
+        SupercategoryComposition,
+    )
+
+    seed_releases(memory_session)
+    seed_domain_category(memory_session, 20, "SUPER")
+    memory_session.add(
+        Category(
+            category_id=21, code="MEMBER", name="MEMBER", is_enumerated=True
+        )
+    )
+    make_member(
+        memory_session,
+        item_id=500,
+        name="FiledTwice",
+        domain_category_id=21,
+        code="from_member",
+    )
+    memory_session.add(
+        ItemCategory(
+            item_id=500,
+            start_release_id=2,
+            category_id=20,
+            code="from_domain",
+        )
+    )
+    memory_session.add(
+        SupercategoryComposition(supercategory_id=20, category_id=21)
+    )
+    memory_session.commit()
+
+    out = queries._load_member_codes(memory_session, {500}, {20})
+
+    assert out == {(500, 20): "from_domain"}
 
 
 # ---------------------------------------------------------------- #

--- a/tests/integration/services/test_domain_membership.py
+++ b/tests/integration/services/test_domain_membership.py
@@ -8,7 +8,8 @@ not hand-built. At release ``4.2.1``:
   (``RT``) and ``eba_UE:x23`` (``UE``) are all impossible there, which is what
   the shipped ``v7368_m`` and ``v7364_m`` do. ``qPO`` and ``qTU`` are
   super-categories, so their value set is their own items plus those of the
-  categories composing them (#359).
+  categories composing them (#359) -- narrowed back to the 18 items
+  ``c0160``'s header enumerates, where that is what the column offers.
 * ``{tF_00.01, r0010, c0010}`` takes items from ``qAS`` while the pre-refit
   ``eba_AS:x2`` is still in ``AS`` -- the domain rename that five more shipped
   operations were never updated for.
@@ -27,7 +28,9 @@ from dpmcore.services.semantic import SemanticService
 
 RELEASE = "4.2.1"
 
-MARKER = "takes items from domain"
+# Both the domain mismatch and the narrower "the column does not
+# enumerate this item" message open this way.
+MARKER = "belongs to domain"
 
 
 @pytest.fixture
@@ -158,6 +161,64 @@ class TestSuperCategories:
         assert "domain qCQ" in warning
         assert "domain qAI, qFI, qSR, qTA, qTU" in warning
         assert "the comparison is never true" in warning
+
+
+class TestHeaderSubcategories:
+    """The header says which of a super-category's items a column takes.
+
+    Widening ``qTU`` to its members takes the accepted set from 1 item
+    to 927, of which ``{tC_14.00, c0160}`` offers 18: its header names
+    ``SubCategoryVersion`` 20918. Judging against that list instead
+    keeps the widening from swallowing the check whole (#359). Only
+    ``qTU``'s own items stay accepted regardless -- a subcategory does
+    not list the domain's "not applicable / all" default.
+    """
+
+    def test_a_member_item_the_column_does_not_offer_warns(self, semantic):
+        """``qx2001`` is in ``qFI``, but not among the column's 18."""
+        expression = "{tC_14.00, c0160} = [eba_qFI:qx2001]"
+
+        (warning,) = _domain_warnings(semantic, expression)
+
+        assert "[eba_qFI:qx2001] belongs to domain qFI" in warning
+        assert "which composes qTU" in warning
+        assert "the 18 items { tC_14.00, c0160 } enumerates there" in warning
+        assert "the comparison is never true" in warning
+
+    def test_the_shipped_operation_this_catches(self, semantic):
+        """``v8786_m`` is the one 4.2.1 operation the narrowing flags.
+
+        Its set holds ``qx2373``, which ``c0160`` offers, and
+        ``qx2160`` ("Covered bonds"), which it does not -- so that
+        member can never match.
+        """
+        expression = (
+            "with {tC_14.00, default: null, interval: false}: if ( "
+            "({c0160} in { [eba_qFI:qx2160], [eba_qFI:qx2373] } "
+            "and {c0110} != [eba_qRP:qx2020] ) ) then "
+            "( {c0051} = [eba_qST:qx2031] ) endif"
+        )
+
+        warnings = _domain_warnings(semantic, expression)
+
+        (warning,) = [w for w in warnings if "[eba_qFI:qx2160]" in w]
+        assert "which composes qTU" in warning
+        assert "this member of the set never matches" in warning
+        # ``qx2373`` is one of the 18, so it is not reported.
+        assert not any("[eba_qFI:qx2373]" in w for w in warnings)
+
+    def test_a_column_with_no_header_subcategory_keeps_the_domain(
+        self, semantic
+    ):
+        """``{tF_40.01, c0095}`` is on ``qSR``, which composes nothing.
+
+        Nothing to narrow, and the message stays the domain one.
+        """
+        expression = "{tF_40.01, c0095} = [eba_PL:x72]"
+
+        (warning,) = _domain_warnings(semantic, expression)
+
+        assert "takes items from domain qSR" in warning
 
 
 class TestComponentKinds:

--- a/tests/integration/services/test_domain_membership.py
+++ b/tests/integration/services/test_domain_membership.py
@@ -6,7 +6,9 @@ not hand-built. At release ``4.2.1``:
 * ``{tC_14.00, c0060}`` takes items from ``qPO``, ``c0061`` from ``qST`` and
   ``c0160`` from ``qTU`` -- so ``eba_PL:x72`` (``PL``), ``eba_RT:x14``
   (``RT``) and ``eba_UE:x23`` (``UE``) are all impossible there, which is what
-  the shipped ``v7368_m`` and ``v7364_m`` do.
+  the shipped ``v7368_m`` and ``v7364_m`` do. ``qPO`` and ``qTU`` are
+  super-categories, so their value set is their own items plus those of the
+  categories composing them (#359).
 * ``{tF_00.01, r0010, c0010}`` takes items from ``qAS`` while the pre-refit
   ``eba_AS:x2`` is still in ``AS`` -- the domain rename that five more shipped
   operations were never updated for.
@@ -60,13 +62,15 @@ class TestShippedOperations:
         assert len(warnings) == 2
         dead_member = next(w for w in warnings if "eba_PL:x72" in w)
         assert "domain PL" in dead_member
-        assert "domain qPO" in dead_member
+        # qPO is a super-category: qOR and qPL are in its value set,
+        # PL is not.
+        assert "domain qOR, qPL, qPO" in dead_member
         assert "this member of the set never matches" in dead_member
         always_true = next(w for w in warnings if "eba_RT:x14" in w)
         assert "domain qST" in always_true
         assert "the comparison is always true" in always_true
 
-    def test_v7364_m_reports_both_members_of_an_unmatchable_set(
+    def test_v7364_m_reports_only_the_member_outside_the_value_set(
         self, semantic
     ):
         expression = (
@@ -79,12 +83,12 @@ class TestShippedOperations:
 
         warnings = _domain_warnings(semantic, expression)
 
-        # c0040 is qST, so the three qST members are silent; c0160 is qTU, so
-        # both of its members are impossible.
-        assert len(warnings) == 2
-        assert all("domain qTU" in w for w in warnings)
-        assert any("eba_qFI:qx2370" in w for w in warnings)
-        assert any("eba_UE:x23" in w for w in warnings)
+        # c0040 is qST, so the three qST members are silent. c0160 is the
+        # super-category qTU, which composes qFI among others, so only
+        # ``eba_UE:x23`` is impossible there (#359).
+        (warning,) = warnings
+        assert "eba_UE:x23" in warning
+        assert "domain qAI, qFI, qSR, qTA, qTU" in warning
 
     def test_the_pre_refit_accounting_standard_rename_is_reported(
         self, semantic
@@ -101,6 +105,59 @@ class TestShippedOperations:
         expression = "{tF_00.01, r0010, c0010} = [eba_qAS:qx2000]"
 
         assert _domain_warnings(semantic, expression) == []
+
+
+class TestSuperCategories:
+    """A super-category's value set is its own items plus its members'.
+
+    ``{tC_14.00, c0160}`` is typed on ``qTU``, which composes ``qAI``,
+    ``qFI``, ``qSR`` and ``qTA`` and holds a single item of its own. The
+    18 items the column actually offers come almost entirely from the
+    members, so judging them against ``qTU`` alone condemned all of them.
+    """
+
+    def test_the_reported_expression_is_silent(self, semantic):
+        """The expression the issue was raised with (#359)."""
+        expression = (
+            "with {tC_14.00}: if {c0446} and {c0160} in "
+            "{[eba_qFI:qx2366], [eba_qFI:qx2369], [eba_qFI:qx2370], "
+            "[eba_qFI:qx2372], [eba_qFI:qx2374]} then "
+            "{c0223, default: 0} / 0.08 <= 0.75 endif"
+        )
+
+        assert _domain_warnings(semantic, expression) == []
+
+    @pytest.mark.parametrize(
+        "signature",
+        [
+            "eba_qAI:qx2006",
+            "eba_qFI:qx2366",
+            "eba_qSR:qx2018",
+            "eba_qTA:qx2042",
+        ],
+    )
+    def test_an_item_of_each_composing_category_is_silent(
+        self, semantic, signature
+    ):
+        expression = f"{{tC_14.00, c0160}} = [{signature}]"
+
+        assert _domain_warnings(semantic, expression) == []
+
+    def test_the_super_categorys_own_item_is_silent(self, semantic):
+        expression = "{tC_14.00, c0160} = [eba_qTU:qx0]"
+
+        assert _domain_warnings(semantic, expression) == []
+
+    def test_an_item_outside_every_composing_category_still_warns(
+        self, semantic
+    ):
+        expression = "{tC_14.00, c0160} = [eba_qCQ:qx2060]"
+
+        (warning,) = _domain_warnings(semantic, expression)
+
+        assert "domain qCQ" in warning
+        assert "domain qAI, qFI, qSR, qTA, qTU" in warning
+        assert "the comparison is never true" in warning
 
 
 class TestComponentKinds:

--- a/tests/unit/dpm_xl/test_domain_queries.py
+++ b/tests/unit/dpm_xl/test_domain_queries.py
@@ -1,32 +1,336 @@
-"""Empty-input guards on the domain lookups (issue #332).
+"""Unit tests for the domain-resolution queries.
 
-Both helpers are asked for the signatures/properties a single expression
-mentions, so an empty request is normal; it must not reach the database.
+``get_item_domains``/``get_property_domains`` back the DPM-XL
+domain-membership warning, and ``SubCategoryQuery`` narrows it from a
+domain to the items a particular column offers. The empty-input paths
+must cost no query at all; everything else runs against an in-memory
+SQLite database so the joins, the super-category expansion and the
+release windows are covered without the fixture DB (issues #332, #359).
+
+Seed model, three releases 1..3:
+
+    Category  qTU    enumerated, composes qFI and qAI from release 1
+    Category  qFI    enumerated, holds item 11 (``eba_qFI:qx1``)
+    Category  qAI    enumerated, holds item 12 (``eba_qAI:qx2``)
+    Category  qDT    not enumerated (a date), holds item 13
+    qTU holds one item of its own, 10 (``eba_qTU:qx0``)
+
+    Property 91 is typed on qTU, property 92 on qDT (so it has no
+    domain at all) and property 93 on the plain category qFI.
+
+    Table version 500 has column header 700 (property 91), whose
+    header version names subcategory 60 — items 10 is *not* in it, 11
+    is.  Cell 800 sits in that column.
 """
 
+from __future__ import annotations
+
+from datetime import date
 from unittest.mock import MagicMock
 
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+
+import dpmcore.orm  # noqa: F401  — ensure all models are loaded
 from dpmcore.dpm_xl.model_queries import (
     ItemCategoryQuery,
     PropertyCategoryQuery,
-    _supercategory_members,
+    SubCategoryQuery,
+)
+from dpmcore.orm.base import Base
+from dpmcore.orm.glossary import (
+    Category,
+    Item,
+    ItemCategory,
+    Property,
+    PropertyCategory,
+    SubCategory,
+    SubCategoryItem,
+    SubCategoryVersion,
+    SupercategoryComposition,
+)
+from dpmcore.orm.infrastructure import Release
+from dpmcore.orm.rendering import (
+    Cell,
+    Header,
+    HeaderVersion,
+    Table,
+    TableVersion,
+    TableVersionCell,
+    TableVersionHeader,
 )
 
-
-def test_no_items_does_not_query():
-    session = MagicMock()
-    assert ItemCategoryQuery.get_item_domains(session, []) == {}
-    session.query.assert_not_called()
+QTU, QFI, QAI, QDT = 1, 2, 3, 4
 
 
-def test_no_properties_does_not_query():
-    session = MagicMock()
-    assert PropertyCategoryQuery.get_property_domains(session, []) == {}
-    session.query.assert_not_called()
+@pytest.fixture
+def session():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    s = Session(bind=engine)
+    s.add_all(
+        Release(
+            release_id=rid,
+            code=f"4.{rid}",
+            date=date(2024, rid, 1),
+            status="Final",
+            is_current=rid == 3,
+        )
+        for rid in (1, 2, 3)
+    )
+    s.add_all(
+        Category(
+            category_id=cid,
+            code=code,
+            name=code,
+            is_enumerated=enumerated,
+            is_active=True,
+            is_external_ref_data=False,
+            created_release_id=1,
+        )
+        for cid, code, enumerated in [
+            (QTU, "qTU", True),
+            (QFI, "qFI", True),
+            (QAI, "qAI", True),
+            (QDT, "qDT", False),
+        ]
+    )
+    s.add_all(
+        SupercategoryComposition(
+            supercategory_id=QTU,
+            category_id=member,
+            start_release_id=1,
+            end_release_id=None,
+        )
+        for member in (QFI, QAI)
+    )
+    s.add_all(
+        Item(
+            item_id=iid, name=f"Item {iid}", is_property=False, is_active=True
+        )
+        for iid in (10, 11, 12, 13)
+    )
+    s.add_all(
+        [
+            Item(item_id=91, name="Type", is_property=True, is_active=True),
+            Item(item_id=92, name="Date", is_property=True, is_active=True),
+            Item(item_id=93, name="Plain", is_property=True, is_active=True),
+            Property(property_id=91, is_composite=False, is_metric=False),
+            Property(property_id=92, is_composite=False, is_metric=False),
+            Property(property_id=93, is_composite=False, is_metric=False),
+        ]
+    )
+    s.flush()
+    s.add_all(
+        ItemCategory(
+            item_id=iid,
+            category_id=cid,
+            code=code,
+            signature=signature,
+            is_default_item=iid == 10,
+            start_release_id=1,
+            end_release_id=None,
+        )
+        for iid, cid, code, signature in [
+            (10, QTU, "qx0", "eba_qTU:qx0"),
+            (11, QFI, "qx1", "eba_qFI:qx1"),
+            (12, QAI, "qx2", "eba_qAI:qx2"),
+            (13, QDT, "d1", "eba_qDT:d1"),
+        ]
+    )
+    s.add_all(
+        [
+            PropertyCategory(
+                property_id=91,
+                category_id=QTU,
+                start_release_id=1,
+                end_release_id=None,
+            ),
+            PropertyCategory(
+                property_id=92,
+                category_id=QDT,
+                start_release_id=1,
+                end_release_id=None,
+            ),
+            PropertyCategory(
+                property_id=93,
+                category_id=QFI,
+                start_release_id=1,
+                end_release_id=None,
+            ),
+        ]
+    )
+    # A subcategory of qTU listing only item 11.
+    s.add_all(
+        [
+            SubCategory(subcategory_id=6, category_id=QTU, code="new_qTU"),
+            SubCategoryVersion(subcategory_vid=60, subcategory_id=6),
+            SubCategoryItem(subcategory_vid=60, item_id=11, order=1),
+        ]
+    )
+    # Table 500 / column header 700 / cell 800.
+    s.add_all(
+        [
+            Table(table_id=50),
+            TableVersion(table_vid=500, table_id=50, code="C_14.00"),
+            Header(header_id=700, table_id=50, direction="Column"),
+            HeaderVersion(
+                header_vid=7000,
+                header_id=700,
+                code="0160",
+                property_id=91,
+                subcategory_vid=60,
+            ),
+            TableVersionHeader(
+                table_vid=500, header_id=700, header_vid=7000, order=1
+            ),
+            Cell(cell_id=800, table_id=50, column_id=700),
+            TableVersionCell(
+                table_vid=500, cell_id=800, cell_code="{C_14.00, c0160}"
+            ),
+        ]
+    )
+    s.commit()
+    yield s
+    s.close()
 
 
-def test_no_domains_does_not_query_supercategories():
-    """A property with no enumerated domain expands nothing (#359)."""
-    session = MagicMock()
-    assert _supercategory_members(session, set(), None) == {}
-    session.query.assert_not_called()
+class TestEmptyInput:
+    def test_no_items_does_not_query(self):
+        session = MagicMock()
+        assert ItemCategoryQuery.get_item_domains(session, []) == {}
+        session.query.assert_not_called()
+
+    def test_no_properties_does_not_query(self):
+        session = MagicMock()
+        assert PropertyCategoryQuery.get_property_domains(session, []) == {}
+        session.query.assert_not_called()
+
+    def test_no_cells_does_not_query(self):
+        session = MagicMock()
+        assert SubCategoryQuery.get_cell_subcategory_vids(session, []) == {}
+        session.query.assert_not_called()
+
+    def test_no_subcategories_does_not_query(self):
+        session = MagicMock()
+        assert SubCategoryQuery.get_subcategory_signatures(session, []) == {}
+        session.query.assert_not_called()
+
+
+class TestItemDomains:
+    def test_an_item_resolves_to_its_filing_category(self, session):
+        domains = ItemCategoryQuery.get_item_domains(
+            session, ["eba_qFI:qx1"], 3
+        )
+
+        assert domains == {"eba_qFI:qx1": {"qFI"}}
+
+    def test_a_non_enumerated_category_is_not_a_domain(self, session):
+        assert (
+            ItemCategoryQuery.get_item_domains(session, ["eba_qDT:d1"], 3)
+            == {}
+        )
+
+    def test_items_are_never_widened_to_a_super_category(self, session):
+        """An item belongs where it is filed, not to what composes it."""
+        domains = ItemCategoryQuery.get_item_domains(
+            session, ["eba_qTU:qx0"], 3
+        )
+
+        assert domains == {"eba_qTU:qx0": {"qTU"}}
+
+
+class TestPropertyDomains:
+    def test_a_plain_property_has_no_members(self, session):
+        domains = PropertyCategoryQuery.get_property_domains(session, [93], 3)[
+            93
+        ]
+
+        assert domains.own == frozenset({"qFI"})
+        assert domains.members == frozenset()
+        assert domains.codes == frozenset({"qFI"})
+
+    def test_a_super_category_reports_own_and_members_apart(self, session):
+        domains = PropertyCategoryQuery.get_property_domains(session, [91], 3)[
+            91
+        ]
+
+        assert domains.own == frozenset({"qTU"})
+        assert domains.members == frozenset({"qFI", "qAI"})
+        assert domains.codes == frozenset({"qTU", "qFI", "qAI"})
+
+    def test_a_property_with_no_enumerated_category_is_absent(self, session):
+        assert 92 not in PropertyCategoryQuery.get_property_domains(
+            session, [92], 3
+        )
+
+    def test_the_composition_window_is_honoured(self, session):
+        session.query(SupercategoryComposition).filter(
+            SupercategoryComposition.category_id == QAI
+        ).update({"start_release_id": 3})
+        session.commit()
+
+        domains = PropertyCategoryQuery.get_property_domains(session, [91], 1)[
+            91
+        ]
+
+        assert domains.members == frozenset({"qFI"})
+
+    def test_the_member_join_does_not_drop_plain_domains(self, session):
+        """An outer join, so both kinds resolve in the same statement."""
+        domains = PropertyCategoryQuery.get_property_domains(
+            session, [91, 93], 3
+        )
+
+        assert set(domains) == {91, 93}
+
+
+class TestCellSubcategories:
+    def test_a_cells_column_header_names_its_subcategory(self, session):
+        found = SubCategoryQuery.get_cell_subcategory_vids(
+            session, [(500, 800)], 3
+        )
+
+        assert found == {(500, 800, 91): 60}
+
+    def test_a_cell_of_another_table_version_is_not_returned(self, session):
+        assert (
+            SubCategoryQuery.get_cell_subcategory_vids(
+                session, [(999, 800)], 3
+            )
+            == {}
+        )
+
+    def test_a_header_without_a_subcategory_is_skipped(self, session):
+        session.query(HeaderVersion).filter(
+            HeaderVersion.header_vid == 7000
+        ).update({"subcategory_vid": None})
+        session.commit()
+
+        assert (
+            SubCategoryQuery.get_cell_subcategory_vids(
+                session, [(500, 800)], 3
+            )
+            == {}
+        )
+
+    def test_the_listed_items_are_returned(self, session):
+        assert SubCategoryQuery.get_subcategory_signatures(
+            session, [60], 3
+        ) == {60: {"eba_qFI:qx1"}}
+
+    def test_an_item_with_no_code_at_the_release_is_left_out(self, session):
+        session.query(ItemCategory).filter(ItemCategory.item_id == 11).update(
+            {"start_release_id": 3}
+        )
+        session.commit()
+
+        assert (
+            SubCategoryQuery.get_subcategory_signatures(session, [60], 1) == {}
+        )

--- a/tests/unit/dpm_xl/test_domain_queries.py
+++ b/tests/unit/dpm_xl/test_domain_queries.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock
 from dpmcore.dpm_xl.model_queries import (
     ItemCategoryQuery,
     PropertyCategoryQuery,
+    _supercategory_members,
 )
 
 
@@ -21,4 +22,11 @@ def test_no_items_does_not_query():
 def test_no_properties_does_not_query():
     session = MagicMock()
     assert PropertyCategoryQuery.get_property_domains(session, []) == {}
+    session.query.assert_not_called()
+
+
+def test_no_domains_does_not_query_supercategories():
+    """A property with no enumerated domain expands nothing (#359)."""
+    session = MagicMock()
+    assert _supercategory_members(session, set(), None) == {}
     session.query.assert_not_called()

--- a/tests/unit/dpm_xl/test_release_window_conditions.py
+++ b/tests/unit/dpm_xl/test_release_window_conditions.py
@@ -1,0 +1,196 @@
+"""Tests for the standalone release-window predicates.
+
+:func:`filter_by_release` applies its window as a ``WHERE`` clause,
+which is wrong for an outer join — it narrows the join back to an inner
+one. :func:`release_window_condition` hands the same predicate back as
+an expression for the ``ON`` clause instead, and
+:func:`release_window_conditions` builds several of them from a single
+load of the release ordering (#359).
+
+Seed model: three dated releases 1..3, plus an undated working release
+9 that always ranks as the latest.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, aliased
+from sqlalchemy.pool import StaticPool
+
+import dpmcore.orm  # noqa: F401  — ensure all models are loaded
+from dpmcore.dpm_xl.utils.filters import (
+    filter_by_release,
+    release_window_condition,
+    release_window_conditions,
+)
+from dpmcore.orm.base import Base
+from dpmcore.orm.glossary import Category, SupercategoryComposition
+from dpmcore.orm.infrastructure import Release
+
+
+@pytest.fixture
+def session():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    s = Session(bind=engine)
+    s.add_all(
+        [
+            Release(release_id=1, code="1.0", date=date(2024, 1, 1)),
+            Release(release_id=2, code="1.1", date=date(2024, 2, 1)),
+            Release(release_id=3, code="1.2", date=date(2024, 3, 1)),
+            Release(release_id=9, code="Playground", date=None),
+        ]
+    )
+    s.add_all(
+        Category(
+            category_id=cid,
+            code=code,
+            name=code,
+            is_enumerated=True,
+            is_active=True,
+            is_external_ref_data=False,
+        )
+        for cid, code in [(1, "SUP"), (2, "MEM")]
+    )
+    s.add(
+        SupercategoryComposition(
+            supercategory_id=1,
+            category_id=2,
+            start_release_id=2,
+            end_release_id=None,
+        )
+    )
+    s.commit()
+    yield s
+    s.close()
+
+
+def _windowed(session, release_id):
+    """Compositions matching the standalone predicate at *release_id*."""
+    condition = release_window_condition(
+        session,
+        start_col=SupercategoryComposition.start_release_id,
+        end_col=SupercategoryComposition.end_release_id,
+        release_id=release_id,
+    )
+    return session.query(SupercategoryComposition).filter(condition).all()
+
+
+def _filtered(session, release_id):
+    """The same, via ``filter_by_release``."""
+    return filter_by_release(
+        session.query(SupercategoryComposition),
+        start_col=SupercategoryComposition.start_release_id,
+        end_col=SupercategoryComposition.end_release_id,
+        release_id=release_id,
+        active_only_fallback=True,
+    ).all()
+
+
+class TestSingleCondition:
+    @pytest.mark.parametrize("release_id", [1, 2, 3, 9, None])
+    def test_it_matches_filter_by_release(self, session, release_id):
+        assert len(_windowed(session, release_id)) == len(
+            _filtered(session, release_id)
+        )
+
+    def test_a_row_before_its_start_release_is_out(self, session):
+        assert _windowed(session, 1) == []
+
+    def test_a_row_from_its_start_release_on_is_in(self, session):
+        assert len(_windowed(session, 2)) == 1
+
+    def test_an_undated_release_ranks_as_the_latest(self, session):
+        assert len(_windowed(session, 9)) == 1
+
+    def test_an_unknown_release_raises(self, session):
+        with pytest.raises(ValueError, match="has no sort_order"):
+            _windowed(session, 42)
+
+
+class TestSeveralConditions:
+    def test_one_predicate_per_window(self, session):
+        conditions = release_window_conditions(
+            session,
+            [
+                (
+                    SupercategoryComposition.start_release_id,
+                    SupercategoryComposition.end_release_id,
+                ),
+                (Category.created_release_id, Category.created_release_id),
+            ],
+            2,
+        )
+
+        assert len(conditions) == 2
+
+    def test_they_are_loaded_from_one_release_query(self, session):
+        from sqlalchemy import event
+
+        statements: list[str] = []
+        engine = session.get_bind()
+
+        def record(conn, cursor, statement, params, context, executemany):
+            statements.append(statement)
+
+        event.listen(engine, "before_cursor_execute", record)
+        try:
+            release_window_conditions(
+                session,
+                [
+                    (
+                        SupercategoryComposition.start_release_id,
+                        SupercategoryComposition.end_release_id,
+                    ),
+                    (
+                        SupercategoryComposition.start_release_id,
+                        SupercategoryComposition.end_release_id,
+                    ),
+                ],
+                2,
+            )
+        finally:
+            event.remove(engine, "before_cursor_execute", record)
+        assert len(statements) == 1
+
+
+class TestOuterJoinStaysOuter:
+    """The reason the predicate has to be an expression at all."""
+
+    def test_the_on_clause_keeps_unmatched_rows(self, session):
+        from sqlalchemy import and_
+
+        member = aliased(Category)
+        condition = release_window_condition(
+            session,
+            start_col=SupercategoryComposition.start_release_id,
+            end_col=SupercategoryComposition.end_release_id,
+            release_id=1,
+        )
+        rows = (
+            session.query(Category.code, member.code)
+            .outerjoin(
+                SupercategoryComposition,
+                and_(
+                    SupercategoryComposition.supercategory_id
+                    == Category.category_id,
+                    condition,
+                ),
+            )
+            .outerjoin(
+                member,
+                member.category_id == SupercategoryComposition.category_id,
+            )
+            .all()
+        )
+
+        # The composition is not open at release 1, but SUP is still
+        # listed — with no member. A WHERE clause would have dropped it.
+        assert ("SUP", None) in rows

--- a/tests/unit/orm/test_supercategories.py
+++ b/tests/unit/orm/test_supercategories.py
@@ -1,0 +1,224 @@
+"""Unit tests for super-category expansion (issue #359).
+
+A super-category's value set is its own items plus those of the
+categories composing it, and ``ItemCategory`` files each item under the
+one category that owns it. Every domain-resolving path in the codebase
+goes through :mod:`dpmcore.orm.supercategories` for that expansion, so
+the query itself — the join, the member filters, the release window and
+the transitive walk — is exercised here against an in-memory SQLite
+database rather than only through the fixture-DB integration tests,
+which CI skips.
+
+Seed model, four releases 1..4:
+
+    SUPER  composes  ALPHA   from release 1 (never closed)
+    SUPER  composes  BETA    from release 3 (never closed)
+    SUPER  composes  RAW     from release 1  — RAW is not enumerated
+    OUTER  composes  SUPER   from release 1  — one level of nesting
+    PLAIN  composes  nothing
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+
+import dpmcore.orm  # noqa: F401  — ensure all models are loaded
+from dpmcore.orm.base import Base
+from dpmcore.orm.glossary import Category, SupercategoryComposition
+from dpmcore.orm.infrastructure import Release
+from dpmcore.orm.supercategories import (
+    load_supercategory_compositions,
+    load_supercategory_member_codes,
+    load_supercategory_members,
+)
+
+ALPHA, BETA, RAW, SUPER, OUTER, PLAIN = 1, 2, 3, 4, 5, 6
+
+
+@pytest.fixture
+def session():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    s = Session(bind=engine)
+    s.add_all(
+        Release(
+            release_id=rid,
+            code=f"1.{rid}",
+            date=date(2024, rid, 1),
+            status="Final",
+            is_current=rid == 4,
+        )
+        for rid in (1, 2, 3, 4)
+    )
+    s.add_all(
+        Category(
+            category_id=cid,
+            code=code,
+            name=code.title(),
+            is_enumerated=enumerated,
+            is_active=True,
+            is_external_ref_data=False,
+            created_release_id=1,
+        )
+        for cid, code, enumerated in [
+            (ALPHA, "ALPHA", True),
+            (BETA, "BETA", True),
+            (RAW, "RAW", False),
+            (SUPER, "SUPER", True),
+            (OUTER, "OUTER", True),
+            (PLAIN, "PLAIN", True),
+        ]
+    )
+    s.add_all(
+        SupercategoryComposition(
+            supercategory_id=parent,
+            category_id=member,
+            start_release_id=start,
+            end_release_id=end,
+        )
+        for parent, member, start, end in [
+            (SUPER, ALPHA, 1, None),
+            (SUPER, BETA, 3, None),
+            (SUPER, RAW, 1, None),
+            (OUTER, SUPER, 1, None),
+        ]
+    )
+    s.commit()
+    yield s
+    s.close()
+
+
+class TestMembersById:
+    def test_a_plain_category_expands_to_nothing(self, session):
+        members = load_supercategory_members(session, {PLAIN}, release_id=None)
+
+        assert members == {}
+
+    def test_the_composing_categories_are_returned(self, session):
+        members = load_supercategory_members(session, {SUPER}, release_id=4)
+
+        assert members == {SUPER: {ALPHA, BETA}}
+
+    def test_a_member_outside_its_window_is_left_out(self, session):
+        """BETA only joins at release 3."""
+        members = load_supercategory_members(session, {SUPER}, release_id=2)
+
+        assert members == {SUPER: {ALPHA}}
+
+    def test_a_non_enumerated_member_is_never_a_value_set(self, session):
+        """RAW composes SUPER at every release but holds no values."""
+        members = load_supercategory_members(session, {SUPER}, release_id=None)
+
+        assert RAW not in members[SUPER]
+
+    def test_nesting_is_followed_to_the_end(self, session):
+        """OUTER composes SUPER, so it also takes SUPER's members."""
+        members = load_supercategory_members(session, {OUTER}, release_id=4)
+
+        assert members == {OUTER: {SUPER, ALPHA, BETA}}
+
+    def test_a_cycle_terminates(self, session):
+        session.add(
+            SupercategoryComposition(
+                supercategory_id=ALPHA,
+                category_id=SUPER,
+                start_release_id=1,
+                end_release_id=None,
+            )
+        )
+        session.commit()
+
+        members = load_supercategory_members(session, {SUPER}, release_id=4)
+
+        # SUPER reaches ALPHA, ALPHA reaches back to SUPER; a key is
+        # never expanded twice, so the walk ends instead of looping,
+        # and a category is not reported as composing itself.
+        assert members == {SUPER: {ALPHA, BETA}}
+
+    def test_several_categories_resolve_in_one_call(self, session):
+        members = load_supercategory_members(
+            session, {SUPER, PLAIN, ALPHA}, release_id=4
+        )
+
+        assert members == {SUPER: {ALPHA, BETA}}
+
+    def test_nothing_to_expand_costs_no_query(self):
+        from unittest.mock import MagicMock
+
+        session = MagicMock()
+
+        assert (
+            load_supercategory_members(session, set(), release_id=None) == {}
+        )
+        session.query.assert_not_called()
+
+
+class TestMembersByCode:
+    def test_codes_mirror_the_id_keyed_answer(self, session):
+        members = load_supercategory_member_codes(
+            session, {"SUPER"}, release_id=4
+        )
+
+        assert members == {"SUPER": {"ALPHA", "BETA"}}
+
+    def test_the_same_release_window_applies(self, session):
+        members = load_supercategory_member_codes(
+            session, {"SUPER"}, release_id=2
+        )
+
+        assert members == {"SUPER": {"ALPHA"}}
+
+    def test_the_same_member_filters_apply(self, session):
+        """The two keyings must not disagree on what counts as a member."""
+        by_code = load_supercategory_member_codes(
+            session, {"SUPER"}, release_id=None
+        )
+        by_id = load_supercategory_members(session, {SUPER}, release_id=None)
+        codes = {c.category_id: c.code for c in session.query(Category).all()}
+
+        assert by_code["SUPER"] == {codes[cid] for cid in by_id[SUPER]}
+
+    def test_nothing_to_expand_costs_no_query(self):
+        from unittest.mock import MagicMock
+
+        session = MagicMock()
+
+        assert (
+            load_supercategory_member_codes(session, set(), release_id=None)
+            == {}
+        )
+        session.query.assert_not_called()
+
+
+class TestCompositions:
+    def test_every_window_is_kept(self, session):
+        compositions = load_supercategory_compositions(session, {SUPER})
+
+        assert {
+            (c.category_id, c.start_release_id) for c in compositions[SUPER]
+        } == {(ALPHA, 1), (BETA, 3)}
+
+    def test_a_non_enumerated_member_is_left_out(self, session):
+        compositions = load_supercategory_compositions(session, {SUPER})
+
+        assert RAW not in {c.category_id for c in compositions[SUPER]}
+
+    def test_a_plain_category_has_no_entry(self, session):
+        assert load_supercategory_compositions(session, {PLAIN}) == {}
+
+    def test_nothing_to_load_costs_no_query(self):
+        from unittest.mock import MagicMock
+
+        session = MagicMock()
+
+        assert load_supercategory_compositions(session, set()) == {}
+        session.query.assert_not_called()

--- a/tests/unit/orm/test_supercategories.py
+++ b/tests/unit/orm/test_supercategories.py
@@ -215,6 +215,32 @@ class TestCompositions:
     def test_a_plain_category_has_no_entry(self, session):
         assert load_supercategory_compositions(session, {PLAIN}) == {}
 
+    def test_nesting_is_loaded_too(self, session):
+        """OUTER composes SUPER, so SUPER's own rows are needed as well.
+
+        The windows stay separate — the caller decides, release by
+        release, whether both links are open.
+        """
+        compositions = load_supercategory_compositions(session, {OUTER})
+
+        assert {c.category_id for c in compositions[OUTER]} == {SUPER}
+        assert {c.category_id for c in compositions[SUPER]} == {ALPHA, BETA}
+
+    def test_a_cycle_terminates(self, session):
+        session.add(
+            SupercategoryComposition(
+                supercategory_id=ALPHA,
+                category_id=SUPER,
+                start_release_id=1,
+                end_release_id=None,
+            )
+        )
+        session.commit()
+
+        compositions = load_supercategory_compositions(session, {SUPER})
+
+        assert {c.category_id for c in compositions[ALPHA]} == {SUPER}
+
     def test_nothing_to_load_costs_no_query(self):
         from unittest.mock import MagicMock
 

--- a/tests/unit/semantic/test_domain_membership_warning.py
+++ b/tests/unit/semantic/test_domain_membership_warning.py
@@ -34,15 +34,24 @@ from dpmcore.dpm_xl.ast.nodes import (
     VarID,
     WhereClauseOp,
 )
+from dpmcore.dpm_xl.model_queries import PropertyDomains
 from dpmcore.dpm_xl.warning_collector import collect_warnings
+
+
+def _domains(own, members=()):
+    return PropertyDomains(own=frozenset(own), members=frozenset(members))
+
 
 # property_id -> domain, as the dictionary would resolve it at a release.
 PROPERTY_DOMAINS = {
-    901: {"qPO"},
-    902: {"qST"},
-    903: {"qAS"},
+    901: _domains({"qPO"}),
+    902: _domains({"qST"}),
+    903: _domains({"qAS"}),
     # A property in a non-enumerated category resolves to no domain.
-    904: set(),
+    904: None,
+    # A super-category: qTU holds one item of its own and draws the
+    # rest of its value set from the categories composing it.
+    905: _domains({"qTU"}, {"qFI", "qAI"}),
 }
 
 # item signature -> domain.
@@ -52,6 +61,12 @@ ITEM_DOMAINS = {
     "eba_RT:x14": {"RT"},
     "eba_AS:x2": {"AS"},
     "eba_qAS:qx1": {"qAS"},
+    # In qTU itself — the "not applicable / all" default item.
+    "eba_qTU:qx0": {"qTU"},
+    # In categories composing qTU: offered by some of its columns.
+    "eba_qFI:qx2366": {"qFI"},
+    "eba_qFI:qx9999": {"qFI"},
+    "eba_qAI:qx2006": {"qAI"},
 }
 
 
@@ -63,7 +78,7 @@ def stub_dictionary(monkeypatch):
         return {
             property_id: PROPERTY_DOMAINS[property_id]
             for property_id in property_ids
-            if PROPERTY_DOMAINS.get(property_id)
+            if PROPERTY_DOMAINS.get(property_id) is not None
         }
 
     def items(session, signatures, release_id=None):
@@ -107,8 +122,13 @@ def fixture_keys(monkeypatch):
     return asked
 
 
-def _selection(*property_ids, table="C_14.00", cols=("0060",)):
-    """A cell selection resolving to one data point per property."""
+def _selection(*property_ids, table="C_14.00", cols=("0060",), cells=None):
+    """A cell selection resolving to one data point per property.
+
+    Without *cells* the frame carries no cell identity, which is how a
+    caller that cannot locate the data points looks: the header
+    subcategory is then unreachable and the domains are all there is.
+    """
     node = VarID(
         table=table,
         rows=None,
@@ -117,7 +137,11 @@ def _selection(*property_ids, table="C_14.00", cols=("0060",)):
         interval=None,
         default=None,
     )
-    node.data = pd.DataFrame({"property_id": list(property_ids)})
+    columns = {"property_id": list(property_ids)}
+    if cells is not None:
+        columns["table_vid"] = [vid for vid, _cell in cells]
+        columns["cell_id"] = [cell for _vid, cell in cells]
+    node.data = pd.DataFrame(columns)
     return node
 
 
@@ -319,6 +343,113 @@ class TestComponentResolution:
         )
 
         assert len(_run(node)) == 2
+
+
+class TestSuperCategories:
+    """A super-category widens the domain; a header narrows it back.
+
+    Property 905 is typed on ``qTU``, which holds its own default item
+    and composes ``qFI`` and ``qAI``. The column's header names a
+    subcategory listing a subset of the members' items, which is what
+    the component actually offers (#359).
+    """
+
+    @pytest.fixture
+    def offered(self, monkeypatch):
+        """Every data point of table 7066 offers ``eba_qFI:qx2366``."""
+
+        def cells(session, cells, release_id=None):
+            return {
+                (table_vid, cell_id, 905): 20918
+                for table_vid, cell_id in cells
+                if table_vid == 7066
+            }
+
+        def signatures(session, vids, release_id=None):
+            return {vid: {"eba_qFI:qx2366"} for vid in vids}
+
+        monkeypatch.setattr(
+            domain_membership.SubCategoryQuery,
+            "get_cell_subcategory_vids",
+            staticmethod(cells),
+        )
+        monkeypatch.setattr(
+            domain_membership.SubCategoryQuery,
+            "get_subcategory_signatures",
+            staticmethod(signatures),
+        )
+
+    def test_an_item_of_a_composing_category_is_silent(self):
+        node = BinOp(_selection(905), "=", _item("eba_qFI:qx2366"))
+
+        assert _run(node) == []
+
+    def test_the_super_categorys_own_item_is_silent(self):
+        node = BinOp(_selection(905), "=", _item("eba_qTU:qx0"))
+
+        assert _run(node) == []
+
+    def test_an_item_outside_every_composing_category_warns(self):
+        node = BinOp(_selection(905), "=", _item("eba_PL:x72"))
+
+        (warning,) = _run(node)
+
+        assert "takes items from domain qAI, qFI, qTU" in warning
+
+    def test_without_cell_identity_the_widened_domain_stands(self):
+        """No table_vid/cell_id column: nothing to look a header up by."""
+        node = BinOp(_selection(905), "=", _item("eba_qFI:qx9999"))
+
+        assert _run(node) == []
+
+    def test_a_member_item_the_column_does_not_offer_warns(self, offered):
+        node = BinOp(
+            _selection(905, cells=[(7066, 800)]), "=", _item("eba_qFI:qx9999")
+        )
+
+        (warning,) = _run(node)
+
+        assert "[eba_qFI:qx9999] belongs to domain qFI" in warning
+        assert "which composes qTU" in warning
+        assert "the 1 item { tC_14.00, c0060 } enumerates there" in warning
+        assert "the comparison is never true" in warning
+
+    def test_an_offered_member_item_stays_silent(self, offered):
+        node = BinOp(
+            _selection(905, cells=[(7066, 800)]), "=", _item("eba_qFI:qx2366")
+        )
+
+        assert _run(node) == []
+
+    def test_the_default_item_survives_the_narrowing(self, offered):
+        """The subcategory does not list it, but the domain still holds it."""
+        node = BinOp(
+            _selection(905, cells=[(7066, 800)]), "=", _item("eba_qTU:qx0")
+        )
+
+        assert _run(node) == []
+
+    def test_a_data_point_with_no_header_subcategory_widens_back(
+        self, offered
+    ):
+        """Table 9999 answers nothing, so the whole selection falls back."""
+        node = BinOp(
+            _selection(905, 905, cells=[(7066, 800), (9999, 801)]),
+            "=",
+            _item("eba_qFI:qx9999"),
+        )
+
+        assert _run(node) == []
+
+    def test_a_plain_domain_is_never_narrowed(self, offered):
+        """No members to recover precision for — and so no extra query."""
+        node = BinOp(
+            _selection(901, cells=[(7066, 800)]), "=", _item("eba_PL:x72")
+        )
+
+        (warning,) = _run(node)
+
+        assert "takes items from domain qPO" in warning
 
 
 class TestOpenKeys:

--- a/tests/unit/server/test_structure_category.py
+++ b/tests/unit/server/test_structure_category.py
@@ -11,7 +11,12 @@ from sqlalchemy.pool import StaticPool
 
 import dpmcore.orm  # noqa: F401  — ensure all models are loaded
 from dpmcore.orm.base import Base
-from dpmcore.orm.glossary import Category, Item, ItemCategory
+from dpmcore.orm.glossary import (
+    Category,
+    Item,
+    ItemCategory,
+    SupercategoryComposition,
+)
 from dpmcore.orm.infrastructure import Concept, Organisation, Release
 from dpmcore.server.app import create_app
 
@@ -48,6 +53,7 @@ def seeded_engine(engine):
         "c-rel-3",
         "c-cat-1",
         "c-cat-2",
+        "c-cat-3",
     ]:
         owner = 1 if guid != "c-rel-3" else None
         session.add(Concept(concept_guid=guid, owner_id=owner))
@@ -118,7 +124,33 @@ def seeded_engine(engine):
                 created_release_id=2,
                 owner_id=1,
             ),
+            # A super-category: it holds one item of its own and draws
+            # the rest of its value set from MC, which composes it from
+            # release 2 onward (#359).
+            Category(
+                category_id=3,
+                code="SUP",
+                name="Super Category",
+                description="A composed domain",
+                is_enumerated=True,
+                is_active=True,
+                is_external_ref_data=False,
+                ref_data_source=None,
+                row_guid="c-cat-3",
+                created_release_id=1,
+                owner_id=1,
+            ),
         ]
+    )
+    session.flush()
+
+    session.add(
+        SupercategoryComposition(
+            supercategory_id=3,
+            category_id=1,
+            start_release_id=2,
+            end_release_id=None,
+        )
     )
     session.flush()
 
@@ -143,6 +175,13 @@ def seeded_engine(engine):
                 item_id=12,
                 name="Item Gamma",
                 description="Third item (added in 3.4)",
+                is_property=False,
+                is_active=True,
+            ),
+            Item(
+                item_id=13,
+                name="Item Delta",
+                description="The super-category's own item",
                 is_property=False,
                 is_active=True,
             ),
@@ -193,6 +232,16 @@ def seeded_engine(engine):
                 signature="SC(SC_001)",
                 end_release_id=None,
             ),
+            # SUP's single own item; the rest come from MC.
+            ItemCategory(
+                item_id=13,
+                start_release_id=1,
+                category_id=3,
+                code="SUP_ALL",
+                is_default_item=True,
+                signature="SUP(SUP_ALL)",
+                end_release_id=None,
+            ),
         ]
     )
     session.commit()
@@ -224,7 +273,7 @@ class TestListAllCategories:
         body = resp.json()
         assert "categories" in body["data"]
         cats = body["data"]["categories"]
-        assert len(cats) == 2
+        assert len(cats) == 3
 
     def test_all_releases(self, client):
         """Explicit release=* returns virtual versions for all cats."""
@@ -232,9 +281,10 @@ class TestListAllCategories:
         assert resp.status_code == 200
         body = resp.json()
         cats = body["data"]["categories"]
-        # MC has 2 versions (items change at 3.4), SC has 1 version
-        assert len(cats) == 3
-        assert body["meta"]["totalCount"] == 3
+        # MC has 2 versions (items change at 3.4), SC has 1 version,
+        # SUP has 2 (its composition of MC opens at 3.4)
+        assert len(cats) == 5
+        assert body["meta"]["totalCount"] == 5
 
     def test_numeric_id_all_releases(self, client):
         """Numeric id with release=* returns all virtual versions."""
@@ -251,8 +301,8 @@ class TestFilterByOwner:
         resp = client.get("/api/v1/structure/category/EBA/*/*")
         assert resp.status_code == 200
         cats = resp.json()["data"]["categories"]
-        # MC(2 versions) + SC(1 version) = 3 entries with release=*
-        assert len(cats) == 3
+        # MC(2) + SC(1) + SUP(2) = 5 entries with release=*
+        assert len(cats) == 5
         assert all(c["owner"] == "EBA" for c in cats)
 
 
@@ -378,6 +428,47 @@ class TestItemFields:
         assert "isProperty" not in item
 
 
+class TestSuperCategories:
+    """A super-category's items are filed under what composes it.
+
+    ``SUP`` holds one item of its own (``SUP_ALL``) and composes ``MC``
+    from release 3.4 onward, so its value set grows when the
+    composition opens — with no ItemCategory row of its own changing
+    (#359).
+    """
+
+    def test_only_its_own_item_before_the_composition_opens(self, client):
+        resp = client.get("/api/v1/structure/category/EBA/SUP/3.3")
+        cat = resp.json()["data"]["categories"][0]
+
+        assert {i["code"] for i in cat["items"]} == {"SUP_ALL"}
+
+    def test_the_composed_categorys_items_join_it(self, client):
+        resp = client.get("/api/v1/structure/category/EBA/SUP/3.4")
+        cat = resp.json()["data"]["categories"][0]
+
+        # MC holds IC_001 and IC_003 at 3.4 (IC_002 ended at 3.3).
+        assert {i["code"] for i in cat["items"]} == {
+            "SUP_ALL",
+            "IC_001",
+            "IC_003",
+        }
+
+    def test_the_composition_opening_starts_a_new_version(self, client):
+        """The item set changes at 3.4, so a version boundary is due."""
+        resp = client.get("/api/v1/structure/category/*/SUP/*")
+        versions = resp.json()["data"]["categories"]
+
+        assert [v["release"] for v in versions] == ["3.3", "3.4"]
+
+    def test_the_composed_category_keeps_its_own_identity(self, client):
+        """Expanding SUP must not change what MC itself reports."""
+        resp = client.get("/api/v1/structure/category/EBA/MC/3.4")
+        cat = resp.json()["data"]["categories"][0]
+
+        assert {i["code"] for i in cat["items"]} == {"IC_001", "IC_003"}
+
+
 class TestEmptyResults:
     def test_empty_database_returns_204(self, empty_client):
         resp = empty_client.get("/api/v1/structure/category")
@@ -438,9 +529,9 @@ class TestVirtualVersioning:
         assert resp.status_code == 204
 
     def test_total_versions_all_categories(self, client):
-        """Total virtual versions: MC(2) + SC(1) = 3."""
+        """Total virtual versions: MC(2) + SC(1) + SUP(2) = 5."""
         resp = client.get("/api/v1/structure/category/*/*/*")
         assert resp.status_code == 200
         body = resp.json()
-        assert body["meta"]["totalCount"] == 3
-        assert len(body["data"]["categories"]) == 3
+        assert body["meta"]["totalCount"] == 5
+        assert len(body["data"]["categories"]) == 5

--- a/tests/unit/server/test_structure_category.py
+++ b/tests/unit/server/test_structure_category.py
@@ -54,6 +54,7 @@ def seeded_engine(engine):
         "c-cat-1",
         "c-cat-2",
         "c-cat-3",
+        "c-cat-4",
     ]:
         owner = 1 if guid != "c-rel-3" else None
         session.add(Concept(concept_guid=guid, owner_id=owner))
@@ -140,17 +141,40 @@ def seeded_engine(engine):
                 created_release_id=1,
                 owner_id=1,
             ),
+            # A super-category composing another one: it holds no item
+            # of its own and draws its whole value set through SUP.
+            Category(
+                category_id=4,
+                code="NST",
+                name="Nested Super Category",
+                description="A domain composed of a composed domain",
+                is_enumerated=True,
+                is_active=True,
+                is_external_ref_data=False,
+                ref_data_source=None,
+                row_guid="c-cat-4",
+                created_release_id=1,
+                owner_id=1,
+            ),
         ]
     )
     session.flush()
 
-    session.add(
-        SupercategoryComposition(
-            supercategory_id=3,
-            category_id=1,
-            start_release_id=2,
-            end_release_id=None,
-        )
+    session.add_all(
+        [
+            SupercategoryComposition(
+                supercategory_id=3,
+                category_id=1,
+                start_release_id=2,
+                end_release_id=None,
+            ),
+            SupercategoryComposition(
+                supercategory_id=4,
+                category_id=3,
+                start_release_id=1,
+                end_release_id=None,
+            ),
+        ]
     )
     session.flush()
 
@@ -273,7 +297,7 @@ class TestListAllCategories:
         body = resp.json()
         assert "categories" in body["data"]
         cats = body["data"]["categories"]
-        assert len(cats) == 3
+        assert len(cats) == 4
 
     def test_all_releases(self, client):
         """Explicit release=* returns virtual versions for all cats."""
@@ -282,9 +306,10 @@ class TestListAllCategories:
         body = resp.json()
         cats = body["data"]["categories"]
         # MC has 2 versions (items change at 3.4), SC has 1 version,
-        # SUP has 2 (its composition of MC opens at 3.4)
-        assert len(cats) == 5
-        assert body["meta"]["totalCount"] == 5
+        # SUP has 2 (its composition of MC opens at 3.4) and NST has 2
+        # (it inherits that change through SUP)
+        assert len(cats) == 7
+        assert body["meta"]["totalCount"] == 7
 
     def test_numeric_id_all_releases(self, client):
         """Numeric id with release=* returns all virtual versions."""
@@ -301,8 +326,8 @@ class TestFilterByOwner:
         resp = client.get("/api/v1/structure/category/EBA/*/*")
         assert resp.status_code == 200
         cats = resp.json()["data"]["categories"]
-        # MC(2) + SC(1) + SUP(2) = 5 entries with release=*
-        assert len(cats) == 5
+        # MC(2) + SC(1) + SUP(2) + NST(2) = 7 entries with release=*
+        assert len(cats) == 7
         assert all(c["owner"] == "EBA" for c in cats)
 
 
@@ -469,6 +494,41 @@ class TestSuperCategories:
         assert {i["code"] for i in cat["items"]} == {"IC_001", "IC_003"}
 
 
+class TestNestedSuperCategories:
+    """A super-category composing another one takes the whole chain.
+
+    ``NST`` composes ``SUP`` from the start and holds nothing of its
+    own, so everything it reports arrives through ``SUP`` — including
+    ``MC``'s items, two links away, once that composition opens at 3.4.
+    The dictionary does not nest super-categories today, but nothing in
+    the schema forbids it and a missing second level would silently
+    drop items (#359).
+    """
+
+    def test_the_second_level_is_reached(self, client):
+        resp = client.get("/api/v1/structure/category/EBA/NST/3.4")
+        cat = resp.json()["data"]["categories"][0]
+
+        assert {i["code"] for i in cat["items"]} == {
+            "SUP_ALL",
+            "IC_001",
+            "IC_003",
+        }
+
+    def test_only_the_first_level_before_the_second_opens(self, client):
+        """At 3.3 SUP does not compose MC yet, so MC's items stay out."""
+        resp = client.get("/api/v1/structure/category/EBA/NST/3.3")
+        cat = resp.json()["data"]["categories"][0]
+
+        assert {i["code"] for i in cat["items"]} == {"SUP_ALL"}
+
+    def test_a_change_two_levels_down_starts_a_new_version(self, client):
+        resp = client.get("/api/v1/structure/category/*/NST/*")
+        versions = resp.json()["data"]["categories"]
+
+        assert [v["release"] for v in versions] == ["3.3", "3.4"]
+
+
 class TestEmptyResults:
     def test_empty_database_returns_204(self, empty_client):
         resp = empty_client.get("/api/v1/structure/category")
@@ -529,9 +589,9 @@ class TestVirtualVersioning:
         assert resp.status_code == 204
 
     def test_total_versions_all_categories(self, client):
-        """Total virtual versions: MC(2) + SC(1) + SUP(2) = 5."""
+        """Total virtual versions: MC(2) + SC(1) + SUP(2) + NST(2) = 7."""
         resp = client.get("/api/v1/structure/category/*/*/*")
         assert resp.status_code == 200
         body = resp.json()
-        assert body["meta"]["totalCount"] == 5
-        assert len(body["data"]["categories"]) == 5
+        assert body["meta"]["totalCount"] == 7
+        assert len(body["data"]["categories"]) == 7

--- a/tests/unit/server/test_structure_property.py
+++ b/tests/unit/server/test_structure_property.py
@@ -17,6 +17,7 @@ from dpmcore.orm.glossary import (
     ItemCategory,
     Property,
     PropertyCategory,
+    SupercategoryComposition,
 )
 from dpmcore.orm.infrastructure import (
     Concept,
@@ -42,7 +43,8 @@ from dpmcore.server.app import create_app
 #         exercises the per-version code change.
 #   - 52 "ASSET" (Asset type) — DataType=Enumeration, PropertyCategory
 #         links to enumerated Category ASSET_TYPE. Items LOAN (alive
-#         at 4.0 only) and BOND (alive throughout).
+#         at 4.0 only) and BOND (alive throughout). ASSET_TYPE also
+#         composes EQUITY_TYPE from 4.1, which is where SHARE is filed.
 #   - 53 "PARTY" — DataType=String, no enumeration.
 # ------------------------------------------------------------------ #
 
@@ -143,7 +145,31 @@ def seeded_engine(engine):
                 created_release_id=1,
                 owner_id=1,
             ),
+            Category(
+                category_id=61,
+                code="EQUITY_TYPE",
+                name="Equity type",
+                description="",
+                is_enumerated=True,
+                is_active=True,
+                is_external_ref_data=False,
+                created_release_id=1,
+                owner_id=1,
+            ),
         ]
+    )
+    s.flush()
+
+    # ASSET_TYPE is a super-category from 4.1 on: EQUITY_TYPE joins it,
+    # bringing SHARE into ASSET_TYPE's value set without SHARE ever
+    # having an ItemCategory row in ASSET_TYPE itself (#359).
+    s.add(
+        SupercategoryComposition(
+            supercategory_id=60,
+            category_id=61,
+            start_release_id=2,
+            end_release_id=None,
+        )
     )
     s.flush()
 
@@ -180,6 +206,7 @@ def seeded_engine(engine):
             # Enumeration members for property 52.
             Item(item_id=700, name="Loan", is_property=False, is_active=True),
             Item(item_id=701, name="Bond", is_property=False, is_active=True),
+            Item(item_id=702, name="Share", is_property=False, is_active=True),
         ]
     )
     s.flush()
@@ -268,6 +295,16 @@ def seeded_engine(engine):
                 code="BOND",
                 is_default_item=False,
                 signature="ASSET_TYPE(BOND)",
+                end_release_id=None,
+            ),
+            # Filed in the composed category, never in ASSET_TYPE.
+            ItemCategory(
+                item_id=702,
+                start_release_id=1,
+                category_id=61,
+                code="SHARE",
+                is_default_item=False,
+                signature="EQUITY_TYPE(SHARE)",
                 end_release_id=None,
             ),
         ]
@@ -389,7 +426,29 @@ class TestEnumeration:
         resp = client.get("/api/v1/structure/property/EBA/ASSET/4.1")
         p = resp.json()["data"]["properties"][0]
         codes = {i["code"] for i in p["enumeration"]["items"]}
-        assert codes == {"BOND"}
+        # LOAN gone (end=2); SHARE arrives with the composition.
+        assert codes == {"BOND", "SHARE"}
+
+    def test_a_composed_categorys_items_are_absent_before_it_joins(
+        self, client
+    ):
+        """The composition only opens at 4.1 (#359)."""
+        resp = client.get("/api/v1/structure/property/EBA/ASSET/4.0")
+        p = resp.json()["data"]["properties"][0]
+
+        assert "SHARE" not in {i["code"] for i in p["enumeration"]["items"]}
+
+    def test_each_item_names_the_category_filing_it(self, client):
+        resp = client.get("/api/v1/structure/property/EBA/ASSET/4.1")
+        enum = resp.json()["data"]["properties"][0]["enumeration"]
+
+        assert enum["categoryCode"] == "ASSET_TYPE"
+        assert {i["code"]: i["categoryCode"] for i in enum["items"]} == {
+            "BOND": "ASSET_TYPE",
+            "SHARE": "EQUITY_TYPE",
+        }
+        for item in enum["items"]:
+            assert item["signature"].startswith(f"{item['categoryCode']}(")
 
     def test_non_enumerated_property(self, client):
         resp = client.get("/api/v1/structure/property/EBA/PARTY/4.0")
@@ -470,15 +529,18 @@ class TestQueryBudget:
         assert resp.status_code == 200
         body = resp.json()
         assert len(body["data"]["properties"]) == 3
-        # Budget breakdown:
+        # Budget breakdown (11 as of #359):
         #   3 release-resolution queries (filter_by_release internals);
         #   1 count, 1 main paginated query;
-        #   2 enumeration loads (PropertyCategory+Category, then
-        #     ItemCategory+Item — only when at least one property is
-        #     enumerated);
+        #   4 enumeration loads (PropertyCategory+Category,
+        #     SuperCategoryComposition, ItemCategory+Item, and the
+        #     member categories' codes — only when at least one
+        #     property is enumerated);
         #   1 owner lookup.
-        # ≤12 leaves headroom; budget is independent of property count.
-        assert counter.count <= 12, (
+        # The super-category lookup is a fixed cost, whatever the
+        # number of enumerated properties.
+        # ≤14 leaves headroom; budget is independent of property count.
+        assert counter.count <= 14, (
             f"property path issued {counter.count} queries — "
             f"likely an N+1 regression."
         )

--- a/tests/unit/server/test_structure_table.py
+++ b/tests/unit/server/test_structure_table.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from datetime import date
-from unittest.mock import MagicMock
 
 import pytest
 from sqlalchemy import create_engine
@@ -39,7 +38,6 @@ from dpmcore.orm.rendering import (
 )
 from dpmcore.orm.variables import Variable, VariableVersion
 from dpmcore.server.app import create_app
-from dpmcore.services.structure import StructureService
 
 # ------------------------------------------------------------------ #
 # Seed model
@@ -69,6 +67,8 @@ from dpmcore.services.structure import StructureService
 # EQUITY_TYPE, where SHARE is filed. SHARE therefore has no
 # ItemCategory row in ASSET_TYPE itself and only resolves once the
 # composition is alive — silent at 3.3, listed from 3.4 (#359).
+# EQUITY_TYPE and SHARE's ItemCategory row are both alive at 3.3, so
+# nothing but the composition window keeps SHARE out there.
 # ------------------------------------------------------------------ #
 
 
@@ -257,7 +257,10 @@ def seeded_engine(engine):
                 is_enumerated=True,
                 is_active=True,
                 is_external_ref_data=False,
-                created_release_id=2,
+                # Alive from 3.3, like SHARE's ItemCategory row below:
+                # the composition window is then the *only* reason SHARE
+                # is absent at 3.3, which is what the test checks.
+                created_release_id=1,
                 owner_id=1,
             ),
         ]
@@ -673,6 +676,37 @@ class TestFactVariableEnumeration:
             "SHARE": "EQUITY_TYPE(SHARE)",
         }
 
+    def test_each_item_names_the_category_filing_it(self, client):
+        """The enumeration's own categoryCode is the parent domain, so a
+        member's signature does not start with it — the item has to say
+        where it is filed (#359).
+        """
+        resp = client.get("/api/v1/structure/table/EBA/F_01.01/3.4")
+        enum = resp.json()["data"]["tables"][0]["factVariables"][0][
+            "enumeration"
+        ]
+
+        assert enum["categoryCode"] == "ASSET_TYPE"
+        assert {i["code"]: i["categoryCode"] for i in enum["items"]} == {
+            "BOND": "ASSET_TYPE",
+            "DEPOSIT": "ASSET_TYPE",
+            "SHARE": "EQUITY_TYPE",
+        }
+        assert {i["code"]: i["categoryId"] for i in enum["items"]} == {
+            "BOND": 60,
+            "DEPOSIT": 60,
+            "SHARE": 61,
+        }
+
+    def test_the_signature_prefix_matches_the_items_own_category(self, client):
+        resp = client.get("/api/v1/structure/table/EBA/F_01.01/3.4")
+        items = resp.json()["data"]["tables"][0]["factVariables"][0][
+            "enumeration"
+        ]["items"]
+
+        for item in items:
+            assert item["signature"].startswith(f"{item['categoryCode']}(")
+
     def test_release_wildcard_uses_per_version_window(self, client):
         """Each TableVersion in the response carries the enumeration
         active at its own start_release (not a single shared window).
@@ -749,14 +783,3 @@ class TestEmptyDatabase:
     def test_empty_returns_204(self, empty_client):
         resp = empty_client.get("/api/v1/structure/table/EBA/F_01.01/3.4")
         assert resp.status_code == 204
-
-
-class TestSuperCategoryExpansion:
-    def test_no_categories_does_not_query(self):
-        """Nothing to expand must not cost a query (#359)."""
-        service = StructureService(MagicMock())
-
-        members = service._load_supercategory_members(set(), release_id=None)
-
-        assert members == {}
-        service.session.query.assert_not_called()

--- a/tests/unit/server/test_structure_table.py
+++ b/tests/unit/server/test_structure_table.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import date
+from unittest.mock import MagicMock
 
 import pytest
 from sqlalchemy import create_engine
@@ -19,6 +20,7 @@ from dpmcore.orm.glossary import (
     SubCategory,
     SubCategoryItem,
     SubCategoryVersion,
+    SupercategoryComposition,
 )
 from dpmcore.orm.infrastructure import (
     Concept,
@@ -37,6 +39,7 @@ from dpmcore.orm.rendering import (
 )
 from dpmcore.orm.variables import Variable, VariableVersion
 from dpmcore.server.app import create_app
+from dpmcore.services.structure import StructureService
 
 # ------------------------------------------------------------------ #
 # Seed model
@@ -56,11 +59,16 @@ from dpmcore.server.app import create_app
 # inherit the row header's subcategory as their enumeration.
 #
 # Subcategory AT_SUB lives under category ASSET_TYPE and lists items
-# LOAN, BOND, DEPOSIT via SubCategoryItem rows. The release-aware
+# LOAN, BOND, DEPOSIT, SHARE via SubCategoryItem rows. The release-aware
 # filter on each item's parent ItemCategory then yields:
 #   - LOAN     valid at 3.3 only        (start=1, end=2)
 #   - BOND     valid at all releases    (start=1, end=None)
 #   - DEPOSIT  valid from 3.4 onward    (start=2, end=None)
+#
+# ASSET_TYPE is also a super-category: from 3.4 onward it composes
+# EQUITY_TYPE, where SHARE is filed. SHARE therefore has no
+# ItemCategory row in ASSET_TYPE itself and only resolves once the
+# composition is alive — silent at 3.3, listed from 3.4 (#359).
 # ------------------------------------------------------------------ #
 
 
@@ -227,18 +235,40 @@ def seeded_engine(engine):
     session.flush()
 
     # Enumerated parent category (must exist before the SubCategory
-    # FK below can resolve).
+    # FK below can resolve), plus the category it composes from 3.4 on.
+    session.add_all(
+        [
+            Category(
+                category_id=60,
+                code="ASSET_TYPE",
+                name="Asset type",
+                description="Domain of assets",
+                is_enumerated=True,
+                is_active=True,
+                is_external_ref_data=False,
+                created_release_id=1,
+                owner_id=1,
+            ),
+            Category(
+                category_id=61,
+                code="EQUITY_TYPE",
+                name="Equity type",
+                description="Domain of equity instruments",
+                is_enumerated=True,
+                is_active=True,
+                is_external_ref_data=False,
+                created_release_id=2,
+                owner_id=1,
+            ),
+        ]
+    )
+    session.flush()
     session.add(
-        Category(
-            category_id=60,
-            code="ASSET_TYPE",
-            name="Asset type",
-            description="Domain of assets",
-            is_enumerated=True,
-            is_active=True,
-            is_external_ref_data=False,
-            created_release_id=1,
-            owner_id=1,
+        SupercategoryComposition(
+            supercategory_id=60,
+            category_id=61,
+            start_release_id=2,
+            end_release_id=None,
         )
     )
     session.flush()
@@ -324,6 +354,7 @@ def seeded_engine(engine):
                 is_property=False,
                 is_active=True,
             ),
+            Item(item_id=703, name="Share", is_property=False, is_active=True),
             # The Property is itself an Item (subtype) — needs an Item row.
             Item(
                 item_id=51,
@@ -363,16 +394,27 @@ def seeded_engine(engine):
                 signature="ASSET_TYPE(DEPOSIT)",
                 end_release_id=None,
             ),
+            # Filed in the composed category, never in ASSET_TYPE.
+            ItemCategory(
+                item_id=703,
+                start_release_id=1,
+                category_id=61,
+                code="SHARE",
+                is_default_item=False,
+                signature="EQUITY_TYPE(SHARE)",
+                end_release_id=None,
+            ),
         ]
     )
     session.flush()
 
-    # Items 700/701/702 become the SubCategoryVersion's members.
+    # Items 700/701/702/703 become the SubCategoryVersion's members.
     session.add_all(
         [
             SubCategoryItem(item_id=700, subcategory_vid=4441, order=1),
             SubCategoryItem(item_id=701, subcategory_vid=4441, order=2),
             SubCategoryItem(item_id=702, subcategory_vid=4441, order=3),
+            SubCategoryItem(item_id=703, subcategory_vid=4441, order=4),
         ]
     )
     session.flush()
@@ -605,7 +647,9 @@ class TestFactVariableEnumeration:
         codes = {
             i["code"] for i in t["factVariables"][0]["enumeration"]["items"]
         }
-        # LOAN ends at 3.4 → still valid at 3.3. DEPOSIT not yet alive.
+        # LOAN ends at 3.4 → still valid at 3.3. DEPOSIT not yet alive,
+        # and the ASSET_TYPE → EQUITY_TYPE composition that SHARE needs
+        # only opens at 3.4.
         assert codes == {"LOAN", "BOND"}
 
     def test_enumeration_items_at_3_4(self, client):
@@ -614,16 +658,20 @@ class TestFactVariableEnumeration:
         codes = {
             i["code"] for i in t["factVariables"][0]["enumeration"]["items"]
         }
-        # LOAN gone (end=2), DEPOSIT now alive.
-        assert codes == {"BOND", "DEPOSIT"}
+        # LOAN gone (end=2), DEPOSIT now alive, and SHARE reachable
+        # through the composed category.
+        assert codes == {"BOND", "DEPOSIT", "SHARE"}
 
     def test_enumeration_items_carry_signature(self, client):
         resp = client.get("/api/v1/structure/table/EBA/F_01.01/3.4")
         t = resp.json()["data"]["tables"][0]
         items = t["factVariables"][0]["enumeration"]["items"]
-        for it in items:
-            assert "signature" in it
-            assert it["signature"].startswith("ASSET_TYPE(")
+        assert {i["code"]: i["signature"] for i in items} == {
+            "BOND": "ASSET_TYPE(BOND)",
+            "DEPOSIT": "ASSET_TYPE(DEPOSIT)",
+            # Named by the category that files it, not by the parent.
+            "SHARE": "EQUITY_TYPE(SHARE)",
+        }
 
     def test_release_wildcard_uses_per_version_window(self, client):
         """Each TableVersion in the response carries the enumeration
@@ -641,7 +689,7 @@ class TestFactVariableEnumeration:
             for i in by_vid[2000]["factVariables"][0]["enumeration"]["items"]
         }
         assert v1_codes == {"LOAN", "BOND"}
-        assert v2_codes == {"BOND", "DEPOSIT"}
+        assert v2_codes == {"BOND", "DEPOSIT", "SHARE"}
 
 
 class TestKeyVariables:
@@ -701,3 +749,14 @@ class TestEmptyDatabase:
     def test_empty_returns_204(self, empty_client):
         resp = empty_client.get("/api/v1/structure/table/EBA/F_01.01/3.4")
         assert resp.status_code == 204
+
+
+class TestSuperCategoryExpansion:
+    def test_no_categories_does_not_query(self):
+        """Nothing to expand must not cost a query (#359)."""
+        service = StructureService(MagicMock())
+
+        members = service._load_supercategory_members(set(), release_id=None)
+
+        assert members == {}
+        service.session.query.assert_not_called()

--- a/tests/unit/server/test_structure_variable.py
+++ b/tests/unit/server/test_structure_variable.py
@@ -474,17 +474,17 @@ class TestQueryBudget:
         body = resp.json()
         # All three variables match at 4.0.
         assert len(body["data"]["variables"]) == 3
-        # Budget breakdown:
-        #   4 release-resolution queries (filter_by_release internals);
+        # Budget breakdown (13 as of #359):
+        #   3 release-resolution queries (filter_by_release internals);
         #   1 variable main, 1 property names, 1 key signatures,
         #   4 subcategory enumeration sub-queries
         #     (SCV+SC+Cat / SCI+Item / SuperCategoryComposition /
         #      ItemCategory),
         #   1 owner lookup.
         # The super-category lookup is one query plus its release
-        # window, fixed however many subcategories are resolved (#359).
-        # ≤16 leaves headroom for incidental changes.
-        assert counter.count <= 16, (
+        # window, fixed however many subcategories are resolved.
+        # ≤15 leaves headroom for incidental changes.
+        assert counter.count <= 15, (
             f"variable path issued {counter.count} queries — "
             f"likely an N+1 regression."
         )

--- a/tests/unit/server/test_structure_variable.py
+++ b/tests/unit/server/test_structure_variable.py
@@ -475,13 +475,16 @@ class TestQueryBudget:
         # All three variables match at 4.0.
         assert len(body["data"]["variables"]) == 3
         # Budget breakdown:
-        #   3 release-resolution queries (filter_by_release internals);
+        #   4 release-resolution queries (filter_by_release internals);
         #   1 variable main, 1 property names, 1 key signatures,
-        #   3 subcategory enumeration sub-queries
-        #     (SCV+SC+Cat / SCI+Item / ItemCategory),
+        #   4 subcategory enumeration sub-queries
+        #     (SCV+SC+Cat / SCI+Item / SuperCategoryComposition /
+        #      ItemCategory),
         #   1 owner lookup.
-        # ≤14 leaves headroom for incidental changes.
-        assert counter.count <= 14, (
+        # The super-category lookup is one query plus its release
+        # window, fixed however many subcategories are resolved (#359).
+        # ≤16 leaves headroom for incidental changes.
+        assert counter.count <= 16, (
             f"variable path issued {counter.count} queries — "
             f"likely an N+1 regression."
         )

--- a/tests/unit/services/layout_exporter/test_queries.py
+++ b/tests/unit/services/layout_exporter/test_queries.py
@@ -1,0 +1,231 @@
+"""Tests for the layout exporter's member-code lookup.
+
+``MemberCode`` is read from the ``ItemCategory`` row that files the item
+under the dimension's domain. Two things make that lookup subtle:
+
+* a *super-category* domain files almost none of its value set under
+  itself, so the categories composing it have to be searched too (#359);
+* one export spans many domains, and the same item can be filed in two
+  of them, so the answer has to be per (item, domain) rather than per
+  item.
+
+Seed model — dimension ``ATY`` is typed on the super-category
+``ASSET_TYPE``, which composes ``EQUITY_TYPE``; dimension ``OTH`` is
+typed on the plain domain ``OTHER``. Item 700 is filed in
+``EQUITY_TYPE`` (as ``SHARE``) and, with a different code, in ``OTHER``
+(as ``OTHER_CODE``).
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+
+import dpmcore.orm  # noqa: F401  — ensure all models are loaded
+from dpmcore.orm.base import Base
+from dpmcore.orm.glossary import (
+    Category,
+    Context,
+    ContextComposition,
+    Item,
+    ItemCategory,
+    Property,
+    PropertyCategory,
+    SupercategoryComposition,
+)
+from dpmcore.services.layout_exporter.queries import (
+    _load_member_codes,
+    load_categorisations,
+)
+
+ASSET_TYPE, EQUITY_TYPE, OTHER, PR = 60, 61, 62, 1
+ATY, OTH = 50, 51
+SHARE_ITEM = 700
+
+
+@pytest.fixture
+def session():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    s = Session(bind=engine)
+    s.add_all(
+        Category(
+            category_id=cid,
+            code=code,
+            name=code,
+            is_enumerated=True,
+            is_active=True,
+            is_external_ref_data=False,
+        )
+        for cid, code in [
+            (PR, "_PR"),
+            (ASSET_TYPE, "ASSET_TYPE"),
+            (EQUITY_TYPE, "EQUITY_TYPE"),
+            (OTHER, "OTHER"),
+        ]
+    )
+    s.add(
+        SupercategoryComposition(
+            supercategory_id=ASSET_TYPE,
+            category_id=EQUITY_TYPE,
+            start_release_id=None,
+            end_release_id=None,
+        )
+    )
+    s.add_all(
+        [
+            Item(
+                item_id=ATY,
+                name="Asset type",
+                is_property=True,
+                is_active=True,
+            ),
+            Item(item_id=OTH, name="Other", is_property=True, is_active=True),
+            Item(
+                item_id=SHARE_ITEM,
+                name="Share",
+                is_property=False,
+                is_active=True,
+            ),
+            Property(property_id=ATY, is_composite=False, is_metric=False),
+            Property(property_id=OTH, is_composite=False, is_metric=False),
+        ]
+    )
+    s.flush()
+    s.add_all(
+        ItemCategory(
+            item_id=item_id,
+            category_id=category_id,
+            code=code,
+            signature=f"{code}",
+            is_default_item=False,
+            start_release_id=start,
+            end_release_id=None,
+        )
+        # ItemCategory's PK is (ItemID, StartReleaseID), so an item
+        # in two categories at once needs two start releases.
+        for item_id, category_id, code, start in [
+            (ATY, PR, "ATY", 1),
+            (OTH, PR, "OTH", 1),
+            (SHARE_ITEM, EQUITY_TYPE, "SHARE", 1),
+            (SHARE_ITEM, OTHER, "OTHER_CODE", 2),
+        ]
+    )
+    s.add_all(
+        [
+            PropertyCategory(
+                property_id=ATY,
+                category_id=ASSET_TYPE,
+                start_release_id=1,
+                end_release_id=None,
+            ),
+            PropertyCategory(
+                property_id=OTH,
+                category_id=OTHER,
+                start_release_id=1,
+                end_release_id=None,
+            ),
+        ]
+    )
+    s.add_all(
+        [
+            Context(context_id=900, signature="ctx"),
+            ContextComposition(
+                context_id=900, property_id=ATY, item_id=SHARE_ITEM
+            ),
+            ContextComposition(
+                context_id=900, property_id=OTH, item_id=SHARE_ITEM
+            ),
+        ]
+    )
+    s.commit()
+    yield s
+    s.close()
+
+
+class TestMemberCodes:
+    def test_a_super_category_member_resolves(self, session):
+        """SHARE is filed in EQUITY_TYPE, never in ASSET_TYPE (#359)."""
+        codes = _load_member_codes(session, {SHARE_ITEM}, {ASSET_TYPE})
+
+        assert codes == {(SHARE_ITEM, ASSET_TYPE): "SHARE"}
+
+    def test_a_plain_domain_resolves_from_its_own_category(self, session):
+        codes = _load_member_codes(session, {SHARE_ITEM}, {OTHER})
+
+        assert codes == {(SHARE_ITEM, OTHER): "OTHER_CODE"}
+
+    def test_each_domain_gets_its_own_code(self, session):
+        """A per-item key would hand one domain the other's code."""
+        codes = _load_member_codes(session, {SHARE_ITEM}, {ASSET_TYPE, OTHER})
+
+        assert codes == {
+            (SHARE_ITEM, ASSET_TYPE): "SHARE",
+            (SHARE_ITEM, OTHER): "OTHER_CODE",
+        }
+
+    def test_the_domains_own_category_wins_over_a_member(self, session):
+        """Filed in both the super-category and one of its members.
+
+        The domain's own category wins whatever its ID — EBA's ``qTU``
+        (1111) outranks all four categories composing it (1007..1037),
+        so ordering by ID alone would pick the wrong one.
+        """
+        session.add(
+            ItemCategory(
+                item_id=SHARE_ITEM,
+                category_id=ASSET_TYPE,
+                code="OWN",
+                signature="OWN",
+                is_default_item=False,
+                start_release_id=3,
+                end_release_id=None,
+            )
+        )
+        session.commit()
+
+        codes = _load_member_codes(session, {SHARE_ITEM}, {ASSET_TYPE})
+
+        assert codes == {(SHARE_ITEM, ASSET_TYPE): "OWN"}
+
+    def test_a_closed_item_category_row_is_ignored(self, session):
+        session.query(ItemCategory).filter(
+            ItemCategory.item_id == SHARE_ITEM,
+            ItemCategory.category_id == EQUITY_TYPE,
+        ).update({"end_release_id": 2})
+        session.commit()
+
+        assert _load_member_codes(session, {SHARE_ITEM}, {ASSET_TYPE}) == {}
+
+    def test_no_items_costs_no_query(self):
+        from unittest.mock import MagicMock
+
+        session = MagicMock()
+
+        assert _load_member_codes(session, set(), {ASSET_TYPE}) == {}
+        session.query.assert_not_called()
+
+    def test_no_domains_costs_no_query(self):
+        from unittest.mock import MagicMock
+
+        session = MagicMock()
+
+        assert _load_member_codes(session, {SHARE_ITEM}, set()) == {}
+        session.query.assert_not_called()
+
+
+class TestCategorisations:
+    def test_each_dimension_reports_its_own_member_code(self, session):
+        members = load_categorisations(session, {900})
+
+        by_dimension = {m.dimension_code: m for m in members[900]}
+        assert by_dimension["ATY"].member_code == "SHARE"
+        assert by_dimension["ATY"].domain_code == "ASSET_TYPE"
+        assert by_dimension["OTH"].member_code == "OTHER_CODE"
+        assert by_dimension["OTH"].domain_code == "OTHER"


### PR DESCRIPTION
## Summary

Closes #359 

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`) with 100% branch coverage (`coverage report --fail-under=100`)
- [ ] Documentation updated (if applicable)

## Impact / Risk

- Breaking changes? (public API / CLI / REST endpoints / Django models)
- Database schema or migration concerns?
- Notes for release/changelog?

## Notes

<!-- Follow-ups, TODOs, or anything reviewers should know. -->
